### PR TITLE
Add deployment binary gates and clone-report fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: "8.14.3"
+          gradle-version: "9.0.0"
 
       - name: jetbrains-package deployment gate
         run: make jetbrains-package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Deployment manifest and binary gates
+        run: make deployment-verify
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -137,6 +140,9 @@ jobs:
       - name: vsix-test (full E2E against real LSP)
         run: xvfb-run -a make vsix-test
 
+      - name: vsix-package deployment gate
+        run: make vsix-package
+
       - name: Upload VSIX coverage
         uses: actions/upload-artifact@v4
         if: always()
@@ -145,3 +151,29 @@ jobs:
           path: |
             clients/vscode/coverage/
           retention-days: 7
+
+  jetbrains:
+    name: JetBrains package gate
+    needs: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14.3"
+
+      - name: jetbrains-package deployment gate
+        run: make jetbrains-package

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ Cargo.lock.bak
 # =============================================================================
 # Gradle / IntelliJ Platform
 # =============================================================================
+clients/jetbrains/.gradle/
+clients/jetbrains/.intellijPlatform/
+clients/jetbrains/build/
 
 codededup-report.json
 codededup-report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -89,5 +89,6 @@ clients/vscode/out/
 
 .ghissues/
 clients/vscode/bin/
+clients/vscode/deployment-toolkit.json
 
 clients/vscode/media/webview/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Rust CLI. See docs/specs/SPEC.md and docs/plans/PLAN.md.
 # =============================================================================
 
-.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help build-release install-binary deployment-verify vsix-install vsix-build vsix-test vsix-test-ollama vsix-coverage vsix-package vsix-rebuild _vsix-stage-and-package jetbrains-build jetbrains-verify jetbrains-package
+.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help build-release install-binary delete-path-binaries deployment-verify vsix-install vsix-build vsix-test vsix-test-ollama vsix-coverage vsix-package vsix-rebuild _vsix-stage-bundled-binaries _vsix-stage-and-package jetbrains-build jetbrains-verify jetbrains-package
 
 GRADLE ?= gradle
 JETBRAINS_DIR := clients/jetbrains
@@ -49,7 +49,7 @@ build:
 ##       (single source of truth). Per-crate thresholds live under
 ##       `.rust.crates.<crate>`; `scripts/coverage-check.sh` enforces
 ##       each one independently — no workspace roll-up masking.
-test:
+test: delete-path-binaries
 	@echo "==> Testing (fail-fast + coverage + per-crate threshold)..."
 	rustup component add llvm-tools-preview 2>/dev/null || true
 	@_rust_ignore=$$(jq -r '.rust.ignore_filename_regex' "$(_COVERAGE_THRESHOLDS_FILE)"); \
@@ -140,6 +140,30 @@ install-binary:
 	  cargo install --locked --path crates/$$_crate --force; \
 	done
 
+## delete-path-binaries: Remove cargo-installed Deslop binaries before tests so
+##                       extension tests cannot accidentally pass by resolving
+##                       PATH instead of the extension bundle. VS Code extension
+##                       directories in PATH are skipped — the resolver's bundled
+##                       candidate (clients/vscode/bin/<platform>/) always wins
+##                       because it is evaluated before the path candidate.
+delete-path-binaries:
+	@echo "==> Removing cargo-installed Deslop binaries from PATH..."
+	@for _bin in deslop deslop-lsp deslop-mcp; do \
+	  cargo uninstall $$_bin 2>/dev/null || true; \
+	  $(RM) "$(HOME)/.cargo/bin/$$_bin" "$(HOME)/.cargo/bin/$$_bin.exe"; \
+	  _found=$$(command -v $$_bin 2>/dev/null || true); \
+	  if [ -n "$$_found" ]; then \
+	    case "$$_found" in \
+	      */.vscode/extensions/*|*/.vscode-server/extensions/*|*/.cursor/extensions/*) \
+	        echo "SKIP: $$_bin at $$_found is a VS Code extension bundle — not a PATH install" ;; \
+	      *) \
+	        echo "FAIL: $$_bin still resolves on PATH at $$_found"; \
+	        echo "Remove it before running tests; extension tests must use bundled binaries."; \
+	        exit 1 ;; \
+	    esac; \
+	  fi; \
+	done
+
 ## deployment-verify: Validate deployment manifest and built binary contracts.
 deployment-verify: build
 	node scripts/verify-deployment-manifest.mjs deployment-toolkit.json
@@ -158,20 +182,20 @@ vsix-build: vsix-install
 	cd clients/vscode/webview-ui && npm run build
 	cd clients/vscode && npm run build
 
-## vsix-test: Run VS Code E2E tests against the REAL deslop-lsp binary.
-vsix-test: vsix-install vsix-build
+## vsix-test: Run VS Code E2E tests against bundled extension binaries only.
+vsix-test: delete-path-binaries vsix-install vsix-build _vsix-stage-bundled-binaries
 	cd clients/vscode && npm test
 
 ## vsix-test-ollama: Run the Ollama-gated VSIX e2e suite (csharp-type4
 ##                   fixture, provider=ollama, model=nomic-embed-text).
 ##                   NEVER runs in `make ci` / `make vsix-test`. Requires
 ##                   a local Ollama daemon and the model pulled.
-vsix-test-ollama: vsix-install vsix-build
+vsix-test-ollama: delete-path-binaries vsix-install vsix-build _vsix-stage-bundled-binaries
 	cd clients/vscode && npm run test:ollama
 
 ## vsix-coverage: Run VS Code E2E + enforce the VSIX coverage threshold.
 ##                Threshold lives in clients/vscode/coverage-thresholds.json.
-vsix-coverage: vsix-install vsix-build
+vsix-coverage: delete-path-binaries vsix-install vsix-build _vsix-stage-bundled-binaries
 	cd clients/vscode && npm run coverage
 
 ## vsix-package: Build the .vsix artifact (does not publish).
@@ -180,9 +204,9 @@ vsix-coverage: vsix-install vsix-build
 ##               extension can resolve them via the bundled path
 ##               ([VSIX-BINARY-VERSIONING]). CI stages every supported platform;
 ##               locally we only have the host toolchain so we only stage that one.
-vsix-package: vsix-install vsix-build _vsix-stage-and-package
+vsix-package: delete-path-binaries vsix-install vsix-build _vsix-stage-and-package
 
-_vsix-stage-and-package:
+_vsix-stage-bundled-binaries:
 	@_uname_s=$$(uname -s); _uname_m=$$(uname -m); \
 	 case "$$_uname_s-$$_uname_m" in \
 	   Darwin-arm64)   _platform=darwin-arm64 ;; \
@@ -203,6 +227,8 @@ _vsix-stage-and-package:
 	   chmod +x "$$_dest/$$_bin$$_ext"; \
 	 done
 	cp deployment-toolkit.json clients/vscode/deployment-toolkit.json
+
+_vsix-stage-and-package: _vsix-stage-bundled-binaries
 	cd clients/vscode && npm run package
 
 ## vsix-clean: Remove VSIX-specific build artifacts (staged bin/, node_modules,

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Rust CLI. See docs/specs/SPEC.md and docs/plans/PLAN.md.
 # =============================================================================
 
-.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help build-release install-binary vsix-install vsix-build vsix-test vsix-test-ollama vsix-coverage vsix-package vsix-rebuild _vsix-stage-and-package jetbrains-build jetbrains-verify jetbrains-package
+.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help build-release install-binary deployment-verify vsix-install vsix-build vsix-test vsix-test-ollama vsix-coverage vsix-package vsix-rebuild _vsix-stage-and-package jetbrains-build jetbrains-verify jetbrains-package
 
 GRADLE ?= gradle
 JETBRAINS_DIR := clients/jetbrains
@@ -91,6 +91,7 @@ ci:
 	@$(MAKE) lint
 	@$(MAKE) test
 	@$(MAKE) build
+	@$(MAKE) deployment-verify
 	@$(MAKE) vsix-coverage
 
 ## setup: Post-create dev environment setup (used by devcontainer)
@@ -138,6 +139,11 @@ install-binary:
 	  echo "==> Installing $$_crate binary..."; \
 	  cargo install --locked --path crates/$$_crate --force; \
 	done
+
+## deployment-verify: Validate deployment manifest and built binary contracts.
+deployment-verify: build
+	node scripts/verify-deployment-manifest.mjs deployment-toolkit.json
+	node scripts/verify-deployment-binaries.mjs deployment-toolkit.json target/release
 
 ## vsix-install: Install Node deps for clients/vscode + webview-ui
 vsix-install:
@@ -196,6 +202,7 @@ _vsix-stage-and-package:
 	   cp "$$_src" "$$_dest/$$_bin$$_ext"; \
 	   chmod +x "$$_dest/$$_bin$$_ext"; \
 	 done
+	cp deployment-toolkit.json clients/vscode/deployment-toolkit.json
 	cd clients/vscode && npm run package
 
 ## vsix-clean: Remove VSIX-specific build artifacts (staged bin/, node_modules,
@@ -209,6 +216,7 @@ vsix-clean:
 	$(RM) clients/vscode/out
 	$(RM) clients/vscode/dist
 	$(RM) clients/vscode/deslop-vscode.vsix
+	$(RM) clients/vscode/deployment-toolkit.json
 	$(RM) clients/vscode/coverage
 
 ## vsix-install-code: Install the packaged clients/vscode/deslop-vscode.vsix
@@ -235,7 +243,10 @@ vsix-rebuild:
 	@echo "==> vsix-rebuild done. Reload the VS Code window to pick up the new extension."
 
 ## jetbrains-build: Build the JetBrains plugin zip.
+##                 JetBrains archive verification is deferred to GitHub #55
+##                 while the local Gradle validation path is tracked in #56.
 jetbrains-build:
+	cargo build --release -p deslop-lsp
 	cd $(JETBRAINS_DIR) && $(GRADLE) buildPlugin
 
 ## jetbrains-verify: Verify JetBrains plugin project and archive structure.
@@ -253,6 +264,7 @@ help:
 	@echo "  lint           - All linters/analyzers (read-only, no formatting)"
 	@echo "  fmt            - Format all code in-place (CHECK=1 for read-only CI check)"
 	@echo "  clean          - Remove build artifacts"
+	@echo "  deployment-verify - Validate deployment manifest and built binary contracts"
 	@echo "  ci             - fmt + lint + rust test + build + VSIX e2e + VSIX coverage"
 	@echo "  setup          - Post-create dev environment setup"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -258,15 +258,19 @@ vsix-install-code:
 
 ## vsix-rebuild: Nuke every build artifact (cargo target/, staged bin/, node_modules,
 ##               dist/, out/, old .vsix), rebuild the workspace + webview + extension
-##               from scratch, repackage the .vsix, and install it into the local
-##               `code` CLI. Use when "why isn't my change showing up" strikes.
-##               Composes existing targets — does not duplicate their logic.
+##               from scratch, repackage the .vsix, install it into the local `code`
+##               CLI, and scrub any cargo-installed PATH copies so the installed VSIX
+##               bundle is the only source of truth. Use when "why isn't my change
+##               showing up" strikes. Composes existing targets — does not duplicate
+##               their logic.
 vsix-rebuild:
 	@$(MAKE) clean
 	@$(MAKE) vsix-clean
 	@$(MAKE) vsix-package
 	@$(MAKE) vsix-install-code
+	@$(MAKE) delete-path-binaries
 	@echo "==> vsix-rebuild done. Reload the VS Code window to pick up the new extension."
+	@echo "    PATH copies removed — the VSIX bundle is now the only source of truth."
 
 ## jetbrains-build: Build the JetBrains plugin zip.
 ##                 JetBrains archive verification is deferred to GitHub #55

--- a/clients/jetbrains/build.gradle.kts
+++ b/clients/jetbrains/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+
 plugins {
     kotlin("jvm") version "2.3.20"
     id("org.jetbrains.intellij.platform") version "2.14.0"
@@ -14,6 +16,9 @@ repositories {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    testImplementation(kotlin("test-junit5"))
+
     intellijPlatform {
         intellijIdea("2026.1")
     }
@@ -39,5 +44,60 @@ intellijPlatform {
             name = "Nimblesite"
             url = "https://github.com/Nimblesite/Deslop"
         }
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.named("prepareSandbox") {
+    doLast {
+        val pluginRoots = pluginSandboxRoots()
+        val manifest = rootProject.layout.projectDirectory.file("../../deployment-toolkit.json").asFile
+        val lsp = lspBinary()
+        pluginRoots.forEach { pluginRoot ->
+            copy {
+                from(manifest)
+                into(pluginRoot)
+            }
+            val targetDir = pluginRoot.resolve("bin/${hostPlatform()}")
+            copy {
+                from(lsp)
+                into(targetDir)
+            }
+            targetDir.resolve(lsp.name).setExecutable(true, false)
+        }
+    }
+}
+
+fun pluginSandboxRoots(): List<File> {
+    val pluginsDir = layout.buildDirectory.dir("idea-sandbox/plugins").get().asFile
+    val roots = pluginsDir.listFiles { file -> file.isDirectory }?.toList().orEmpty()
+    if (roots.isEmpty()) throw GradleException("No JetBrains sandbox plugin root found.")
+    return roots
+}
+
+fun lspBinary(): File {
+    val name = if (hostPlatform().startsWith("win32")) "deslop-lsp.exe" else "deslop-lsp"
+    val dir = System.getenv("DESLOP_BINARY_DIR")?.let(::file)
+        ?: rootProject.layout.projectDirectory.dir("../../target/release").asFile
+    val binary = dir.resolve(name)
+    if (!binary.isFile) throw GradleException("Missing $binary; build deslop-lsp first.")
+    return binary
+}
+
+fun hostPlatform(): String {
+    val arch = if (System.getProperty("os.arch").lowercase() in setOf("aarch64", "arm64")) {
+        "arm64"
+    } else {
+        "x64"
+    }
+    val name = System.getProperty("os.name").lowercase()
+    return when {
+        name.contains("mac") -> "darwin-$arch"
+        name.contains("linux") -> "linux-$arch"
+        name.contains("windows") -> "win32-x64"
+        else -> "unknown-$arch"
     }
 }

--- a/clients/jetbrains/build.gradle.kts
+++ b/clients/jetbrains/build.gradle.kts
@@ -1,19 +1,26 @@
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 
 plugins {
     kotlin("jvm") version "2.3.20"
-    id("org.jetbrains.intellij.platform") version "2.14.0"
+    id("org.jetbrains.intellij.platform")
 }
 
 group = "com.nimblesite"
 version = "0.1.0"
-
-repositories {
-    mavenCentral()
-    intellijPlatform {
-        defaultRepositories()
-    }
-}
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
@@ -51,40 +58,61 @@ tasks.test {
     useJUnitPlatform()
 }
 
-tasks.named("prepareSandbox") {
-    doLast {
-        val pluginRoots = pluginSandboxRoots()
-        val manifest = rootProject.layout.projectDirectory.file("../../deployment-toolkit.json").asFile
-        val lsp = lspBinary()
-        pluginRoots.forEach { pluginRoot ->
-            copy {
-                from(manifest)
-                into(pluginRoot)
-            }
-            val targetDir = pluginRoot.resolve("bin/${hostPlatform()}")
-            copy {
-                from(lsp)
-                into(targetDir)
-            }
-            targetDir.resolve(lsp.name).setExecutable(true, false)
-        }
+val hostPlatformName = hostPlatform()
+val lspBinaryName = if (hostPlatformName.startsWith("win32")) "deslop-lsp.exe" else "deslop-lsp"
+val binaryDirectory = System.getenv("DESLOP_BINARY_DIR")?.let(::File)
+    ?: rootProject.layout.projectDirectory.dir("../../target/release").asFile
+val lspBinaryFile = binaryDirectory.resolve(lspBinaryName)
+val deploymentManifestFile = rootProject.layout.projectDirectory
+    .file("../../deployment-toolkit.json")
+    .asFile
+
+abstract class CopyLspArtifactsToSandbox : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val deploymentManifest: RegularFileProperty
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val lspBinary: RegularFileProperty
+
+    @get:OutputDirectory
+    abstract val pluginDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val hostPlatform: Property<String>
+
+    @TaskAction
+    fun copyArtifacts() {
+        val binaryFile = lspBinary.get().asFile
+        if (!binaryFile.isFile) throw GradleException("Missing $binaryFile; build deslop-lsp first.")
+
+        val pluginRoot = pluginDirectory.get().asFile.toPath()
+        val targetDir = pluginRoot.resolve("bin").resolve(hostPlatform.get())
+        val targetBinary = targetDir.resolve(binaryFile.name)
+        Files.createDirectories(pluginRoot)
+        Files.createDirectories(targetDir)
+        Files.copy(
+            deploymentManifest.get().asFile.toPath(),
+            pluginRoot.resolve("deployment-toolkit.json"),
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+        Files.copy(binaryFile.toPath(), targetBinary, StandardCopyOption.REPLACE_EXISTING)
+        targetBinary.toFile().setExecutable(true, false)
     }
 }
 
-fun pluginSandboxRoots(): List<File> {
-    val pluginsDir = layout.buildDirectory.dir("idea-sandbox/plugins").get().asFile
-    val roots = pluginsDir.listFiles { file -> file.isDirectory }?.toList().orEmpty()
-    if (roots.isEmpty()) throw GradleException("No JetBrains sandbox plugin root found.")
-    return roots
+val prepareSandbox = tasks.named<PrepareSandboxTask>("prepareSandbox")
+val copyLspArtifactsToSandbox = tasks.register<CopyLspArtifactsToSandbox>("copyLspArtifactsToSandbox") {
+    dependsOn(prepareSandbox)
+    deploymentManifest.set(deploymentManifestFile)
+    lspBinary.set(lspBinaryFile)
+    pluginDirectory.set(prepareSandbox.flatMap { it.pluginDirectory })
+    hostPlatform.set(hostPlatformName)
 }
 
-fun lspBinary(): File {
-    val name = if (hostPlatform().startsWith("win32")) "deslop-lsp.exe" else "deslop-lsp"
-    val dir = System.getenv("DESLOP_BINARY_DIR")?.let(::file)
-        ?: rootProject.layout.projectDirectory.dir("../../target/release").asFile
-    val binary = dir.resolve(name)
-    if (!binary.isFile) throw GradleException("Missing $binary; build deslop-lsp first.")
-    return binary
+tasks.named("buildPlugin") {
+    dependsOn(copyLspArtifactsToSandbox)
 }
 
 fun hostPlatform(): String {

--- a/clients/jetbrains/settings.gradle.kts
+++ b/clients/jetbrains/settings.gradle.kts
@@ -1,11 +1,14 @@
+import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        intellijPlatform {
-            defaultRepositories()
-        }
     }
+}
+
+plugins {
+    id("org.jetbrains.intellij.platform.settings") version "2.14.0"
 }
 
 dependencyResolutionManagement {

--- a/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopBinaryResolver.kt
+++ b/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopBinaryResolver.kt
@@ -2,63 +2,283 @@ package com.nimblesite.deslop.jetbrains
 
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
-import com.intellij.openapi.util.SystemInfoRt
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 internal object DeslopBinaryResolver {
-    private const val BINARY_NAME = "deslop-lsp"
-    private const val ENV_DIR = "DESLOP_BINARY_DIR"
     private const val PLUGIN_ID_VALUE = "nimblesite.deslop.jetbrains"
 
-    fun command(): String {
-        return envBinary()?.toString()
-            ?: pathBinary()?.toString()
-            ?: bundledBinary()?.toString()
-            ?: binaryName()
+    fun resolveLsp(): DeslopResolvedBinary {
+        val pluginRoot = pluginRoot()
+        val manifest = DeslopDeploymentManifest.load(pluginRoot.resolve("deployment-toolkit.json"))
+        return resolveLsp(manifest, ResolverInputs(pluginRoot = pluginRoot))
     }
 
-    private fun envBinary(): Path? {
-        val dir = System.getenv(ENV_DIR)?.takeIf(String::isNotBlank) ?: return null
-        return Path.of(dir).resolve(binaryName()).takeIf(::isUsable)
+    fun resolveLsp(
+        manifest: DeslopDeploymentManifest,
+        inputs: ResolverInputs,
+    ): DeslopResolvedBinary {
+        val component = manifest.requiredJetBrainsComponent("deslop-lsp")
+        var skippedPath: Candidate? = null
+        for (candidate in candidates(component, inputs)) {
+            val resolved = verifyCandidate(component, candidate)
+            if (resolved != null) return resolved
+            skippedPath = candidate
+        }
+        throw DeslopBinaryResolutionException(missingMessage(component, skippedPath))
     }
 
-    private fun pathBinary(): Path? {
-        val path = System.getenv("PATH") ?: System.getenv("Path") ?: return null
-        return path.split(File.pathSeparator).asSequence()
+    private fun candidates(
+        component: ComponentContract,
+        inputs: ResolverInputs,
+    ): List<Candidate> {
+        return listOfNotNull(
+            envPathCandidate(component, inputs),
+            envDirCandidate(component, inputs),
+            bundledCandidate(component, inputs),
+            pathCandidate(component, inputs),
+        )
+    }
+
+    private fun envPathCandidate(
+        component: ComponentContract,
+        inputs: ResolverInputs,
+    ): Candidate? {
+        val pathVar = component.pathVar ?: return null
+        val configured = inputs.env[pathVar]?.takeIf(String::isNotBlank) ?: return null
+        return Candidate("env-path", Path.of(configured), hardFailure = true)
+    }
+
+    private fun envDirCandidate(
+        component: ComponentContract,
+        inputs: ResolverInputs,
+    ): Candidate? {
+        val dirVar = component.dirVar ?: return null
+        val configured = inputs.env[dirVar]?.takeIf(String::isNotBlank) ?: return null
+        return Candidate("env-dir", Path.of(configured).resolve(component.binaryName(inputs.platform)), true)
+    }
+
+    private fun bundledCandidate(
+        component: ComponentContract,
+        inputs: ResolverInputs,
+    ): Candidate? {
+        val pluginRoot = inputs.pluginRoot ?: return null
+        return Candidate("bundled", pluginRoot.resolve(component.bundlePath(inputs.platform)), true)
+    }
+
+    private fun pathCandidate(
+        component: ComponentContract,
+        inputs: ResolverInputs,
+    ): Candidate? {
+        val pathValue = inputs.env["PATH"] ?: inputs.env["Path"] ?: return null
+        return pathValue.split(File.pathSeparator)
             .filter(String::isNotBlank)
-            .map { Path.of(it).resolve(binaryName()) }
-            .firstOrNull(::isUsable)
+            .map { Path.of(it).resolve(component.binaryName(inputs.platform)) }
+            .firstOrNull(Files::isRegularFile)
+            ?.let { Candidate("path", it, hardFailure = false) }
     }
 
-    private fun bundledBinary(): Path? {
-        val plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID_VALUE)) ?: return null
-        return plugin.pluginPath.resolve("bin")
-            .resolve(platformDir())
-            .resolve(binaryName())
-            .takeIf(::isUsable)
+    private fun verifyCandidate(
+        component: ComponentContract,
+        candidate: Candidate,
+    ): DeslopResolvedBinary? {
+        if (!Files.isRegularFile(candidate.path)) return handleMissing(component, candidate)
+        val probe = VersionProbe.read(candidate.path)
+        if (probe.name == component.id && probe.version == component.expectedVersion) {
+            return DeslopResolvedBinary(component.id, candidate.path, candidate.source, probe.version)
+        }
+        if (!candidate.hardFailure) return null
+        throw DeslopBinaryResolutionException(mismatchMessage(component, candidate, probe.found()))
     }
 
-    private fun isUsable(path: Path): Boolean {
-        return Files.isRegularFile(path) && (SystemInfoRt.isWindows || Files.isExecutable(path))
+    private fun handleMissing(
+        component: ComponentContract,
+        candidate: Candidate,
+    ): DeslopResolvedBinary? {
+        if (!candidate.hardFailure) return null
+        throw DeslopBinaryResolutionException(
+            "Deslop cannot start: ${component.id} ${component.expectedVersion} was not found at " +
+                "${candidate.path} from ${candidate.source}.",
+        )
     }
 
-    private fun binaryName(): String {
-        return if (SystemInfoRt.isWindows) "$BINARY_NAME.exe" else BINARY_NAME
+    private fun pluginRoot(): Path {
+        val plugin = PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID_VALUE))
+            ?: throw DeslopBinaryResolutionException("Deslop plugin root is unavailable.")
+        return plugin.pluginPath
+    }
+}
+
+internal data class ResolverInputs(
+    val pluginRoot: Path? = null,
+    val env: Map<String, String> = System.getenv(),
+    val platform: String = currentPlatform(),
+)
+
+internal data class DeslopResolvedBinary(
+    val componentId: String,
+    val path: Path,
+    val source: String,
+    val version: String,
+)
+
+internal class DeslopBinaryResolutionException(message: String) : RuntimeException(message)
+
+internal data class DeslopDeploymentManifest(
+    val components: List<ComponentContract>,
+    val jetBrainsActivationVerifies: Set<String>,
+) {
+    fun requiredJetBrainsComponent(id: String): ComponentContract {
+        if (id !in jetBrainsActivationVerifies) {
+            throw DeslopBinaryResolutionException("JetBrains host does not verify $id.")
+        }
+        return components.firstOrNull { it.id == id }
+            ?: throw DeslopBinaryResolutionException("deployment-toolkit.json is missing $id.")
     }
 
-    private fun platformDir(): String {
-        val arch = if (isArm64()) "arm64" else "x64"
-        return when {
-            SystemInfoRt.isMac -> "darwin-$arch"
-            SystemInfoRt.isLinux -> "linux-$arch"
-            SystemInfoRt.isWindows -> "win32-x64"
-            else -> "unknown-$arch"
+    companion object {
+        fun load(path: Path): DeslopDeploymentManifest {
+            val root = Json.parseToJsonElement(Files.readString(path)).jsonObject
+            return DeslopDeploymentManifest(parseComponents(root), parseJetBrainsHost(root))
+        }
+
+        private fun parseComponents(root: JsonObject): List<ComponentContract> {
+            return root["components"]?.jsonArray.orEmpty()
+                .mapNotNull { ComponentContract.fromJson(it.jsonObject) }
+        }
+
+        private fun parseJetBrainsHost(root: JsonObject): Set<String> {
+            return root["hosts"]?.jsonObject
+                ?.get("jetbrains")?.jsonObject
+                ?.get("activationVerifies")?.jsonArray
+                ?.map { it.jsonPrimitive.content }
+                ?.toSet()
+                .orEmpty()
         }
     }
+}
 
-    private fun isArm64(): Boolean {
-        return System.getProperty("os.arch").lowercase() in setOf("aarch64", "arm64")
+internal data class ComponentContract(
+    val id: String,
+    val binaryName: String,
+    val expectedVersion: String,
+    val bundleTemplate: String?,
+    val pathVar: String?,
+    val dirVar: String?,
+) {
+    fun binaryName(platform: String): String {
+        return if (platform.startsWith("win32")) "$binaryName.exe" else binaryName
     }
+
+    fun bundlePath(platform: String): Path {
+        val template = bundleTemplate
+            ?: throw DeslopBinaryResolutionException("$id has no bundled path.")
+        val value = template
+            .replace("\${platform}", platform)
+            .replace("\${binaryName}", binaryName)
+            .replace("\${exe}", if (platform.startsWith("win32")) ".exe" else "")
+        return Path.of(value)
+    }
+
+    companion object {
+        fun fromJson(json: JsonObject): ComponentContract? {
+            val kind = json.stringValue("kind") ?: return null
+            if (kind !in setOf("cli", "lsp", "mcp")) return null
+            return ComponentContract(
+                id = stringAt(json, "id"),
+                binaryName = stringAt(json, "binaryName"),
+                expectedVersion = stringAt(json, "expectedVersion"),
+                bundleTemplate = objectAt(json, "bundled")?.stringValue("bundlePath"),
+                pathVar = objectAt(json, "env")?.stringValue("pathVar"),
+                dirVar = objectAt(json, "env")?.stringValue("dirVar"),
+            )
+        }
+    }
+}
+
+private data class Candidate(
+    val source: String,
+    val path: Path,
+    val hardFailure: Boolean,
+)
+
+private data class VersionProbe(
+    val name: String?,
+    val version: String?,
+    val raw: String,
+) {
+    fun found(): String {
+        return if (name != null && version != null) "$name $version" else raw.ifBlank { "not found" }
+    }
+
+    companion object {
+        fun read(path: Path): VersionProbe {
+            return runCatching { readProcess(path) }
+                .getOrElse { VersionProbe(null, null, it.message.orEmpty()) }
+        }
+
+        private fun readProcess(path: Path): VersionProbe {
+            val process = ProcessBuilder(path.toString(), "--version").start()
+            if (!process.waitFor(1500, TimeUnit.MILLISECONDS)) {
+                process.destroyForcibly()
+                return VersionProbe(null, null, "timeout")
+            }
+            val line = process.inputStream.bufferedReader().readLine().orEmpty()
+            if (process.exitValue() != 0) return VersionProbe(null, null, line)
+            val parts = line.trim().split(" ")
+            return if (parts.size == 2) VersionProbe(parts[0], parts[1], line)
+            else VersionProbe(null, null, line)
+        }
+    }
+}
+
+private fun currentPlatform(): String {
+    val arch = if (System.getProperty("os.arch").lowercase() in setOf("aarch64", "arm64")) {
+        "arm64"
+    } else {
+        "x64"
+    }
+    val name = System.getProperty("os.name").lowercase()
+    return when {
+        name.contains("mac") -> "darwin-$arch"
+        name.contains("linux") -> "linux-$arch"
+        name.contains("windows") -> "win32-x64"
+        else -> "unknown-$arch"
+    }
+}
+
+private fun missingMessage(component: ComponentContract, skippedPath: Candidate?): String {
+    val suffix = skippedPath?.let { " Last checked: ${it.path} from ${it.source}." }.orEmpty()
+    return "No matching ${component.id} ${component.expectedVersion} binary found.$suffix"
+}
+
+private fun mismatchMessage(
+    component: ComponentContract,
+    candidate: Candidate,
+    found: String,
+): String {
+    return "Deslop cannot start: ${component.id} version mismatch. " +
+        "Expected ${component.expectedVersion} from deployment-toolkit.json. " +
+        "Found $found at ${candidate.path} from ${candidate.source}."
+}
+
+private fun stringAt(json: JsonObject, key: String): String {
+    return json.stringValue(key)
+        ?: throw DeslopBinaryResolutionException("deployment-toolkit.json is missing $key.")
+}
+
+private fun objectAt(json: JsonObject, key: String): JsonObject? {
+    return json[key]?.jsonObject
+}
+
+private fun JsonObject.stringValue(key: String): String? {
+    return (this[key] as? JsonPrimitive)?.content
 }

--- a/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopLspServerDescriptor.kt
+++ b/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopLspServerDescriptor.kt
@@ -6,7 +6,10 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import java.nio.file.Path
 
-internal class DeslopLspServerDescriptor(project: Project) :
+internal class DeslopLspServerDescriptor(
+    project: Project,
+    private val binary: DeslopResolvedBinary,
+) :
     ProjectWideLspServerDescriptor(project, "Deslop") {
 
     override fun isSupportedFile(file: VirtualFile): Boolean {
@@ -15,7 +18,7 @@ internal class DeslopLspServerDescriptor(project: Project) :
 
     override fun createCommandLine(): GeneralCommandLine {
         val workspaceRoot = workspaceRoot()
-        return GeneralCommandLine(DeslopBinaryResolver.command())
+        return GeneralCommandLine(binary.path.toString())
             .withParameters(workspaceRoot.toString(), "--min-nodes", "30", "--embeddings", "off")
             .withWorkDirectory(workspaceRoot.toFile())
     }

--- a/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopLspServerSupportProvider.kt
+++ b/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopLspServerSupportProvider.kt
@@ -11,7 +11,9 @@ internal class DeslopLspServerSupportProvider : LspServerSupportProvider {
         serverStarter: LspServerSupportProvider.LspServerStarter,
     ) {
         if (DeslopSupportedFiles.includes(file)) {
-            serverStarter.ensureServerStarted(DeslopLspServerDescriptor(project))
+            runCatching { DeslopBinaryResolver.resolveLsp() }
+                .onSuccess { serverStarter.ensureServerStarted(DeslopLspServerDescriptor(project, it)) }
+                .onFailure { DeslopStartupNotifier.show(project, it.message.orEmpty()) }
         }
     }
 }

--- a/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopStartupNotifier.kt
+++ b/clients/jetbrains/src/main/kotlin/com/nimblesite/deslop/jetbrains/DeslopStartupNotifier.kt
@@ -1,0 +1,17 @@
+package com.nimblesite.deslop.jetbrains
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+
+internal object DeslopStartupNotifier {
+    private const val GROUP_ID = "Deslop"
+
+    fun show(project: Project, message: String) {
+        val text = message.ifBlank { "Deslop cannot start because deslop-lsp failed verification." }
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup(GROUP_ID)
+            .createNotification(text, NotificationType.ERROR)
+            .notify(project)
+    }
+}

--- a/clients/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/clients/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,7 @@
     <depends>com.intellij.modules.lsp</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <notificationGroup id="Deslop" displayType="BALLOON" />
         <platform.lsp.serverSupportProvider
             implementation="com.nimblesite.deslop.jetbrains.DeslopLspServerSupportProvider" />
     </extensions>

--- a/clients/jetbrains/src/test/kotlin/com/nimblesite/deslop/jetbrains/DeslopBinaryResolverTest.kt
+++ b/clients/jetbrains/src/test/kotlin/com/nimblesite/deslop/jetbrains/DeslopBinaryResolverTest.kt
@@ -1,0 +1,130 @@
+package com.nimblesite.deslop.jetbrains
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class DeslopBinaryResolverTest {
+    private val platform = testPlatform()
+
+    @Test
+    fun envPathMismatchBlocksStartup() {
+        val root = tempRoot()
+        val envBin = script(root.resolve("env/deslop-lsp"), "deslop-lsp", "9.9.9")
+        val error = assertFailsWith<DeslopBinaryResolutionException> {
+            resolve(root, mapOf("DESLOP_LSP_PATH" to envBin.toString()))
+        }
+        assertContains(error.message.orEmpty(), "Found deslop-lsp 9.9.9")
+        assertContains(error.message.orEmpty(), "env-path")
+    }
+
+    @Test
+    fun envDirectoryMismatchBlocksStartup() {
+        val root = tempRoot()
+        script(root.resolve("env/deslop-lsp"), "deslop-lsp", "9.9.9")
+        val error = assertFailsWith<DeslopBinaryResolutionException> {
+            resolve(root, mapOf("DESLOP_BINARY_DIR" to root.resolve("env").toString()))
+        }
+        assertContains(error.message.orEmpty(), "env-dir")
+    }
+
+    @Test
+    fun stalePathBinaryDoesNotOverrideBundledBinary() {
+        val root = tempRoot()
+        script(root.resolve("path/deslop-lsp"), "deslop-lsp", "9.9.9")
+        bundled(root, "deslop-lsp", "0.1.0")
+        val resolved = resolve(root, mapOf("PATH" to root.resolve("path").toString()))
+        assertEquals("bundled", resolved.source)
+        assertEquals("0.1.0", resolved.version)
+    }
+
+    @Test
+    fun bundledBinaryStartsSuccessfully() {
+        val root = tempRoot()
+        bundled(root, "deslop-lsp", "0.1.0")
+        val resolved = resolve(root, emptyMap())
+        assertEquals(root.resolve("plugin/bin/$platform/deslop-lsp"), resolved.path)
+    }
+
+    @Test
+    fun missingBundledBinaryReportsPathAndSource() {
+        val root = tempRoot()
+        val error = assertFailsWith<DeslopBinaryResolutionException> {
+            resolve(root, emptyMap())
+        }
+        assertContains(error.message.orEmpty(), "was not found")
+        assertContains(error.message.orEmpty(), "bundled")
+    }
+
+    @Test
+    fun componentNameMismatchReportsExpectedAndFound() {
+        val root = tempRoot()
+        bundled(root, "deslop", "0.1.0")
+        val error = assertFailsWith<DeslopBinaryResolutionException> {
+            resolve(root, emptyMap())
+        }
+        assertContains(error.message.orEmpty(), "Expected 0.1.0")
+        assertContains(error.message.orEmpty(), "Found deslop 0.1.0")
+    }
+
+    private fun resolve(
+        root: Path,
+        env: Map<String, String>,
+    ): DeslopResolvedBinary {
+        return DeslopBinaryResolver.resolveLsp(
+            manifest(),
+            ResolverInputs(root.resolve("plugin"), env, platform),
+        )
+    }
+
+    private fun bundled(root: Path, name: String, version: String): Path {
+        return script(root.resolve("plugin/bin/$platform/deslop-lsp"), name, version)
+    }
+
+    private fun script(path: Path, name: String, version: String): Path {
+        path.parent.createDirectories()
+        path.writeText("#!/bin/sh\necho '$name $version'\n")
+        path.toFile().setExecutable(true)
+        return path
+    }
+
+    private fun tempRoot(): Path {
+        return Files.createTempDirectory("deslop-jetbrains-resolver-")
+    }
+
+    private fun manifest(): DeslopDeploymentManifest {
+        return DeslopDeploymentManifest(
+            components = listOf(
+                ComponentContract(
+                    id = "deslop-lsp",
+                    binaryName = "deslop-lsp",
+                    expectedVersion = "0.1.0",
+                    bundleTemplate = "bin/\${platform}/\${binaryName}\${exe}",
+                    pathVar = "DESLOP_LSP_PATH",
+                    dirVar = "DESLOP_BINARY_DIR",
+                ),
+            ),
+            jetBrainsActivationVerifies = setOf("deslop-lsp"),
+        )
+    }
+}
+
+private fun testPlatform(): String {
+    val arch = if (System.getProperty("os.arch").lowercase() in setOf("aarch64", "arm64")) {
+        "arm64"
+    } else {
+        "x64"
+    }
+    val name = System.getProperty("os.name").lowercase()
+    return when {
+        name.contains("mac") -> "darwin-$arch"
+        name.contains("linux") -> "linux-$arch"
+        name.contains("windows") -> "win32-x64"
+        else -> "unknown-$arch"
+    }
+}

--- a/clients/vscode/.vscode-test-ollama.mjs
+++ b/clients/vscode/.vscode-test-ollama.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 // Ollama-gated VSIX e2e tests. Points a REAL VS Code instance at the
-// real deslop-lsp binary with provider="ollama" + model="nomic-embed-text",
+// bundled deslop-lsp binary with provider="ollama" + model="nomic-embed-text",
 // over the csharp-type4 fixture (recursive vs. iterative — semantically
 // equivalent, structurally distinct, so only an embedding pass can match).
 //
@@ -13,7 +13,6 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const fixture = path.join(here, "out", "test", "fixtures", "csharp-type4");
-const releaseDir = path.join(here, "..", "..", "target", "release");
 
 export default defineConfig({
   tests: [
@@ -24,7 +23,9 @@ export default defineConfig({
       launchArgs: ["--disable-extensions"],
       env: {
         DESLOP_TEST_FIXTURE: fixture,
-        DESLOP_BINARY_DIR: releaseDir,
+        DESLOP_BINARY_DIR: "",
+        DESLOP_LSP_PATH: "",
+        DESLOP_MCP_PATH: "",
       },
       mocha: {
         ui: "tdd",

--- a/clients/vscode/.vscode-test.mjs
+++ b/clients/vscode/.vscode-test.mjs
@@ -7,7 +7,6 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const fixture = path.join(here, "out", "test", "fixtures", "csharp-small");
-const releaseDir = path.join(here, "..", "..", "target", "release");
 
 export default defineConfig({
   tests: [
@@ -20,7 +19,9 @@ export default defineConfig({
       launchArgs: ["--disable-extensions"],
       env: {
         DESLOP_TEST_FIXTURE: fixture,
-        DESLOP_BINARY_DIR: releaseDir,
+        DESLOP_BINARY_DIR: "",
+        DESLOP_LSP_PATH: "",
+        DESLOP_MCP_PATH: "",
       },
       mocha: {
         ui: "tdd",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -28,6 +28,7 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
+    "onStartupFinished",
     "onUri:deslop",
     "onLanguage:csharp",
     "onLanguage:rust",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -289,6 +289,16 @@
           "default": "",
           "description": "Optional path to .deslop.toml. Mirrors CLI --config."
         },
+        "deslop.lspPath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional absolute path to deslop-lsp. The binary must match deployment-toolkit.json before activation."
+        },
+        "deslop.mcpPath": {
+          "type": "string",
+          "default": "",
+          "description": "Optional absolute path to deslop-mcp. The binary must match deployment-toolkit.json before activation."
+        },
         "deslop.liveBubble.enabled": {
           "type": "boolean",
           "default": true,
@@ -327,7 +337,8 @@
     "pretest:ollama": "npm run compile && npm run build && rm -rf out/test/fixtures && cp -R src/test/fixtures out/test/fixtures",
     "test:ollama": "vscode-test --config .vscode-test-ollama.mjs",
     "coverage": "npm run pretest && vscode-test --coverage && node ./scripts/check-coverage.mjs",
-    "package": "npm run build && vsce package --no-dependencies -o deslop-vscode.vsix && node ./scripts/assert-vsix-schema-doc.mjs"
+    "verify:package": "node ./scripts/verify-vsix-package.mjs",
+    "package": "npm run build && vsce package --no-dependencies -o deslop-vscode.vsix && node ./scripts/assert-vsix-schema-doc.mjs && npm run verify:package"
   },
   "dependencies": {
     "pino": "^10.3.1",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -55,6 +55,10 @@
         "title": "Deslop: Compare With Canonical Occurrence"
       },
       {
+        "command": "deslop.compareOccurrenceWithCanonical",
+        "title": "Compare With Canonical"
+      },
+      {
         "command": "deslop.pickEmbeddingModel",
         "title": "Deslop: Pick Embedding Model"
       },
@@ -126,6 +130,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "deslop.compareOccurrenceWithCanonical",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "deslop.topOffenders.showByCluster",
@@ -150,7 +160,7 @@
           "group": "navigation@2"
         },
         {
-          "command": "deslop.openOccurrence",
+          "command": "deslop.compareOccurrenceWithCanonical",
           "when": "viewItem == deslop.occurrence",
           "group": "navigation@1"
         },

--- a/clients/vscode/scripts/verify-vsix-package.mjs
+++ b/clients/vscode/scripts/verify-vsix-package.mjs
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const vsixRoot = resolve(here, "..");
+const vsixArg = process.argv[2] ?? "deslop-vscode.vsix";
+const vsixPath = isAbsolute(vsixArg) ? vsixArg : resolve(vsixRoot, vsixArg);
+const platform = currentPlatform();
+const manifestEntry = "extension/deployment-toolkit.json";
+
+const entries = unzipText(["-Z1", vsixPath]).split("\n").filter(Boolean);
+assertEntry(entries, manifestEntry);
+
+const manifest = JSON.parse(unzipText(["-p", vsixPath, manifestEntry]));
+const components = executableComponents(manifest);
+const activationIds = new Set(manifest.hosts?.vscode?.activationVerifies ?? []);
+const binPrefix = `extension/bin/${platform}/`;
+const binEntries = entries.filter((entry) => entry.startsWith(binPrefix) && !entry.endsWith("/"));
+
+for (const component of components.filter((item) => activationIds.has(item.id))) {
+  assertEntry(entries, `${binPrefix}${nameWithSuffix(component)}`);
+}
+for (const entry of binEntries) {
+  verifyBundledEntry(entry, componentForEntry(entry, components));
+}
+
+console.log(`Verified deployment manifest and ${binEntries.length} ${platform} VSIX binaries`);
+
+function verifyBundledEntry(entry, component) {
+  if (!component) throw new Error(`Undeclared executable in VSIX: ${entry}`);
+  const temp = mkdtempSync(join(tmpdir(), "deslop-vsix-"));
+  try {
+    unzipText(["-q", vsixPath, entry, "-d", temp]);
+    const binaryPath = join(temp, entry);
+    assertExecutable(binaryPath);
+    assertVersion(binaryPath, component);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function componentForEntry(entry, components) {
+  const fileName = entry.slice(entry.lastIndexOf("/") + 1);
+  return components.find((component) => nameWithSuffix(component) === fileName);
+}
+
+function assertVersion(binaryPath, component) {
+  const result = spawnSync(binaryPath, ["--version"], { encoding: "utf8", timeout: 1500 });
+  if (result.status !== 0) throw new Error(`${binaryPath} --version failed`);
+  const first = firstLine(String(result.stdout));
+  const expected = `${component.id} ${component.expectedVersion}`;
+  if (first !== expected) throw new Error(`${binaryPath} reported ${first}; expected ${expected}`);
+}
+
+function assertExecutable(binaryPath) {
+  if (platform.startsWith("win32")) return;
+  if ((statSync(binaryPath).mode & 0o111) === 0) {
+    throw new Error(`${binaryPath} is not executable`);
+  }
+}
+
+function executableComponents(manifest) {
+  return (manifest.components ?? []).filter((component) =>
+    ["cli", "lsp", "mcp"].includes(component.kind),
+  );
+}
+
+function assertEntry(entries, entry) {
+  if (!entries.includes(entry)) throw new Error(`Missing ${entry} in ${vsixPath}`);
+}
+
+function unzipText(args) {
+  const result = spawnSync("unzip", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`unzip ${args.join(" ")} failed: ${String(result.stderr)}`);
+  }
+  return String(result.stdout);
+}
+
+function nameWithSuffix(component) {
+  return `${component.binaryName}${platform.startsWith("win32") ? ".exe" : ""}`;
+}
+
+function firstLine(text) {
+  const end = text.indexOf("\n");
+  const line = end >= 0 ? text.slice(0, end) : text;
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function currentPlatform() {
+  if (process.platform === "darwin" && process.arch === "arm64") return "darwin-arm64";
+  if (process.platform === "darwin" && process.arch === "x64") return "darwin-x64";
+  if (process.platform === "linux" && process.arch === "x64") return "linux-x64";
+  if (process.platform === "linux" && process.arch === "arm64") return "linux-arm64";
+  if (process.platform === "win32" && process.arch === "x64") return "win32-x64";
+  throw new Error(`unsupported platform ${process.platform}-${process.arch}`);
+}

--- a/clients/vscode/src/binary.ts
+++ b/clients/vscode/src/binary.ts
@@ -1,20 +1,14 @@
-// Binary resolver per [VSIX-BINARY-VERSIONING].
-//
-// Order of resolution:
-//   1. ${DESLOP_BINARY_DIR} — nightly / local builds override everything.
-//   2. PATH — reachable via shell (brew tap, scoop bucket, cargo install),
-//      accepted only if `<binary> --version` matches the extension version exactly.
-//   3. Bundled ${extensionPath}/bin/<platform>/<binary>.
-//
-// When (3) wins, the resolver prepends that directory to the current VS Code
-// process PATH so integrated terminals, task runners, and launch configs see
-// `deslop` without the user modifying their shell profile.
+// Manifest-backed binary resolver for the VS Code host.
+// Contract source:
+// https://github.com/MelbourneDeveloper/deployment_toolkit/blob/main/docs/specs/ide-extension-deployment.md#required-startup-behavior
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 
 export type BinaryKind = "lsp" | "mcp" | "cli";
+
+export type BinarySource = "user-setting" | "env-path" | "env-dir" | "bundled" | "path";
 
 export type Platform =
   | "darwin-arm64"
@@ -25,9 +19,50 @@ export type Platform =
 
 export interface ResolvedBinary {
   kind: BinaryKind;
-  source: "env" | "path" | "bundled";
+  componentId: string;
+  source: BinarySource;
   path: string;
+  version: string;
+}
+
+export interface BinarySettings {
+  lspPath?: string;
+  mcpPath?: string;
+}
+
+export interface DeploymentManifest {
+  manifestVersion: number;
+  product: { id: string; version: string };
+  components: DeploymentComponent[];
+  hosts: Record<string, HostContract | undefined>;
+}
+
+export interface DeploymentComponent {
+  id: string;
+  kind: string;
+  language: string;
+  binaryName: string;
+  expectedVersion: string;
+  bundled?: { bundlePath: string };
+  userSetting?: string;
+  env?: { pathVar?: string; dirVar?: string };
+  required?: boolean;
+}
+
+export interface HostContract {
+  activationVerifies: string[];
+}
+
+interface Candidate {
+  source: BinarySource;
+  path: string;
+  hardFailure: boolean;
+}
+
+interface VersionProbe {
+  name: string | null;
   version: string | null;
+  raw: string;
 }
 
 export class UnsupportedPlatformError extends Error {
@@ -44,93 +79,282 @@ export class BundledBinaryMissingError extends Error {
   }
 }
 
-const BINARY_NAMES: Record<BinaryKind, string> = {
-  lsp: "deslop-lsp",
-  mcp: "deslop-mcp",
-  cli: "deslop",
-};
+export class BinaryVerificationError extends Error {
+  constructor(component: DeploymentComponent, candidate: Candidate, found: string) {
+    super(mismatchMessage(component, candidate, found));
+    this.name = "BinaryVerificationError";
+  }
+}
+
+export class BinaryMissingError extends Error {
+  constructor(component: DeploymentComponent, source: BinarySource, binaryPath: string) {
+    super(
+      `Deslop cannot start: ${component.id} ${component.expectedVersion} was not found at ${binaryPath} from ${source}.`,
+    );
+    this.name = "BinaryMissingError";
+  }
+}
+
+export function loadDeploymentManifest(extensionPath: string): DeploymentManifest {
+  const manifestPath = deploymentManifestPath(extensionPath);
+  const raw = fs.readFileSync(manifestPath, "utf8");
+  return JSON.parse(raw) as DeploymentManifest;
+}
+
+export function resolveHostBinaries(
+  extensionPath: string,
+  host: string,
+  manifest: DeploymentManifest,
+  settings: BinarySettings = {},
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, ResolvedBinary> {
+  const hostContract = manifest.hosts[host];
+  if (!hostContract) throw new Error(`deployment manifest has no ${host} host contract`);
+  return Object.fromEntries(
+    hostContract.activationVerifies.map((id) => [
+      id,
+      resolveComponent(extensionPath, requireComponent(manifest, id), settings, env),
+    ]),
+  );
+}
 
 export function resolveBinary(
   extensionPath: string,
   kind: BinaryKind,
-  expectedVersion: string,
+  manifest: DeploymentManifest,
+  settings: BinarySettings = {},
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedBinary {
-  const platform = currentPlatform();
-  const binName = nameWithSuffix(kind, platform);
-
-  const fromEnv = tryEnv(env, binName);
-  if (fromEnv) {
-    return { kind, source: "env", path: fromEnv, version: versionOf(fromEnv) };
-  }
-
-  const fromPath = tryPath(binName, env);
-  if (fromPath) {
-    const ver = versionOf(fromPath);
-    if (ver && ver === expectedVersion) {
-      return { kind, source: "path", path: fromPath, version: ver };
-    }
-  }
-
-  const bundledDir = path.join(extensionPath, "bin", platform);
-  const bundledPath = path.join(bundledDir, binName);
-  if (!fs.existsSync(bundledPath)) {
-    throw new BundledBinaryMissingError(bundledPath);
-  }
-  prependToPath(env, bundledDir);
-  return { kind, source: "bundled", path: bundledPath, version: versionOf(bundledPath) };
+  const component = manifest.components.find((candidate) => candidate.kind === kind);
+  if (!component) throw new Error(`deployment manifest has no ${kind} component`);
+  return resolveComponent(extensionPath, component, settings, env);
 }
 
-function tryEnv(env: NodeJS.ProcessEnv, binName: string): string | null {
-  const dir = env["DESLOP_BINARY_DIR"];
-  if (!dir) return null;
-  const candidate = path.join(dir, binName);
-  return fs.existsSync(candidate) ? candidate : null;
-}
-
-function tryPath(binName: string, env: NodeJS.ProcessEnv): string | null {
-  const pathValue = env["PATH"] ?? env["Path"] ?? "";
-  const sep = process.platform === "win32" ? ";" : ":";
-  for (const dir of pathValue.split(sep)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, binName);
-    if (fs.existsSync(candidate)) return candidate;
+function resolveComponent(
+  extensionPath: string,
+  component: DeploymentComponent,
+  settings: BinarySettings,
+  env: NodeJS.ProcessEnv,
+): ResolvedBinary {
+  let skippedPath: Candidate | undefined;
+  for (const candidate of candidates(extensionPath, component, settings, env)) {
+    const resolved = verifyCandidate(component, candidate, env);
+    if (resolved) return resolved;
+    skippedPath = candidate;
   }
-  return null;
+  throwMissing(component, skippedPath);
 }
 
-function versionOf(binaryPath: string): string | null {
+function verifyCandidate(
+  component: DeploymentComponent,
+  candidate: Candidate,
+  env: NodeJS.ProcessEnv,
+): ResolvedBinary | undefined {
+  if (!fs.existsSync(candidate.path)) return handleMissing(candidate, component);
+  const probe = versionProbe(candidate.path);
+  if (probe.name === component.id && probe.version === component.expectedVersion) {
+    if (candidate.source === "bundled") prependToPath(env, path.dirname(candidate.path));
+    return resolvedBinary(component, candidate, probe.version);
+  }
+  if (!candidate.hardFailure) return undefined;
+  throw new BinaryVerificationError(component, candidate, foundVersion(probe));
+}
+
+function handleMissing(candidate: Candidate, component?: DeploymentComponent): undefined {
+  if (candidate.source === "bundled") throw new BundledBinaryMissingError(candidate.path);
+  if (candidate.hardFailure && component) {
+    throw new BinaryMissingError(component, candidate.source, candidate.path);
+  }
+  return undefined;
+}
+
+function candidates(
+  extensionPath: string,
+  component: DeploymentComponent,
+  settings: BinarySettings,
+  env: NodeJS.ProcessEnv,
+): Candidate[] {
+  return [
+    ...settingCandidate(component, settings),
+    ...envPathCandidate(component, env),
+    ...envDirCandidate(component, env),
+    bundledCandidate(extensionPath, component),
+    pathCandidate(component, env),
+  ].filter((candidate): candidate is Candidate => Boolean(candidate));
+}
+
+function settingCandidate(
+  component: DeploymentComponent,
+  settings: BinarySettings,
+): Candidate[] {
+  const configured = settingValue(component, settings);
+  return configured ? [{ source: "user-setting", path: configured, hardFailure: true }] : [];
+}
+
+function envPathCandidate(component: DeploymentComponent, env: NodeJS.ProcessEnv): Candidate[] {
+  const pathVar = component.env?.pathVar;
+  const configured = pathVar ? nonBlank(env[pathVar]) : undefined;
+  return configured ? [{ source: "env-path", path: configured, hardFailure: true }] : [];
+}
+
+function envDirCandidate(component: DeploymentComponent, env: NodeJS.ProcessEnv): Candidate[] {
+  const dirVar = component.env?.dirVar;
+  const configured = dirVar ? nonBlank(env[dirVar]) : undefined;
+  return configured ? [candidateFromDir(component, configured, "env-dir", true)] : [];
+}
+
+function bundledCandidate(
+  extensionPath: string,
+  component: DeploymentComponent,
+): Candidate | undefined {
+  if (!component.bundled) return undefined;
+  const bundlePath = component.bundled.bundlePath;
+  return {
+    source: "bundled",
+    path: path.join(extensionPath, interpolateBundlePath(bundlePath, component)),
+    hardFailure: true,
+  };
+}
+
+function pathCandidate(
+  component: DeploymentComponent,
+  env: NodeJS.ProcessEnv,
+): Candidate | undefined {
+  const found = findOnPath(nameWithSuffix(component), env);
+  return found ? { source: "path", path: found, hardFailure: false } : undefined;
+}
+
+function candidateFromDir(
+  component: DeploymentComponent,
+  dir: string,
+  source: BinarySource,
+  hardFailure: boolean,
+): Candidate {
+  return { source, path: path.join(dir, nameWithSuffix(component)), hardFailure };
+}
+
+function settingValue(component: DeploymentComponent, settings: BinarySettings): string | undefined {
+  if (component.kind === "lsp") return nonBlank(settings.lspPath);
+  if (component.kind === "mcp") return nonBlank(settings.mcpPath);
+  return undefined;
+}
+
+function versionProbe(binaryPath: string): VersionProbe {
   try {
     const result = spawnSync(binaryPath, ["--version"], { encoding: "utf8", timeout: 1500 });
-    if (result.status !== 0) return null;
-    const out = (result.stdout + result.stderr).trim();
-    const match = out.match(/\b(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\b/);
-    return match ? (match[1] ?? null) : null;
-  } catch {
-    return null;
+    if (result.status !== 0) return { name: null, version: null, raw: String(result.stderr) };
+    return parseVersionLine(firstLine(String(result.stdout)));
+  } catch (err) {
+    return { name: null, version: null, raw: err instanceof Error ? err.message : String(err) };
   }
+}
+
+function parseVersionLine(line: string): VersionProbe {
+  const parts = line.trim().split(" ");
+  if (parts.length !== 2) return { name: null, version: null, raw: line };
+  return { name: parts[0] ?? null, version: parts[1] ?? null, raw: line };
+}
+
+function firstLine(text: string): string {
+  const end = text.indexOf("\n");
+  const line = end >= 0 ? text.slice(0, end) : text;
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function findOnPath(binName: string, env: NodeJS.ProcessEnv): string | undefined {
+  const pathValue = env["PATH"] ?? env["Path"] ?? "";
+  return pathValue
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((dir) => path.join(dir, binName))
+    .find((candidate) => fs.existsSync(candidate));
+}
+
+function interpolateBundlePath(template: string, component: DeploymentComponent): string {
+  return template
+    .replace("${platform}", currentPlatform())
+    .replace("${binaryName}", component.binaryName)
+    .replace("${exe}", currentPlatform().startsWith("win32") ? ".exe" : "");
+}
+
+function resolvedBinary(
+  component: DeploymentComponent,
+  candidate: Candidate,
+  version: string | null,
+): ResolvedBinary {
+  return {
+    kind: toBinaryKind(component.kind),
+    componentId: component.id,
+    source: candidate.source,
+    path: candidate.path,
+    version: version ?? "",
+  };
+}
+
+function requireComponent(manifest: DeploymentManifest, id: string): DeploymentComponent {
+  const component = manifest.components.find((candidate) => candidate.id === id);
+  if (!component) throw new Error(`deployment manifest has no component ${id}`);
+  return component;
+}
+
+function deploymentManifestPath(extensionPath: string): string {
+  const packagedPath = path.join(extensionPath, "deployment-toolkit.json");
+  if (fs.existsSync(packagedPath)) return packagedPath;
+  return path.resolve(extensionPath, "..", "..", "deployment-toolkit.json");
+}
+
+function throwMissing(component: DeploymentComponent, skipped?: Candidate): never {
+  const suffix = skipped ? ` Last checked: ${skipped.path} from ${skipped.source}.` : "";
+  throw new Error(`No matching ${component.id} ${component.expectedVersion} binary found.${suffix}`);
+}
+
+function foundVersion(probe: VersionProbe): string {
+  return probe.name && probe.version ? `${probe.name} ${probe.version}` : probe.raw || "not found";
+}
+
+function mismatchMessage(
+  component: DeploymentComponent,
+  candidate: Candidate,
+  found: string,
+): string {
+  return [
+    `Deslop cannot start: ${component.id} version mismatch.`,
+    `Expected ${component.expectedVersion} from deployment-toolkit.json.`,
+    `Found ${found} at ${candidate.path} from ${candidate.source}.`,
+    "Use a matching binary or clear the configured override.",
+  ].join(" ");
 }
 
 function prependToPath(env: NodeJS.ProcessEnv, dir: string): void {
   const key = process.platform === "win32" ? "Path" : "PATH";
   const existing = env[key] ?? "";
-  const sep = process.platform === "win32" ? ";" : ":";
-  if (existing.split(sep).includes(dir)) return;
-  env[key] = existing ? `${dir}${sep}${existing}` : dir;
+  if (existing.split(path.delimiter).includes(dir)) return;
+  env[key] = existing ? `${dir}${path.delimiter}${existing}` : dir;
 }
 
-function nameWithSuffix(kind: BinaryKind, platform: Platform): string {
-  const suffix = platform.startsWith("win32") ? ".exe" : "";
-  return `${BINARY_NAMES[kind]}${suffix}`;
+function nameWithSuffix(component: DeploymentComponent): string {
+  const suffix = currentPlatform().startsWith("win32") ? ".exe" : "";
+  return `${component.binaryName}${suffix}`;
+}
+
+function toBinaryKind(kind: string): BinaryKind {
+  if (kind === "cli" || kind === "lsp" || kind === "mcp") return kind;
+  throw new Error(`component kind ${kind} is not executable`);
+}
+
+function nonBlank(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
 }
 
 function currentPlatform(): Platform {
-  const p = process.platform;
-  const a = process.arch;
-  if (p === "darwin" && a === "arm64") return "darwin-arm64";
-  if (p === "darwin" && a === "x64") return "darwin-x64";
-  if (p === "linux" && a === "x64") return "linux-x64";
-  if (p === "linux" && a === "arm64") return "linux-arm64";
-  if (p === "win32" && a === "x64") return "win32-x64";
-  throw new UnsupportedPlatformError(p, a);
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === "darwin" && arch === "arm64") return "darwin-arm64";
+  if (platform === "darwin" && arch === "x64") return "darwin-x64";
+  if (platform === "linux" && arch === "x64") return "linux-x64";
+  if (platform === "linux" && arch === "arm64") return "linux-arm64";
+  if (platform === "win32" && arch === "x64") return "win32-x64";
+  throw new UnsupportedPlatformError(platform, arch);
 }

--- a/clients/vscode/src/commands/register.ts
+++ b/clients/vscode/src/commands/register.ts
@@ -53,8 +53,12 @@ export function registerCommands(
     vscode.commands.registerCommand("deslop.jumpToNextOccurrence", () =>
       jumpToNextOccurrence(store),
     ),
-    vscode.commands.registerCommand("deslop.compareWithCanonical", (id: string) =>
-      compareWithCanonical(store, id),
+    vscode.commands.registerCommand("deslop.compareWithCanonical", (target: unknown) =>
+      compareWithCanonicalTarget(store, target),
+    ),
+    vscode.commands.registerCommand(
+      "deslop.compareOccurrenceWithCanonical",
+      (target: unknown) => compareWithCanonicalTarget(store, target),
     ),
     vscode.commands.registerCommand("deslop.pickEmbeddingModel", () =>
       pickEmbeddingModel(store, clientOf),
@@ -213,19 +217,105 @@ export function jumpToNextOccurrence(store: ReportStore): void {
   openOccurrence(next).catch(() => undefined);
 }
 
+export async function compareWithCanonicalTarget(
+  store: ReportStore,
+  target: unknown,
+): Promise<void> {
+  if (isOccurrenceNode(target)) {
+    const selection = selectedOccurrenceCompare(store, target.occurrence);
+    if (!selection) return;
+    await openCompareDiff(selection.cluster.id, selection.canonical, selection.selected);
+    return;
+  }
+  const clusterId = clusterIdFromCompareTarget(store, target);
+  if (!clusterId) return;
+  await compareWithCanonical(store, clusterId);
+}
+
+interface OccurrenceCompareSelection {
+  readonly cluster: ReportCluster;
+  readonly canonical: ReportOccurrence;
+  readonly selected: ReportOccurrence;
+}
+
+function selectedOccurrenceCompare(
+  store: ReportStore,
+  occurrence: ReportOccurrence,
+): OccurrenceCompareSelection | undefined {
+  const cluster = parentClusterForOccurrence(store, occurrence);
+  const canonical = cluster?.occurrences[0];
+  const selected = cluster?.occurrences.find((candidate) =>
+    sameOccurrence(candidate, occurrence),
+  );
+  if (!cluster || !canonical || !selected || sameOccurrence(canonical, selected)) {
+    return undefined;
+  }
+  return { cluster, canonical, selected };
+}
+
+function parentClusterForOccurrence(
+  store: ReportStore,
+  occurrence: ReportOccurrence,
+): ReportCluster | undefined {
+  return store.current.report?.clusters.find((cluster) =>
+    cluster.occurrences.some((candidate) => sameOccurrence(candidate, occurrence)),
+  );
+}
+
+function sameOccurrence(left: ReportOccurrence, right: ReportOccurrence): boolean {
+  return (
+    left.path === right.path &&
+    left.start_byte === right.start_byte &&
+    left.end_byte === right.end_byte
+  );
+}
+
+function clusterIdFromCompareTarget(
+  store: ReportStore,
+  target: unknown,
+): string | undefined {
+  if (typeof target === "string") return target;
+  if (isCompareTreeTarget(target)) return clusterIdForTreeNode(target, store);
+  return undefined;
+}
+
+function isCompareTreeTarget(
+  target: unknown,
+): target is ClusterNode | OccurrenceNode {
+  return isOccurrenceNode(target) || isClusterNode(target);
+}
+
+function isClusterNode(target: unknown): target is ClusterNode {
+  if (typeof target !== "object" || target === null || !("cluster" in target)) {
+    return false;
+  }
+  const cluster = (target as Partial<ClusterNode>).cluster as
+    | Partial<ReportCluster>
+    | undefined;
+  return typeof cluster?.id === "string" && Array.isArray(cluster.occurrences);
+}
+
 export async function compareWithCanonical(store: ReportStore, clusterId: string): Promise<void> {
   const cluster = store.current.report?.clusters.find((c) => c.id === clusterId);
   if (!cluster || cluster.occurrences.length < 2) return;
   const [a, b] = cluster.occurrences;
   if (!a || !b) return;
+  await openCompareDiff(cluster.id, a, b);
+}
+
+async function openCompareDiff(
+  clusterId: string,
+  a: ReportOccurrence,
+  b: ReportOccurrence,
+): Promise<void> {
   // Always diff occurrence bytes via the deslop-compare provider — same-file
   // clusters would otherwise collapse to "whole file vs. itself" because
   // `vscode.diff` dedupes identical URIs into a single editor pane.
   await vscode.commands.executeCommand(
     "vscode.diff",
-    buildCompareUri(a, "a", cluster.id),
-    buildCompareUri(b, "b", cluster.id),
-    `Compare (cluster ${cluster.id})`,
+    buildCompareUri(a, "a", clusterId),
+    buildCompareUri(b, "b", clusterId),
+    `Compare (cluster ${clusterId})`,
   );
 }
 

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -51,6 +51,8 @@ let resolvedMcp: ResolvedBinary | undefined;
 /// LanguageClient without parallel activation or command-surface hacks.
 export interface ExtensionApi {
   readonly client: LanguageClient | undefined;
+  readonly resolvedLsp: ResolvedBinary | undefined;
+  readonly resolvedMcp: ResolvedBinary | undefined;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
@@ -117,7 +119,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
     client = startLanguageClient(resolvedLsp);
   } catch (err) {
     surfaceStartupFailure(err, reportStore);
-    return { get client() { return client; } };
+    return currentApi();
   }
 
   const decorations = new DecorationManager(reportStore);
@@ -142,7 +144,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
     await client.start();
   } catch (err) {
     surfaceStartupFailure(err, reportStore);
-    return { get client() { return client; } };
+    return currentApi();
   }
   wireNotifications(client, reportStore);
   await seedInitialReport(client, reportStore);
@@ -154,7 +156,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
       );
     }),
   );
-  return { get client() { return client; } };
+  return currentApi();
 }
 
 export async function deactivate(): Promise<void> {
@@ -162,6 +164,14 @@ export async function deactivate(): Promise<void> {
     await client.stop();
     client = undefined;
   }
+}
+
+function currentApi(): ExtensionApi {
+  return {
+    get client() { return client; },
+    get resolvedLsp() { return resolvedLsp; },
+    get resolvedMcp() { return resolvedMcp; },
+  };
 }
 
 // [VSIX-TOP-OFFENDERS-GROUPING] Mirror the persisted setting onto a

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -10,10 +10,16 @@ import {
 } from "vscode-languageclient/node";
 
 import {
-  resolveBinary,
   BundledBinaryMissingError,
   UnsupportedPlatformError,
   ResolvedBinary,
+  loadDeploymentManifest,
+  resolveBinary,
+  resolveHostBinaries,
+  BinaryVerificationError,
+  BinaryMissingError,
+  DeploymentManifest,
+  BinarySettings,
 } from "./binary";
 import { log, logError, initOutputChannel } from "./logging";
 import { ReportStore } from "./reportStore";
@@ -87,8 +93,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
   );
 
   try {
-    resolvedLsp = resolveBinary(context.extensionPath, "lsp", currentExtensionVersion(context));
-    resolvedMcp = tryResolveOptional(context.extensionPath, "mcp", currentExtensionVersion(context));
+    const manifest = loadDeploymentManifest(context.extensionPath);
+    const resolved = resolveHostBinaries(
+      context.extensionPath,
+      "vscode",
+      manifest,
+      currentBinarySettings(),
+    );
+    resolvedLsp = requireResolved(resolved, "deslop-lsp");
+    resolvedMcp = resolved["deslop-mcp"];
     log("lsp resolved", {
       path: resolvedLsp.path,
       source: resolvedLsp.source,
@@ -331,14 +344,32 @@ export async function seedInitialReport(c: LanguageClient, store: ReportStore): 
 export function tryResolveOptional(
   extensionPath: string,
   kind: "mcp",
-  version: string,
+  manifest: DeploymentManifest,
+  settings: BinarySettings = {},
 ): ResolvedBinary | undefined {
   try {
-    return resolveBinary(extensionPath, kind, version);
+    return resolveBinary(extensionPath, kind, manifest, settings);
   } catch (err) {
     logError(err, `resolve ${kind} (optional)`);
     return undefined;
   }
+}
+
+function currentBinarySettings(): BinarySettings {
+  const cfg = vscode.workspace.getConfiguration("deslop");
+  return {
+    lspPath: cfg.get<string>("lspPath", ""),
+    mcpPath: cfg.get<string>("mcpPath", ""),
+  };
+}
+
+function requireResolved(
+  resolved: Record<string, ResolvedBinary>,
+  componentId: string,
+): ResolvedBinary {
+  const binary = resolved[componentId];
+  if (!binary) throw new Error(`Required Deslop component ${componentId} did not resolve.`);
+  return binary;
 }
 
 export function currentExtensionVersion(context: vscode.ExtensionContext): string {
@@ -365,9 +396,11 @@ export function surfaceStartupFailure(err: unknown, store?: ReportStore): void {
   logError(err, "language client startup");
   const isMissing = err instanceof BundledBinaryMissingError;
   const isUnsupported = err instanceof UnsupportedPlatformError;
+  const isMismatch = err instanceof BinaryVerificationError;
+  const isConfiguredMissing = err instanceof BinaryMissingError;
   const message =
-    isMissing || isUnsupported
-      ? (err).message
+    isMissing || isUnsupported || isMismatch || isConfiguredMissing
+      ? err.message
       : "Deslop failed to start its analysis server. See the Deslop output channel.";
   store?.setLifecycle({ kind: "failed", message });
   vscode.window

--- a/clients/vscode/src/test/suite/bubble.e2e.test.ts
+++ b/clients/vscode/src/test/suite/bubble.e2e.test.ts
@@ -6,10 +6,26 @@ import * as assert from "node:assert/strict";
 import * as vscode from "vscode";
 import { sleep } from "./helpers";
 
+interface BinaryExport {
+  readonly source?: string;
+  readonly path?: string;
+}
+
+interface ExtensionExports {
+  readonly resolvedLsp?: BinaryExport;
+  readonly resolvedMcp?: BinaryExport;
+}
+
 suite("live bubble (real LSP)", () => {
-  test("extension spawns the real deslop-lsp binary", () => {
-    const ext = vscode.extensions.getExtension("nimblesite.deslop-vscode");
-    assert.ok(ext?.isActive, "extension must be active against the real LSP");
+  test("extension spawns bundled Deslop binaries", async () => {
+    const ext = vscode.extensions.getExtension<ExtensionExports>("nimblesite.deslop-vscode");
+    assert.ok(ext, "extension must be installed");
+    const api = await ext.activate();
+    assert.ok(ext.isActive, "extension must be active against the real LSP");
+    assert.equal(api.resolvedLsp?.source, "bundled");
+    assert.equal(api.resolvedMcp?.source, "bundled");
+    assert.match(api.resolvedLsp?.path ?? "", /[/\\]bin[/\\][^/\\]+[/\\]deslop-lsp(?:\.exe)?$/);
+    assert.match(api.resolvedMcp?.path ?? "", /[/\\]bin[/\\][^/\\]+[/\\]deslop-mcp(?:\.exe)?$/);
   });
 
   test("editing a duplicated range triggers re-analysis", async () => {

--- a/clients/vscode/src/test/unit/binary.unit.test.ts
+++ b/clients/vscode/src/test/unit/binary.unit.test.ts
@@ -1,14 +1,16 @@
-// Unit tests for the binary resolver. Covers every branch of the env→PATH→bundled
-// decision tree without needing VS Code.
+// Unit tests for manifest-backed binary resolution.
 
 import * as assert from "node:assert/strict";
 import {
   resolveBinary,
+  resolveHostBinaries,
   BundledBinaryMissingError,
   UnsupportedPlatformError,
+  BinaryVerificationError,
+  type DeploymentManifest,
 } from "../../binary";
 import { mkdirSync, writeFileSync, chmodSync, rmSync } from "node:fs";
-import { resolve } from "node:path";
+import { delimiter, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 function platformId(): string {
@@ -20,93 +22,129 @@ function platformId(): string {
   throw new Error(`unsupported ${process.platform}-${process.arch}`);
 }
 
-function writeVersionScript(path: string, version: string): void {
-  writeFileSync(path, `#!/bin/sh\necho 'deslop ${version}'\n`);
-  chmodSync(path, 0o755);
+function writeVersionScript(filePath: string, name: string, version: string): void {
+  writeFileSync(filePath, `#!/bin/sh\necho '${name} ${version}'\n`);
+  chmodSync(filePath, 0o755);
+}
+
+function manifest(): DeploymentManifest {
+  return {
+    manifestVersion: 1,
+    product: { id: "deslop", version: "0.1.0" },
+    components: [
+      component("deslop-lsp", "lsp", "DESLOP_LSP_PATH"),
+      component("deslop-mcp", "mcp", "DESLOP_MCP_PATH"),
+      component("deslop", "cli", undefined),
+    ],
+    hosts: { vscode: { activationVerifies: ["deslop-lsp", "deslop-mcp"] } },
+  };
+}
+
+function component(id: string, kind: string, pathVar: string | undefined) {
+  const env = pathVar
+    ? { pathVar, dirVar: "DESLOP_BINARY_DIR" }
+    : { dirVar: "DESLOP_BINARY_DIR" };
+  return {
+    id,
+    kind,
+    language: "rust",
+    binaryName: id,
+    expectedVersion: "0.1.0",
+    bundled: { bundlePath: "bin/${platform}/${binaryName}${exe}" },
+    env,
+    required: true,
+  };
 }
 
 suite("binary resolver", () => {
   const tmp = resolve(tmpdir(), `deslop-binary-${process.pid}-${Date.now()}`);
   const envDir = resolve(tmp, "env");
   const pathDir = resolve(tmp, "pathdir");
+  const userDir = resolve(tmp, "user");
   const extDir = resolve(tmp, "ext");
   const bundledDir = resolve(extDir, "bin", platformId());
 
   suiteSetup(() => {
     mkdirSync(envDir, { recursive: true });
     mkdirSync(pathDir, { recursive: true });
+    mkdirSync(userDir, { recursive: true });
     mkdirSync(bundledDir, { recursive: true });
-    writeVersionScript(resolve(envDir, "deslop-lsp"), "9.9.9");
-    writeVersionScript(resolve(pathDir, "deslop-lsp"), "0.1.0");
-    writeVersionScript(resolve(bundledDir, "deslop-lsp"), "0.1.0");
-    writeVersionScript(resolve(envDir, "deslop-mcp"), "9.9.9");
-    writeVersionScript(resolve(bundledDir, "deslop-mcp"), "0.1.0");
-    writeVersionScript(resolve(bundledDir, "deslop"), "0.1.0");
+    writeVersionScript(resolve(envDir, "deslop-lsp"), "deslop-lsp", "9.9.9");
+    writeVersionScript(resolve(envDir, "deslop-mcp"), "deslop-mcp", "0.1.0");
+    writeVersionScript(resolve(pathDir, "deslop-lsp"), "deslop-lsp", "9.9.9");
+    writeVersionScript(resolve(bundledDir, "deslop-lsp"), "deslop-lsp", "0.1.0");
+    writeVersionScript(resolve(bundledDir, "deslop-mcp"), "deslop-mcp", "0.1.0");
+    writeVersionScript(resolve(bundledDir, "deslop"), "deslop", "0.1.0");
+    writeVersionScript(resolve(userDir, "deslop-lsp"), "deslop-lsp", "9.9.9");
   });
 
   suiteTeardown(() => {
-    try {
-      rmSync(tmp, { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
+    rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("DESLOP_BINARY_DIR wins over PATH + bundled", () => {
-    const env = { ...process.env, DESLOP_BINARY_DIR: envDir };
-    const resolved = resolveBinary(extDir, "lsp", "0.1.0", env);
-    assert.equal(resolved.source, "env");
-    assert.equal(resolved.kind, "lsp");
-    assert.ok(resolved.path.startsWith(envDir));
+  test("user setting mismatch blocks activation", () => {
+    assert.throws(
+      () =>
+        resolveBinary(extDir, "lsp", manifest(), {
+          lspPath: resolve(userDir, "deslop-lsp"),
+        }),
+      BinaryVerificationError,
+    );
   });
 
-  test("PATH wins when version matches", () => {
-    const env: NodeJS.ProcessEnv = { ...process.env, PATH: pathDir };
-    delete env["DESLOP_BINARY_DIR"];
-    const resolved = resolveBinary(extDir, "lsp", "0.1.0", env);
-    assert.equal(resolved.source, "path");
+  test("env path mismatch blocks activation", () => {
+    const env: NodeJS.ProcessEnv = { DESLOP_LSP_PATH: resolve(envDir, "deslop-lsp") };
+    assert.throws(() => resolveBinary(extDir, "lsp", manifest(), {}, env), /9\.9\.9/);
+  });
+
+  test("env directory mismatch blocks activation", () => {
+    const env: NodeJS.ProcessEnv = { DESLOP_BINARY_DIR: envDir };
+    assert.throws(() => resolveBinary(extDir, "lsp", manifest(), {}, env), /env-dir/);
+  });
+
+  test("PATH mismatch falls back to matching bundled binary", () => {
+    const env: NodeJS.ProcessEnv = { PATH: pathDir };
+    const resolved = resolveBinary(extDir, "lsp", manifest(), {}, env);
+    assert.equal(resolved.source, "bundled");
     assert.equal(resolved.version, "0.1.0");
+    assert.ok(env["PATH"]?.split(delimiter).includes(bundledDir) ?? false);
   });
 
-  test("PATH falls back to bundled when version mismatches", () => {
-    const env = { ...process.env, PATH: pathDir } as NodeJS.ProcessEnv;
-    delete env["DESLOP_BINARY_DIR"];
-    const resolved = resolveBinary(extDir, "lsp", "9.9.9", env);
-    assert.equal(resolved.source, "bundled");
-    assert.ok(env["PATH"]?.split(":").includes(bundledDir) ?? env["PATH"]?.split(";").includes(bundledDir));
+  test("bundled success resolves all VS Code activation checks", () => {
+    const resolved = resolveHostBinaries(extDir, "vscode", manifest(), {}, { PATH: "" });
+    assert.equal(resolved["deslop-lsp"]?.source, "bundled");
+    assert.equal(resolved["deslop-mcp"]?.source, "bundled");
   });
 
-  test("bundled used when neither env nor PATH has the binary", () => {
-    const env = { ...process.env, PATH: "/nonexistent" } as NodeJS.ProcessEnv;
-    delete env["DESLOP_BINARY_DIR"];
-    const resolved = resolveBinary(extDir, "lsp", "0.1.0", env);
-    assert.equal(resolved.source, "bundled");
-  });
-
-  test("bundled-missing throws BundledBinaryMissingError", () => {
-    const env = { ...process.env, PATH: "" } as NodeJS.ProcessEnv;
-    delete env["DESLOP_BINARY_DIR"];
+  test("missing bundled binary blocks activation", () => {
     const emptyExt = resolve(tmp, "empty-ext");
     mkdirSync(resolve(emptyExt, "bin", platformId()), { recursive: true });
     assert.throws(
-      () => resolveBinary(emptyExt, "lsp", "0.1.0", env),
+      () => resolveBinary(emptyExt, "lsp", manifest(), {}, { PATH: "" }),
       BundledBinaryMissingError,
     );
   });
 
-  test("mcp resolves alongside lsp", () => {
-    const env = { ...process.env, DESLOP_BINARY_DIR: envDir };
-    const resolved = resolveBinary(extDir, "mcp", "0.1.0", env);
-    assert.equal(resolved.kind, "mcp");
-    assert.equal(resolved.source, "env");
+  test("binary name mismatch blocks activation", () => {
+    const mismatchExt = resolve(tmp, "mismatch-ext");
+    const mismatchBin = resolve(mismatchExt, "bin", platformId());
+    mkdirSync(mismatchBin, { recursive: true });
+    writeVersionScript(resolve(mismatchBin, "deslop-lsp"), "deslop", "0.1.0");
+    assert.throws(
+      () => resolveBinary(mismatchExt, "lsp", manifest(), {}, { PATH: "" }),
+      /Found deslop 0\.1\.0/,
+    );
   });
 
-  test("cli kind resolves to bundled deslop", () => {
-    const env = { ...process.env, PATH: "" } as NodeJS.ProcessEnv;
-    delete env["DESLOP_BINARY_DIR"];
-    const resolved = resolveBinary(extDir, "cli", "0.1.0", env);
-    assert.equal(resolved.kind, "cli");
-    assert.equal(resolved.source, "bundled");
+  test("bundled version mismatch blocks activation", () => {
+    const staleExt = resolve(tmp, "stale-ext");
+    const staleBin = resolve(staleExt, "bin", platformId());
+    mkdirSync(staleBin, { recursive: true });
+    writeVersionScript(resolve(staleBin, "deslop-lsp"), "deslop-lsp", "9.9.9");
+    assert.throws(
+      () => resolveBinary(staleExt, "lsp", manifest(), {}, { PATH: "" }),
+      /Expected 0\.1\.0/,
+    );
   });
 
   test("UnsupportedPlatformError has expected shape", () => {
@@ -117,22 +155,5 @@ suite("binary resolver", () => {
   test("BundledBinaryMissingError exposes path", () => {
     const err = new BundledBinaryMissingError("/nope");
     assert.equal(err.binaryPath, "/nope");
-  });
-
-  test("env dir without binary falls through to PATH", () => {
-    const emptyEnv = resolve(tmp, "empty-env");
-    mkdirSync(emptyEnv, { recursive: true });
-    const env = { ...process.env, DESLOP_BINARY_DIR: emptyEnv, PATH: pathDir };
-    const resolved = resolveBinary(extDir, "lsp", "0.1.0", env);
-    assert.equal(resolved.source, "path");
-  });
-
-  test("prependToPath is idempotent", () => {
-    const env = { ...process.env, PATH: "" } as NodeJS.ProcessEnv;
-    delete env["DESLOP_BINARY_DIR"];
-    resolveBinary(extDir, "lsp", "0.1.0", env);
-    const first = env["PATH"];
-    resolveBinary(extDir, "lsp", "0.1.0", env);
-    assert.equal(env["PATH"], first);
   });
 });

--- a/clients/vscode/src/test/unit/compare-target.unit.test.ts
+++ b/clients/vscode/src/test/unit/compare-target.unit.test.ts
@@ -1,0 +1,115 @@
+// Unit: compare command target resolution. The context menu passes tree
+// nodes, while links and webviews pass cluster ids.
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as vscode from "vscode";
+
+import { compareWithCanonicalTarget } from "../../commands/register";
+import { ReportStore } from "../../reportStore";
+import { OccurrenceNode } from "../../tree/providers";
+import { Report, ReportCluster } from "../../types/report";
+
+async function findDiffTab(): Promise<vscode.TabInputTextDiff> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    for (const group of vscode.window.tabGroups.all) {
+      for (const tab of group.tabs) {
+        if (tab.input instanceof vscode.TabInputTextDiff) return tab.input;
+      }
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
+  }
+  throw new Error("no diff tab opened after compare target resolution");
+}
+
+function report(clusters: ReportCluster[]): Report {
+  return {
+    report_schema_version: 1,
+    tool_version: "v",
+    min_nodes: 30,
+    files_analysed: 1,
+    clusters_hidden: 0,
+    cache_stats: { hits: 0, misses: 0 },
+    metrics: {
+      analysed_loc: 10,
+      duplicated_loc: 5,
+      duplication_percent: 50,
+      clusters_total: clusters.length,
+      duplicated_files: 1,
+      threshold: { percent: 0, breached: false, source: "none" },
+    },
+    schema_doc: "",
+    action_hints: [],
+    embedding_provenance: null,
+    clusters,
+  };
+}
+
+function cluster(
+  id: string,
+  occurrences: { path: string; start_byte: number; end_byte: number }[],
+): ReportCluster {
+  return {
+    id,
+    weight: 10,
+    size: occurrences.length,
+    canonical_node_count: 4,
+    signals: { structural: 1, token_jaccard: 1, embedding_cos: 0, fused: 1 },
+    occurrences: occurrences.map((occurrence) => ({ ...occurrence, hidden: false })),
+    summary: "",
+    interpretation: "",
+  };
+}
+
+suite("compare command targets", () => {
+  test("occurrence tree rows compare their parent cluster", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cdd-cmp-target-"));
+    const canonical = path.join(dir, "Canonical.cs");
+    const ignored = path.join(dir, "Ignored.cs");
+    const sibling = path.join(dir, "Sibling.cs");
+    const canonicalText = "public class Canonical { }\n";
+    const ignoredText = "public class Ignored { }\n";
+    const siblingText = "public class SelectedSibling { }\n";
+    fs.writeFileSync(canonical, canonicalText, "utf8");
+    fs.writeFileSync(ignored, ignoredText, "utf8");
+    fs.writeFileSync(sibling, siblingText, "utf8");
+
+    try {
+      const c = cluster("c-target", [
+        { path: canonical, start_byte: 0, end_byte: canonicalText.length },
+        { path: ignored, start_byte: 0, end_byte: ignoredText.length },
+        { path: sibling, start_byte: 0, end_byte: siblingText.length },
+      ]);
+      const occurrence = c.occurrences[2];
+      assert.ok(occurrence);
+      const store = new ReportStore();
+      store.setSnapshot(report([c]), 0);
+
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+      await compareWithCanonicalTarget(store, new OccurrenceNode(occurrence));
+      const diff = await findDiffTab();
+
+      assert.equal(diff.original.scheme, "deslop-compare");
+      assert.equal(diff.modified.scheme, "deslop-compare");
+      assert.notEqual(diff.original.toString(), diff.modified.toString());
+
+      const original = await vscode.workspace.openTextDocument(diff.original);
+      const modified = await vscode.workspace.openTextDocument(diff.modified);
+      assert.equal(original.getText(), canonicalText);
+      assert.equal(modified.getText(), siblingText);
+      assert.notEqual(modified.getText(), ignoredText);
+    } finally {
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unresolved compare targets are no-ops", async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    await compareWithCanonicalTarget(new ReportStore(), { command: "no cluster" });
+  });
+});

--- a/clients/vscode/src/test/unit/extension-internals.unit.test.ts
+++ b/clients/vscode/src/test/unit/extension-internals.unit.test.ts
@@ -60,12 +60,14 @@ suite("extension internals", () => {
     revealActiveBinary(
       {
         kind: "lsp",
+        componentId: "deslop-lsp",
         source: "bundled",
         path: "/tmp/lsp",
         version: "1.0.0",
       },
       {
         kind: "mcp",
+        componentId: "deslop-mcp",
         source: "bundled",
         path: "/tmp/mcp",
         version: "1.0.0",
@@ -77,9 +79,10 @@ suite("extension internals", () => {
     revealActiveBinary(
       {
         kind: "lsp",
-        source: "env",
+        componentId: "deslop-lsp",
+        source: "env-dir",
         path: "/tmp/lsp",
-        version: null,
+        version: "1.0.0",
       },
       undefined,
     );
@@ -94,7 +97,7 @@ suite("extension internals", () => {
     delete process.env["DESLOP_BINARY_DIR"];
     process.env["PATH"] = "/nope";
     try {
-      const result = tryResolveOptional("/nonexistent/extension", "mcp", "0.1.0");
+      const result = tryResolveOptional("/nonexistent/extension", "mcp", optionalManifest());
       assert.equal(result, undefined);
     } finally {
       process.env = saved;
@@ -411,3 +414,22 @@ suite("extension internals", () => {
     assert.equal(resolveWorkspaceRoot(), first.uri.fsPath);
   });
 });
+
+function optionalManifest() {
+  return {
+    manifestVersion: 1,
+    product: { id: "deslop", version: "0.1.0" },
+    components: [
+      {
+        id: "deslop-mcp",
+        kind: "mcp",
+        language: "rust",
+        binaryName: "deslop-mcp",
+        expectedVersion: "0.1.0",
+        bundled: { bundlePath: "bin/${platform}/${binaryName}${exe}" },
+        required: true,
+      },
+    ],
+    hosts: {},
+  };
+}

--- a/clients/vscode/src/test/unit/package-menus.unit.test.ts
+++ b/clients/vscode/src/test/unit/package-menus.unit.test.ts
@@ -1,0 +1,57 @@
+// Unit: package contribution checks for VS Code menus. Reads package.json
+// through JSON.parse so structured contributions stay validated as data.
+
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface PackageContribution {
+  contributes: {
+    commands: CommandContribution[];
+    menus: Record<string, MenuContribution[]>;
+  };
+}
+
+interface CommandContribution {
+  command: string;
+  title: string;
+}
+
+interface MenuContribution {
+  command: string;
+  when?: string;
+  group?: string;
+}
+
+function extensionPackage(): PackageContribution {
+  const packagePath = path.resolve(__dirname, "../../..", "package.json");
+  const text = fs.readFileSync(packagePath, "utf8");
+  return JSON.parse(text) as PackageContribution;
+}
+
+function commandTitle(pkg: PackageContribution, command: string): string | undefined {
+  return pkg.contributes.commands.find((item) => item.command === command)?.title;
+}
+
+suite("package menu contributions", () => {
+  test("occurrence context menu compares with canonical instead of opening", () => {
+    const pkg = extensionPackage();
+    const contextItems = pkg.contributes.menus["view/item/context"];
+    assert.ok(contextItems, "view/item/context menu must be contributed");
+    const occurrenceItems = contextItems.filter(
+      (item) => item.when === "viewItem == deslop.occurrence",
+    );
+
+    assert.deepEqual(
+      occurrenceItems
+        .filter((item) => item.group === "navigation@1")
+        .map((item) => item.command),
+      ["deslop.compareOccurrenceWithCanonical"],
+    );
+    assert.equal(
+      commandTitle(pkg, "deslop.compareOccurrenceWithCanonical"),
+      "Compare With Canonical",
+    );
+    assert.ok(!occurrenceItems.some((item) => item.command === "deslop.openOccurrence"));
+  });
+});

--- a/clients/vscode/src/test/unit/package-menus.unit.test.ts
+++ b/clients/vscode/src/test/unit/package-menus.unit.test.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 interface PackageContribution {
+  activationEvents: string[];
   contributes: {
     commands: CommandContribution[];
     menus: Record<string, MenuContribution[]>;
@@ -34,6 +35,14 @@ function commandTitle(pkg: PackageContribution, command: string): string | undef
 }
 
 suite("package menu contributions", () => {
+  test("activationEvents includes onStartupFinished so analysis begins at VS Code startup", () => {
+    const pkg = extensionPackage();
+    assert.ok(
+      pkg.activationEvents.includes("onStartupFinished"),
+      `activationEvents must include "onStartupFinished" — analysis must not wait for panel open. Got: ${JSON.stringify(pkg.activationEvents)}`,
+    );
+  });
+
   test("occurrence context menu compares with canonical instead of opening", () => {
     const pkg = extensionPackage();
     const contextItems = pkg.contributes.menus["view/item/context"];

--- a/clients/vscode/src/test/unit/panels-open.unit.test.ts
+++ b/clients/vscode/src/test/unit/panels-open.unit.test.ts
@@ -1,0 +1,44 @@
+// Unit: openReportPanel / openClusterPanel panel lifecycle — covers the
+// create-first + reveal-on-second-call paths that E2E tests cannot reach
+// because they exercise the dist/ bundle, not the instrumented out/ module.
+
+import * as assert from "node:assert/strict";
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { handleMessage, openReportPanel } from "../../webview/panels";
+import { ReportStore } from "../../reportStore";
+
+function fakeCtx(): vscode.ExtensionContext {
+  return {
+    extensionPath: path.join(__dirname, "..", "..", ".."),
+    extensionUri: vscode.Uri.file(path.join(__dirname, "..", "..", "..")),
+    subscriptions: [] as vscode.Disposable[],
+  } as unknown as vscode.ExtensionContext;
+}
+
+suite("panels lifecycle", () => {
+  test("openReportPanel opens a new panel and reveals it on a second call", () => {
+    const store = new ReportStore();
+    const ctx = fakeCtx();
+
+    const tabsBefore = vscode.window.tabGroups.all.flatMap((g) => g.tabs).length;
+    openReportPanel(ctx, store);
+    const tabsAfterFirst = vscode.window.tabGroups.all.flatMap((g) => g.tabs).length;
+    assert.ok(tabsAfterFirst >= tabsBefore, "first openReportPanel must not reduce the open tab count");
+
+    openReportPanel(ctx, store); // hits the existing-panel reveal branch
+    const tabsAfterSecond = vscode.window.tabGroups.all.flatMap((g) => g.tabs).length;
+    assert.equal(
+      tabsAfterSecond,
+      tabsAfterFirst,
+      "second openReportPanel call must reveal the existing panel, not open a new tab",
+    );
+  });
+
+  test("handleMessage with kind undefined is a no-op", async () => {
+    const store = new ReportStore();
+    // Explicit undefined kind hits the `case undefined: return` branch.
+    await handleMessage(store, { kind: undefined });
+    assert.ok(store.current.report === null, "a no-op message must not mutate the store");
+  });
+});

--- a/clients/vscode/src/test/unit/tree.topOffenders.unit.test.ts
+++ b/clients/vscode/src/test/unit/tree.topOffenders.unit.test.ts
@@ -26,6 +26,7 @@ import {
   tooltipText,
   withGroupBy,
 } from "./tree.helpers";
+import { CATEGORY_STYLE } from "../../tree/nodes";
 
 suite("TopOffendersProvider", () => {
   test("renders an Analysing… placeholder before the first report arrives", () => {
@@ -363,6 +364,34 @@ suite("TopOffendersProvider", () => {
     assert.match(near.accessibilityInformation?.label ?? "", /Near\.cs/);
     assert.match(tooltipText(exact), /\/repo\/src\/a\/Exact\.cs/);
     assert.match(tooltipText(near), /\/repo\/src\/b\/Near\.cs/);
+  });
+
+  test("identical cluster icon is red not green — green implies safe, but identical code is worst severity", () => {
+    // [VSIX-TOP-OFFENDERS-CATEGORY-COLORS] Identical = error level, must not use green.
+    const store = new ReportStore();
+    store.setSnapshot(
+      report([cluster("clone", 100, "/repo/src/Clone.cs", 0, 20, "identical")]),
+      0,
+    );
+    const provider = new TopOffendersProvider(store, new StatusTicker());
+    const [node] = provider.getChildren();
+    assert.ok(node, "identical cluster must render a node");
+    assert.equal(
+      iconColorId(node),
+      "charts.red",
+      "identical clones are the highest severity — icon must be red, not green",
+    );
+  });
+
+  test("no category style uses charts.green — green is never correct for code duplication", () => {
+    // [VSIX-TOP-OFFENDERS-CATEGORY-COLORS] Green implies safety/good; duplicates are never good.
+    for (const [bucket, style] of Object.entries(CATEGORY_STYLE)) {
+      assert.notEqual(
+        style.color,
+        "charts.green",
+        `${bucket} must not use charts.green — green implies the code is in good shape`,
+      );
+    }
   });
 
   test("expanding a cluster node yields OccurrenceNode children", () => {

--- a/clients/vscode/src/tree/nodes.ts
+++ b/clients/vscode/src/tree/nodes.ts
@@ -29,7 +29,7 @@ export type Node =
 // [VSIX-TOP-OFFENDERS-CATEGORY-COLORS] Category colour is metadata
 // backed by text/a11y labels, never the only signal.
 export const CATEGORY_STYLE: Record<Bucket, { icon: string; color: string }> = {
-  identical: { icon: "circle-filled", color: "charts.green" },
+  identical: { icon: "circle-filled", color: "charts.red" },
   nearly_identical: { icon: "circle-large-filled", color: "charts.orange" },
   loosely_similar: { icon: "circle-outline", color: "charts.blue" },
   same_behavior: { icon: "sparkle", color: "charts.purple" },

--- a/crates/deslop-core/src/lib.rs
+++ b/crates/deslop-core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod report_metrics;
 pub mod sibling;
 pub mod state;
 pub mod tokens;
+pub mod version_contract;
 
 pub use buckets::{bucket_labels, classify, classify_signals, BucketLabels, ClusterKind};
 pub use config::{BoilerplateImportsMode, ExclusionConfig, DEFAULT_CONFIG_FILENAME};
@@ -57,6 +58,9 @@ pub use report_boilerplate::{ReportBoilerplateHint, ReportBoilerplateOccurrence}
 pub use report_metrics::{
     compute_repo_metrics, count_analysed_lines, validate_threshold_percent, AnalysedLines,
     MetricsInputs, RepoMetrics, ThresholdSource, ThresholdSummary,
+};
+pub use version_contract::{
+    json_version_line, plain_version_line, version_contract_output, ComponentKind,
 };
 
 /// Semantic version of the `deslop-core` library.

--- a/crates/deslop-core/src/lsh.rs
+++ b/crates/deslop-core/src/lsh.rs
@@ -39,13 +39,22 @@ pub type Signature = [u64; SIGNATURE_LEN];
 /// Computes a [`Signature`] for a set of k-grams of normalised node kinds.
 /// Deterministic: given the same input it always returns the same output,
 /// across processes and architectures.
+///
+/// Uses blake3 XOF to derive all 128 slot values from a single hash call
+/// per k-gram — 128× fewer hasher allocations than the naïve seeded approach.
 #[must_use]
 pub fn minhash_signature(kgrams: &[&[&'static str]]) -> Signature {
     let mut signature: Signature = [EMPTY_HASH_SENTINEL; SIGNATURE_LEN];
+    let mut expanded = [0u8; SIGNATURE_LEN * 8];
     for gram in kgrams {
-        let kgram_bytes = kgram_bytes(gram);
-        for (index, slot) in signature.iter_mut().enumerate() {
-            let candidate = seeded_hash(&kgram_bytes, index);
+        let gram_bytes = kgram_bytes(gram);
+        let mut hasher = Hasher::new();
+        let _ = hasher.update(&gram_bytes);
+        hasher.finalize_xof().fill(&mut expanded);
+        for (slot, chunk) in signature.iter_mut().zip(expanded.chunks_exact(8)) {
+            let mut arr = [0u8; 8];
+            arr.copy_from_slice(chunk);
+            let candidate = u64::from_le_bytes(arr);
             if candidate < *slot {
                 *slot = candidate;
             }
@@ -139,19 +148,4 @@ fn kgram_bytes(gram: &[&'static str]) -> Vec<u8> {
         buffer.push(0);
     }
     buffer
-}
-
-/// Returns a deterministic 64-bit hash of `payload` seeded with `index`.
-/// Uses `blake3` throughout for one dependency surface.
-fn seeded_hash(payload: &[u8], index: usize) -> u64 {
-    let mut hasher = Hasher::new();
-    let seed = u64::try_from(index).unwrap_or(u64::MAX);
-    let _ = hasher.update(&seed.to_le_bytes());
-    let _ = hasher.update(payload);
-    let digest = hasher.finalize();
-    let bytes = digest.as_bytes();
-    let mut narrow = [0_u8; 8];
-    let slice = bytes.get(..8).unwrap_or(&[0_u8; 8]);
-    narrow.copy_from_slice(slice);
-    u64::from_le_bytes(narrow)
 }

--- a/crates/deslop-core/src/pipeline/session.rs
+++ b/crates/deslop-core/src/pipeline/session.rs
@@ -413,13 +413,23 @@ impl PipelineSession {
         last_pass_stats: CacheStats,
     ) -> Result<Report, CoreError> {
         let corpus = self.snapshot_corpus();
+        tracing::debug!(
+            fingerprints = corpus.fingerprints.len(),
+            "building signatures"
+        );
         let signatures = build_signatures_with_languages(
             &corpus.fingerprints,
             &corpus.trees,
             &self.file_languages,
         );
+        tracing::debug!(signatures = signatures.len(), "running LSH band collisions");
         let lsh_pairs = band_collisions(&signatures);
+        tracing::debug!(lsh_pairs = lsh_pairs.len(), "running embedding pass");
         let embedding_outcome = run_embedding_pass(config, &corpus)?;
+        tracing::debug!(
+            embedding_pairs = embedding_outcome.pairs.len(),
+            "collecting candidate pairs"
+        );
         let pairs = candidate_pairs_for_language_policy(
             &corpus.fingerprints,
             &signatures,
@@ -428,8 +438,18 @@ impl PipelineSession {
             &self.file_languages,
             self.exclusion.allows_cross_language_comparison(),
         );
+        tracing::debug!(
+            candidate_pairs = pairs.len(),
+            "clustering by transitive closure"
+        );
         let fused_clusters = cluster_by_transitive_closure(&pairs);
+        tracing::debug!(clusters = fused_clusters.len(), "building ranked clusters");
         let clusters = build_ranked_fused_clusters(&corpus.fingerprints, &fused_clusters);
+        tracing::info!(
+            ranked_clusters = clusters.len(),
+            fingerprints = corpus.fingerprints.len(),
+            "render complete"
+        );
         Ok(render_report(ReportInputs {
             clusters: &clusters,
             registry: &self.registry,

--- a/crates/deslop-core/src/pipeline/signatures.rs
+++ b/crates/deslop-core/src/pipeline/signatures.rs
@@ -17,6 +17,12 @@ use crate::{
     },
 };
 
+/// Builds a `FileId → &NormalizedNode` index to avoid O(files) linear scans
+/// for every fingerprint in [`build_signatures_with_languages`].
+fn build_tree_index(trees: &[NormalizedNode]) -> HashMap<FileId, &NormalizedNode> {
+    trees.iter().map(|tree| (tree.file_id, tree)).collect()
+}
+
 /// Language-aware signature builder. When the fingerprint's file has
 /// a known language in `file_languages`, import/prologue boilerplate
 /// is stripped from the token stream so shared import patterns stop
@@ -29,10 +35,11 @@ pub fn build_signatures_with_languages<S: BuildHasher>(
     trees: &[NormalizedNode],
     file_languages: &HashMap<FileId, &'static str, S>,
 ) -> Vec<Signature> {
+    let tree_index = build_tree_index(trees);
     let mut signatures: Vec<Signature> = Vec::with_capacity(fingerprints.len());
     for fingerprint in fingerprints {
         let language = file_languages.get(&fingerprint.file_id).copied();
-        let Some(root) = tree_for_file(trees, fingerprint) else {
+        let Some(root) = tree_index.get(&fingerprint.file_id).copied() else {
             signatures.push(empty_signature(fingerprint, language));
             continue;
         };
@@ -52,18 +59,6 @@ pub fn build_signatures_with_languages<S: BuildHasher>(
         signatures.push(signature);
     }
     signatures
-}
-
-/// Returns the normalised AST root for `fingerprint`'s file by scanning
-/// the per-run tree list. O(n) per lookup; acceptable because the number
-/// of files is small compared to the number of fingerprints.
-fn tree_for_file<'a>(
-    trees: &'a [NormalizedNode],
-    fingerprint: &Fingerprint,
-) -> Option<&'a NormalizedNode> {
-    trees
-        .iter()
-        .find(|tree| tree.file_id == fingerprint.file_id)
 }
 
 /// Returns true when an exact fingerprint range contains prologue syntax.
@@ -126,26 +121,21 @@ fn empty_signature(fingerprint: &Fingerprint, language: Option<&str>) -> Signatu
 
 /// Fingerprint-scoped signature used when no k-grams are available. This
 /// avoids treating unrelated empty token sets as perfect LSH matches.
+/// Uses blake3 XOF to derive all 128 slot values from a single hash call.
 fn fallback_signature(fingerprint: &Fingerprint) -> Signature {
-    let mut signature = [0_u64; SIGNATURE_LEN];
-    for (index, slot) in signature.iter_mut().enumerate() {
-        *slot = fallback_slot(fingerprint, index);
-    }
-    signature
-}
-
-/// Derives one deterministic fallback slot from stable fingerprint data.
-fn fallback_slot(fingerprint: &Fingerprint, index: usize) -> u64 {
     let mut hasher = Hasher::new();
     let _ = hasher.update(&fingerprint.hash);
     let _ = hasher.update(&fingerprint.byte_range.start.to_le_bytes());
     let _ = hasher.update(&fingerprint.byte_range.end.to_le_bytes());
-    let _ = hasher.update(&index.to_le_bytes());
-    let digest = hasher.finalize();
-    let mut narrow = [0_u8; 8];
-    let slice = digest.as_bytes().get(..8).unwrap_or(&[0_u8; 8]);
-    narrow.copy_from_slice(slice);
-    u64::from_le_bytes(narrow)
+    let mut expanded = [0u8; SIGNATURE_LEN * 8];
+    hasher.finalize_xof().fill(&mut expanded);
+    let mut signature = [0_u64; SIGNATURE_LEN];
+    for (slot, chunk) in signature.iter_mut().zip(expanded.chunks_exact(8)) {
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(chunk);
+        *slot = u64::from_le_bytes(arr);
+    }
+    signature
 }
 
 /// Default signature used for legacy non-Python empty token streams.

--- a/crates/deslop-core/src/report.rs
+++ b/crates/deslop-core/src/report.rs
@@ -21,6 +21,7 @@ use crate::{
     buckets::{bucket_labels, classify_signals, ClusterKind},
     cluster::Cluster,
     config::ExclusionConfig,
+    fingerprint::Fingerprint,
     pair::PairScore,
     report_boilerplate::{build_boilerplate_hints, ReportBoilerplateHint},
     report_location::format_occurrence,
@@ -407,7 +408,7 @@ fn cluster_to_report<S: BuildHasher>(
         sources,
         signals,
     );
-    let interpretation = interpret(signals, canonical_node_count);
+    let interpretation = interpret(signals, &cluster.members, sources);
     let bucket = classify_signals(signals).wire_label().to_owned();
     let occurrences_total = occurrences.len();
     ReportCluster {
@@ -487,14 +488,50 @@ fn summarise(
     )
 }
 
-/// Maps the signal triple onto a one-line interpretation for AI
-/// agents. JSON `cluster.interpretation` is an AI-only surface per
-/// [CLONE-BUCKETS-DUAL-LABEL], so the output composes plain title +
-/// action sentence + `Type-N`. The `canonical_node_count` is unused
-/// today — kept in the signature so callers don't churn; routing
-/// lives in `buckets::classify_signals`.
-fn interpret(signals: ReportSignals, _canonical_node_count: usize) -> String {
-    bucket_labels(classify_signals(signals)).agent_summary()
+/// Maps the signal triple onto a one-line interpretation for AI agents.
+/// JSON `cluster.interpretation` is an AI-only surface per
+/// [CLONE-BUCKETS-DUAL-LABEL]. The Type-1/Type-2 distinction additionally
+/// checks raw source slices so Type-2 clusters never receive Type-1 extract
+/// guidance ([AUTOFIX-EXTRACT-DEPENDENCIES]).
+fn interpret(
+    signals: ReportSignals,
+    members: &[Fingerprint],
+    sources: &HashMap<FileId, Vec<u8>>,
+) -> String {
+    let kind = classify_signals(signals);
+    if kind == ClusterKind::Identical && !source_slices_are_identical(members, sources) {
+        return "Identical code. Same structure after identifier/literal normalization; \
+                extract only after choosing parameters. (Type-2 renamed clone)"
+            .to_owned();
+    }
+    bucket_labels(kind).agent_summary()
+}
+
+/// Returns true when every cluster member maps to the same raw source bytes.
+fn source_slices_are_identical(
+    members: &[Fingerprint],
+    sources: &HashMap<FileId, Vec<u8>>,
+) -> bool {
+    let Some(first) = members
+        .first()
+        .and_then(|member| source_slice(member, sources))
+    else {
+        return false;
+    };
+    members
+        .iter()
+        .skip(1)
+        .all(|member| source_slice(member, sources).is_some_and(|slice| slice == first))
+}
+
+/// Borrows the source bytes covered by one fingerprint range.
+fn source_slice<'a>(
+    member: &Fingerprint,
+    sources: &'a HashMap<FileId, Vec<u8>>,
+) -> Option<&'a [u8]> {
+    sources
+        .get(&member.file_id)?
+        .get(member.byte_range.start..member.byte_range.end)
 }
 
 /// Formats one occurrence through the shared human-location renderer.

--- a/crates/deslop-core/src/report.rs
+++ b/crates/deslop-core/src/report.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     ast::ByteRange,
     boilerplate::BoilerplateRange,
-    buckets::{bucket_labels, classify_signals},
+    buckets::{bucket_labels, classify_signals, ClusterKind},
     cluster::Cluster,
     config::ExclusionConfig,
     pair::PairScore,
@@ -320,8 +320,18 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
                 inputs.exclusion,
                 inputs.sources,
             );
-            let all_hidden = !report_cluster.occurrences.is_empty()
-                && report_cluster.occurrences.iter().all(|occ| occ.hidden);
+            // [#58 FUSION-STRATEGY-GATE-NO-TOKEN-ONLY]: LooselySimilar clusters
+            // carry only token-overlap signal with no structural or semantic
+            // anchor. Token-only matches (test boilerplate, import scaffolding)
+            // push token_jaccard near 1.0 while structural stays near 0,
+            // causing these to rank as #1 offenders despite containing no
+            // actionable duplication. Exclude them from the human-facing ranked
+            // output; the raw analysis data remains available via the pipeline.
+            let loosely_similar =
+                classify_signals(report_cluster.signals) == ClusterKind::LooselySimilar;
+            let all_hidden = loosely_similar
+                || (!report_cluster.occurrences.is_empty()
+                    && report_cluster.occurrences.iter().all(|occ| occ.hidden));
             (report_cluster, all_hidden)
         })
         .collect();

--- a/crates/deslop-core/src/version_contract.rs
+++ b/crates/deslop-core/src/version_contract.rs
@@ -1,0 +1,123 @@
+//! Deployment Toolkit binary version output helpers.
+
+use serde::Serialize;
+
+/// Deployment Toolkit version-output schema version.
+const MANIFEST_VERSION: u32 = 1;
+/// Product id shared by every Deslop executable component.
+const PRODUCT_ID: &str = "deslop";
+/// Language label required by the version-output schema.
+const RUST_LANGUAGE: &str = "rust";
+
+/// Executable component kind used in Deployment Toolkit version JSON.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ComponentKind {
+    /// Cold-cache command-line interface.
+    Cli,
+    /// Language Server Protocol server.
+    Lsp,
+    /// Model Context Protocol server.
+    Mcp,
+}
+
+impl ComponentKind {
+    /// Returns the schema string for this component kind.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Lsp => "lsp",
+            Self::Mcp => "mcp",
+        }
+    }
+}
+
+/// JSON payload emitted by `--version --json`.
+#[derive(Serialize)]
+struct VersionManifest<'a> {
+    /// Version-output schema revision.
+    #[serde(rename = "manifestVersion")]
+    manifest_version: u32,
+    /// Deployment component id.
+    name: &'a str,
+    /// Semantic component version.
+    version: &'a str,
+    /// Deployment component kind.
+    kind: &'a str,
+    /// Implementation language.
+    language: &'a str,
+    /// Product id that owns the component.
+    product: &'a str,
+}
+
+/// Builds the exact plain-text version contract line.
+#[must_use]
+pub fn plain_version_line(component_id: &str) -> String {
+    format!("{component_id} {}\n", crate::version())
+}
+
+/// Builds JSON output matching Deployment Toolkit's version schema.
+///
+/// See <https://github.com/MelbourneDeveloper/deployment_toolkit/blob/main/schemas/version-manifest.schema.json>.
+///
+/// # Errors
+///
+/// Returns a serialization error if the schema payload cannot be encoded.
+pub fn json_version_line(
+    component_id: &str,
+    kind: ComponentKind,
+) -> Result<String, serde_json::Error> {
+    let mut output = serde_json::to_string(&version_manifest(component_id, kind))?;
+    output.push('\n');
+    Ok(output)
+}
+
+/// Returns version output when CLI args request the contract.
+///
+/// Supports the issue-required `--version --json` form and the private-doc
+/// `--version --format json` spelling.
+///
+/// # Errors
+///
+/// Returns a serialization error when JSON output is requested and fails.
+pub fn version_contract_output(
+    args: &[String],
+    component_id: &str,
+    kind: ComponentKind,
+) -> Result<Option<String>, serde_json::Error> {
+    if !requests_version(args) {
+        return Ok(None);
+    }
+    if requests_json(args) {
+        return json_version_line(component_id, kind).map(Some);
+    }
+    Ok(Some(plain_version_line(component_id)))
+}
+
+/// Returns whether args request any version output.
+fn requests_version(args: &[String]) -> bool {
+    args.iter()
+        .skip(1)
+        .any(|arg| matches!(arg.as_str(), "--version" | "-V"))
+}
+
+/// Returns whether args request JSON version output.
+fn requests_json(args: &[String]) -> bool {
+    args.iter().skip(1).any(|arg| arg == "--json")
+        || args.windows(2).any(|pair| {
+            pair.first().is_some_and(|flag| flag == "--format")
+                && pair.get(1).is_some_and(|value| value == "json")
+        })
+}
+
+/// Builds the structured JSON payload before serialization.
+fn version_manifest(component_id: &str, kind: ComponentKind) -> VersionManifest<'_> {
+    VersionManifest {
+        manifest_version: MANIFEST_VERSION,
+        name: component_id,
+        version: crate::version(),
+        kind: kind.as_str(),
+        language: RUST_LANGUAGE,
+        product: PRODUCT_ID,
+    }
+}

--- a/crates/deslop-lsp/src/backend.rs
+++ b/crates/deslop-lsp/src/backend.rs
@@ -16,7 +16,10 @@ use deslop_core::{
         EmbeddingMode, EmbeddingProvider, OllamaProvider, StubProvider, DEFAULT_OLLAMA_ENDPOINT,
         DEFAULT_OLLAMA_MODEL, DEFAULT_PROVIDER_ID, STUB_PROVIDER_ID,
     },
-    live::{AnalysisSession, EmbeddingProgress, EmbeddingProgressReporter, LiveApi, LiveService},
+    live::{
+        AnalysisSession, ChangeSummary, EmbeddingProgress, EmbeddingProgressReporter, LiveApi,
+        LiveError, LiveService, ReportChangedNotification,
+    },
 };
 use tokio::sync::Mutex;
 use tower::Service;
@@ -49,6 +52,10 @@ pub const DIAGNOSTIC_SOURCE: &str = "deslop";
 /// Method name for the `deslop/embeddingProgress` custom notification
 /// pushed around a model swap ([VSIX-SESSION-PROGRESS]).
 pub const EMBEDDING_PROGRESS: &str = "deslop/embeddingProgress";
+
+/// Method name for the `deslop/reportChanged` custom notification
+/// pushed after an analysis generation changes.
+pub const REPORT_CHANGED: &str = "deslop/reportChanged";
 
 /// [LSP-EMBEDDING-CONSENT] Embedding startup settings supplied by the client after the user
 /// has explicitly selected a model. `Off` means no startup embedding
@@ -173,12 +180,12 @@ impl LspBackend {
     ) -> Result<Self, deslop_core::live::LiveError> {
         let provider = build_startup_provider(embedding)?;
         let mut session = if matches!(embedding.mode, EmbeddingMode::Off) {
-            AnalysisSession::new(workspace_root, min_nodes, false, None, provider)?
+            AnalysisSession::new(workspace_root, min_nodes, true, None, provider)?
         } else {
             AnalysisSession::new_with_mode(
                 workspace_root,
                 min_nodes,
-                false,
+                true,
                 None,
                 provider,
                 embedding.mode,
@@ -208,9 +215,40 @@ impl LspBackend {
         if paths.is_empty() {
             return;
         }
+        match self.changed_paths_notification(paths).await {
+            Ok(Some(notification)) => {
+                self.client
+                    .send_notification::<ReportChangedLspNotification>(notification)
+                    .await;
+            }
+            Ok(None) => {}
+            Err(error) => tracing::error!(%error, "failed to apply changed paths"),
+        }
+    }
+
+    /// Applies paths and converts a non-empty delta into an LSP notification.
+    async fn changed_paths_notification(
+        &self,
+        paths: &[PathBuf],
+    ) -> Result<Option<ReportChangedNotification>, LiveError> {
         let session = self.service.session();
-        let mut guard = session.lock().await;
-        let _outcome = guard.apply_changes(paths);
+        let (previous_generation, previous_report, delta) = {
+            let mut guard = session.lock().await;
+            let previous_generation = guard.generation();
+            let previous_report = guard.report();
+            let delta = guard.apply_changes(paths)?;
+            (previous_generation, previous_report, delta)
+        };
+        self.service
+            .remember_snapshot(previous_generation, previous_report)
+            .await;
+        if delta.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(ReportChangedNotification {
+            generation: delta.to_generation,
+            summary: ChangeSummary::from_delta(&delta),
+        }))
     }
 }
 
@@ -437,6 +475,16 @@ impl tower_lsp::lsp_types::notification::Notification for EmbeddingProgressNotif
     const METHOD: &'static str = EMBEDDING_PROGRESS;
 }
 
+/// Type-only marker so `tower_lsp::Client::send_notification` can
+/// dispatch `deslop/reportChanged`.
+#[derive(Debug)]
+pub enum ReportChangedLspNotification {}
+
+impl tower_lsp::lsp_types::notification::Notification for ReportChangedLspNotification {
+    type Params = ReportChangedNotification;
+    const METHOD: &'static str = REPORT_CHANGED;
+}
+
 /// Boots the LSP server over stdio. Used by the binary entry point
 /// and by E2E tests that drive the binary as a black box.
 ///
@@ -468,6 +516,7 @@ pub async fn run_stdio(
         }
     })
     .custom_method(custom_methods::REPORT_GET, custom_methods::report_get)
+    .custom_method(custom_methods::REPORT_DELTA, custom_methods::report_delta)
     .custom_method(
         custom_methods::REPORT_FOR_FILE,
         custom_methods::report_for_file,
@@ -513,6 +562,7 @@ pub async fn run_stdio(
 /// `-32602 Missing params field` before the handler runs.
 const NO_PARAM_METHODS: &[&str] = &[
     custom_methods::REPORT_GET,
+    custom_methods::REPORT_DELTA,
     custom_methods::LIST_MODELS,
     custom_methods::SESSION_CONFIG,
     custom_methods::REPORT_SCHEMA_DOC,

--- a/crates/deslop-lsp/src/custom_methods.rs
+++ b/crates/deslop-lsp/src/custom_methods.rs
@@ -37,6 +37,8 @@ fn truncate_cluster_for_wire(cluster: &mut ReportCluster) {
 
 /// Method name for `deslop/reportGet`.
 pub const REPORT_GET: &str = "deslop/reportGet";
+/// Method name for `deslop/reportDelta`.
+pub const REPORT_DELTA: &str = "deslop/reportDelta";
 /// Method name for `deslop/reportForFile`.
 pub const REPORT_FOR_FILE: &str = "deslop/reportForFile";
 /// Method name for `deslop/reportForRange`.
@@ -63,6 +65,13 @@ pub const VIRTUAL_DOCUMENT: &str = "deslop/virtualDocument";
 pub struct PathParams {
     /// Workspace-relative or absolute path.
     pub path: PathBuf,
+}
+
+/// Parameters for `report/delta`.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ReportDeltaParams {
+    /// Generation the client already has. Missing means "previous generation."
+    pub since_generation: Option<u64>,
 }
 
 /// Parameters for `report/forRange`.
@@ -144,6 +153,31 @@ pub async fn report_schema_doc(
 ) -> LspResult<serde_json::Value> {
     let report = backend.service().report_get().await;
     Ok(serde_json::Value::String(report.schema_doc.clone()))
+}
+
+/// Forwards `report/delta`.
+///
+/// # Errors
+///
+/// Never errors today — kept fallible to match the JSON-RPC method
+/// signature.
+pub async fn report_delta(
+    backend: &LspBackend,
+    params: ReportDeltaParams,
+) -> LspResult<serde_json::Value> {
+    let since = match params.since_generation {
+        Some(generation) => generation,
+        None => previous_generation(backend).await,
+    };
+    let delta = backend.service().report_delta(since).await;
+    Ok(serde_json::to_value(delta).unwrap_or(serde_json::Value::Null))
+}
+
+/// Returns the generation immediately before the current live snapshot.
+async fn previous_generation(backend: &LspBackend) -> u64 {
+    let session = backend.service().session();
+    let guard = session.lock().await;
+    guard.generation().saturating_sub(1)
 }
 
 /// Catch-all params for no-arg methods. Accepts any JSON value

--- a/crates/deslop-lsp/src/main.rs
+++ b/crates/deslop-lsp/src/main.rs
@@ -7,13 +7,24 @@
 use std::{env, path::PathBuf, process::ExitCode};
 
 use anyhow::{anyhow, Result};
-use deslop_core::embedding::{DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL, DEFAULT_PROVIDER_ID};
+use deslop_core::{
+    embedding::{DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL, DEFAULT_PROVIDER_ID},
+    version_contract_output, ComponentKind,
+};
 use deslop_lsp::backend::LspEmbeddingConfig;
+use tokio::runtime::{Builder, Runtime};
 use tracing_subscriber::EnvFilter;
 
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> ExitCode {
-    if let Err(error) = run().await {
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    if let Err(error) = print_version_contract(&args) {
+        tracing::error!(%error, "deslop-lsp version output failed");
+        return ExitCode::from(1);
+    }
+    if requests_version(&args) {
+        return ExitCode::SUCCESS;
+    }
+    if let Err(error) = build_runtime().and_then(|runtime| runtime.block_on(run(args))) {
         tracing::error!(%error, "deslop-lsp exited with error");
         return ExitCode::from(1);
     }
@@ -21,17 +32,7 @@ async fn main() -> ExitCode {
 }
 
 /// Parses CLI arguments and starts the server.
-async fn run() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    if args
-        .iter()
-        .skip(1)
-        .any(|arg| arg == "--version" || arg == "-V")
-    {
-        println!("deslop-lsp {}", env!("CARGO_PKG_VERSION"));
-        return Ok(());
-    }
-
+async fn run(args: Vec<String>) -> Result<()> {
     init_tracing();
     tracing::info!(argv = ?args, "deslop-lsp starting");
     let workspace_root = parse_workspace_root(&args)?;
@@ -48,6 +49,26 @@ async fn run() -> Result<()> {
         "deslop-lsp args parsed",
     );
     deslop_lsp::run_stdio(workspace_root, min_nodes, embedding).await
+}
+
+/// Builds the Tokio runtime only after version preflight has returned false.
+fn build_runtime() -> Result<Runtime> {
+    Ok(Builder::new_multi_thread().enable_all().build()?)
+}
+
+/// Prints Deployment Toolkit version output when requested.
+fn print_version_contract(args: &[String]) -> Result<()> {
+    if let Some(output) = version_contract_output(args, "deslop-lsp", ComponentKind::Lsp)? {
+        print!("{output}");
+    }
+    Ok(())
+}
+
+/// Returns whether args request version output.
+fn requests_version(args: &[String]) -> bool {
+    args.iter()
+        .skip(1)
+        .any(|arg| matches!(arg.as_str(), "--version" | "-V"))
 }
 
 /// Reads the optional `--worker-threads` value, defaulting to 0 which

--- a/crates/deslop-lsp/tests/cli.rs
+++ b/crates/deslop-lsp/tests/cli.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use std::time::Duration;
+use std::{path::Path, time::Duration};
 
 use anyhow::{anyhow, Result};
 use assert_cmd::Command;
@@ -50,6 +50,39 @@ fn initialize_reports_server_info_version() -> Result<()> {
     let _shutdown = call(&mut stdin, &mut stdout, "shutdown", &Value::Null)?;
     let _ = child.kill();
     Ok(())
+}
+
+#[test]
+fn reload_uses_fingerprint_cache_for_unchanged_workspace() -> Result<()> {
+    let workspace = copy_fixture("csharp-small")?;
+    let _cold = report_after_start(workspace.path())?;
+    let warm = report_after_start(workspace.path())?;
+    let hits = cache_stat(&warm, "hits")?;
+    assert!(
+        hits > 0,
+        "warm LSP restart must reuse fingerprint cache entries, got report: {warm}"
+    );
+    Ok(())
+}
+
+fn report_after_start(workspace: &Path) -> Result<Value> {
+    let mut child = spawn_lsp(workspace, 15)?;
+    let (mut stdin, mut stdout, _stderr) = take_io(&mut child)?;
+    let _init = handshake(&mut stdin, &mut stdout)?;
+    let response = call(&mut stdin, &mut stdout, "deslop/reportGet", &Value::Null)?;
+    let _shutdown = call(&mut stdin, &mut stdout, "shutdown", &Value::Null)?;
+    let _ = child.kill();
+    response
+        .get("result")
+        .cloned()
+        .ok_or_else(|| anyhow!("missing report result: {response}"))
+}
+
+fn cache_stat(report: &Value, field: &str) -> Result<u64> {
+    report
+        .pointer(&format!("/cache_stats/{field}"))
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("missing cache_stats.{field}: {report}"))
 }
 
 fn pointer<'a>(value: &'a Value, path: &str) -> Result<&'a str> {

--- a/crates/deslop-lsp/tests/cli.rs
+++ b/crates/deslop-lsp/tests/cli.rs
@@ -1,9 +1,14 @@
 //! Contract tests for the `deslop-lsp` binary surface.
 
+mod common;
+
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use assert_cmd::Command;
+use serde_json::Value;
+
+use crate::common::{call, copy_fixture, handshake, spawn_lsp, take_io};
 
 // Implements the deployment-toolkit binary contract: every IDE-launched
 // executable must expose a stable plain text version line.
@@ -18,4 +23,47 @@ fn prints_exact_version_contract() -> Result<()> {
         .stdout("deslop-lsp 0.1.0\n")
         .stderr("");
     Ok(())
+}
+
+#[test]
+fn prints_json_version_contract() -> Result<()> {
+    let output = Command::cargo_bin("deslop-lsp")?
+        .timeout(Duration::from_secs(2))
+        .arg("--version")
+        .arg("--json")
+        .output()?;
+    assert!(output.status.success(), "status was {}", output.status);
+    let value: Value = serde_json::from_slice(&output.stdout)?;
+    assert_version_manifest(&value, "deslop-lsp", "lsp");
+    assert!(output.stderr.is_empty(), "stderr must stay empty");
+    Ok(())
+}
+
+#[test]
+fn initialize_reports_server_info_version() -> Result<()> {
+    let workspace = copy_fixture("csharp-small")?;
+    let mut child = spawn_lsp(workspace.path(), 15)?;
+    let (mut stdin, mut stdout, _stderr) = take_io(&mut child)?;
+    let init = handshake(&mut stdin, &mut stdout)?;
+    assert_eq!(pointer(&init, "/result/serverInfo/name")?, "deslop-lsp");
+    assert_eq!(pointer(&init, "/result/serverInfo/version")?, "0.1.0");
+    let _shutdown = call(&mut stdin, &mut stdout, "shutdown", &Value::Null)?;
+    let _ = child.kill();
+    Ok(())
+}
+
+fn pointer<'a>(value: &'a Value, path: &str) -> Result<&'a str> {
+    value
+        .pointer(path)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing string at {path}: {value}"))
+}
+
+fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
+    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
+    assert_eq!(value.get("name"), Some(&Value::from(name)));
+    assert_eq!(value.get("version"), Some(&Value::from("0.1.0")));
+    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
+    assert_eq!(value.get("language"), Some(&Value::from("rust")));
+    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
 }

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -61,14 +61,25 @@ fn report_changed_fires_for_pure_removal_delta() -> Result<()> {
 
     let (init_id, init) = initialize_request()?;
     let _init = send_and_recv_frame(&mut stdin, &frames, init_id, &init)?;
-    let initial = request_response(&mut stdin, &frames, "deslop/reportGet", &serde_json::json!({}))?;
-    ensure!(cluster_count(&initial) > 0, "fixture must start with duplicate clusters");
+    let initial = request_response(
+        &mut stdin,
+        &frames,
+        "deslop/reportGet",
+        &serde_json::json!({}),
+    )?;
+    ensure!(
+        cluster_count(&initial) > 0,
+        "fixture must start with duplicate clusters"
+    );
 
     fs::write(&beta, unrelated_csharp())?;
     write_frame(&mut stdin, &watched_file_changed(&beta)?)?;
     let changed = recv_method(&frames, "deslop/reportChanged", Duration::from_secs(5))?;
     let removed = json_u64(&changed, "/params/summary/clusters_removed")?;
-    ensure!(removed > 0, "reportChanged must describe at least one removed cluster");
+    ensure!(
+        removed > 0,
+        "reportChanged must describe at least one removed cluster"
+    );
 
     let params = serde_json::json!({ "since_generation": 1 });
     let delta = request_response(&mut stdin, &frames, "deslop/reportDelta", &params)?;

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -242,7 +242,7 @@ fn recv_response(
     id: i64,
     timeout: Duration,
 ) -> Result<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
+    let deadline = deadline_after(timeout)?;
     loop {
         let frame = recv_next(frames, deadline, &format!("response id {id}"))?;
         if frame.get("id").and_then(serde_json::Value::as_i64) == Some(id) {
@@ -257,13 +257,19 @@ fn recv_method(
     method: &str,
     timeout: Duration,
 ) -> Result<serde_json::Value> {
-    let deadline = Instant::now() + timeout;
+    let deadline = deadline_after(timeout)?;
     loop {
         let frame = recv_next(frames, deadline, method)?;
         if frame.get("method").and_then(serde_json::Value::as_str) == Some(method) {
             return Ok(frame);
         }
     }
+}
+
+fn deadline_after(timeout: Duration) -> Result<Instant> {
+    Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(|| anyhow!("timeout duration is too large"))
 }
 
 /// Receives one frame before `deadline`.

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -9,10 +9,16 @@ use std::{
     io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio},
-    sync::atomic::{AtomicI64, Ordering},
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        mpsc::{self, Receiver},
+    },
+    time::{Duration, Instant},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
+
+type FrameResult = std::result::Result<serde_json::Value, String>;
 
 /// JSON-RPC id counter for this integration-test process.
 static NEXT_ID: AtomicI64 = AtomicI64::new(10_000);
@@ -40,6 +46,46 @@ fn vscode_core_notifications_are_implemented_or_explicitly_nooped() -> Result<()
         "normal VS Code notifications must be implemented or explicit no-ops: {stderr_text}"
     );
     Ok(())
+}
+
+/// [LIVE-NOTIFICATIONS] A pure-removal edit must push reportChanged
+/// and expose the removed cluster ids through reportDelta.
+#[test]
+fn report_changed_fires_for_pure_removal_delta() -> Result<()> {
+    let workspace = copy_fixture("csharp-small")?;
+    let beta = workspace.path().join("Beta.cs");
+    let mut child = spawn_lsp(workspace.path(), 15)?;
+    let (mut stdin, stdout, _stderr) = take_io(&mut child)?;
+    let _guard = KillOnDrop(&mut child);
+    let frames = spawn_frame_reader(stdout);
+
+    let (init_id, init) = initialize_request()?;
+    let _init = send_and_recv_frame(&mut stdin, &frames, init_id, &init)?;
+    let initial = request_response(&mut stdin, &frames, "deslop/reportGet", &serde_json::json!({}))?;
+    ensure!(cluster_count(&initial) > 0, "fixture must start with duplicate clusters");
+
+    fs::write(&beta, unrelated_csharp())?;
+    write_frame(&mut stdin, &watched_file_changed(&beta)?)?;
+    let changed = recv_method(&frames, "deslop/reportChanged", Duration::from_secs(5))?;
+    let removed = json_u64(&changed, "/params/summary/clusters_removed")?;
+    ensure!(removed > 0, "reportChanged must describe at least one removed cluster");
+
+    let params = serde_json::json!({ "since_generation": 1 });
+    let delta = request_response(&mut stdin, &frames, "deslop/reportDelta", &params)?;
+    ensure!(
+        json_array_len(&delta, "/result/clusters_removed")? > 0,
+        "reportDelta must include removed cluster ids"
+    );
+    Ok(())
+}
+
+struct KillOnDrop<'a>(&'a mut Child);
+
+impl Drop for KillOnDrop<'_> {
+    fn drop(&mut self) {
+        let _kill = self.0.kill();
+        let _wait = self.0.wait();
+    }
 }
 
 /// Returns a workspace-relative fixture path.
@@ -112,6 +158,19 @@ fn read_frame(reader: &mut BufReader<ChildStdout>) -> Result<serde_json::Value> 
     Ok(serde_json::from_slice(&buf)?)
 }
 
+/// Reads frames on a background thread so tests can time out waiting
+/// for notifications without blocking forever on stdout.
+fn spawn_frame_reader(mut stdout: BufReader<ChildStdout>) -> Receiver<FrameResult> {
+    let (tx, rx) = mpsc::channel();
+    let _reader = std::thread::spawn(move || loop {
+        let frame = read_frame(&mut stdout).map_err(|error| error.to_string());
+        if tx.send(frame).is_err() {
+            break;
+        }
+    });
+    rx
+}
+
 /// Reads the `Content-Length` header block.
 fn read_content_length(reader: &mut BufReader<ChildStdout>) -> Result<usize> {
     let mut content_length: Option<usize> = None;
@@ -142,6 +201,72 @@ fn send_and_recv(
             return Ok(frame);
         }
     }
+}
+
+/// Sends a request and waits for the matching response from a frame channel.
+fn send_and_recv_frame(
+    stdin: &mut ChildStdin,
+    frames: &Receiver<FrameResult>,
+    id: i64,
+    payload: &str,
+) -> Result<serde_json::Value> {
+    write_frame(stdin, payload)?;
+    recv_response(frames, id, Duration::from_secs(10))
+}
+
+/// Builds, sends, and receives a JSON-RPC request.
+fn request_response(
+    stdin: &mut ChildStdin,
+    frames: &Receiver<FrameResult>,
+    method: &str,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value> {
+    let (id, payload) = request(method, params)?;
+    send_and_recv_frame(stdin, frames, id, &payload)
+}
+
+/// Waits until a response with `id` arrives.
+fn recv_response(
+    frames: &Receiver<FrameResult>,
+    id: i64,
+    timeout: Duration,
+) -> Result<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let frame = recv_next(frames, deadline, &format!("response id {id}"))?;
+        if frame.get("id").and_then(serde_json::Value::as_i64) == Some(id) {
+            return Ok(frame);
+        }
+    }
+}
+
+/// Waits until a notification with `method` arrives.
+fn recv_method(
+    frames: &Receiver<FrameResult>,
+    method: &str,
+    timeout: Duration,
+) -> Result<serde_json::Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let frame = recv_next(frames, deadline, method)?;
+        if frame.get("method").and_then(serde_json::Value::as_str) == Some(method) {
+            return Ok(frame);
+        }
+    }
+}
+
+/// Receives one frame before `deadline`.
+fn recv_next(
+    frames: &Receiver<FrameResult>,
+    deadline: Instant,
+    label: &str,
+) -> Result<serde_json::Value> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    ensure!(!remaining.is_zero(), "timed out waiting for {label}");
+    let frame = frames
+        .recv_timeout(remaining)
+        .map_err(|_error| anyhow!("timed out waiting for {label}"))?;
+    frame.map_err(|error| anyhow!(error))
 }
 
 /// Builds an `initialize` request.
@@ -200,6 +325,21 @@ fn normal_vscode_notifications(path: &Path) -> Result<Vec<String>> {
     ])
 }
 
+/// Builds the watched-file notification VS Code sends after a save.
+fn watched_file_changed(path: &Path) -> Result<String> {
+    let uri = tower_lsp::lsp_types::Url::from_file_path(path)
+        .map_err(|()| anyhow!("path is not absolute: {}", path.display()))?;
+    notification(
+        "workspace/didChangeWatchedFiles",
+        &serde_json::json!({ "changes": [{ "uri": uri.as_str(), "type": 2 }] }),
+    )
+}
+
+/// Replacement content with no duplicated method body.
+fn unrelated_csharp() -> &'static str {
+    "public class Beta {\n    public string Name() {\n        return \"unique\";\n    }\n}\n"
+}
+
 /// Builds a JSON-RPC notification.
 fn notification(method: &str, params: &serde_json::Value) -> Result<String> {
     let payload = serde_json::json!({
@@ -208,6 +348,31 @@ fn notification(method: &str, params: &serde_json::Value) -> Result<String> {
         "params": params
     });
     Ok(serde_json::to_string(&payload)?)
+}
+
+/// Returns the report cluster count from a JSON-RPC response frame.
+fn cluster_count(frame: &serde_json::Value) -> usize {
+    frame
+        .pointer("/result/clusters")
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len)
+}
+
+/// Reads a required integer field from a JSON frame.
+fn json_u64(frame: &serde_json::Value, pointer: &str) -> Result<u64> {
+    frame
+        .pointer(pointer)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| anyhow!("missing numeric field {pointer}: {frame}"))
+}
+
+/// Reads a required array length from a JSON frame.
+fn json_array_len(frame: &serde_json::Value, pointer: &str) -> Result<usize> {
+    frame
+        .pointer(pointer)
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .ok_or_else(|| anyhow!("missing array field {pointer}: {frame}"))
 }
 
 /// Stops the child process and returns stderr.

--- a/crates/deslop-mcp/src/main.rs
+++ b/crates/deslop-mcp/src/main.rs
@@ -4,12 +4,12 @@
 //! configure tracing, construct the [`PipelineSessionBackend`], and
 //! drive the server against stdin / stdout.
 
-use std::{io, path::PathBuf, sync::Arc};
+use std::{env, io, path::PathBuf, sync::Arc};
 
 use clap::Parser;
 use deslop_core::{
     embedding::{DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL},
-    EmbeddingMode, DEFAULT_PROVIDER_ID,
+    version_contract_output, ComponentKind, EmbeddingMode, DEFAULT_PROVIDER_ID,
 };
 use deslop_mcp::{McpServer, PipelineSessionBackend, SessionBackendConfig};
 use tracing::error;
@@ -58,7 +58,19 @@ struct Cli {
 }
 
 fn main() {
-    if let Err(err) = run() {
+    let args: Vec<String> = env::args().collect();
+    match version_contract_output(&args, "deslop-mcp", ComponentKind::Mcp) {
+        Ok(Some(output)) => {
+            print!("{output}");
+            return;
+        }
+        Ok(None) => {}
+        Err(err) => {
+            error!(reason = %err, "mcp_version_contract_failure");
+            std::process::exit(1);
+        }
+    }
+    if let Err(err) = run(args) {
         error!(reason = %err, "mcp_server_failure");
         std::process::exit(1);
     }
@@ -70,9 +82,9 @@ fn main() {
 ///
 /// Returns any error surfaced by backend construction or the
 /// transport loop.
-fn run() -> Result<(), Box<dyn std::error::Error>> {
+fn run(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     install_tracing();
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(args);
     let mode: EmbeddingMode = cli.embeddings.parse()?;
     let config = SessionBackendConfig {
         root: cli.root,

--- a/crates/deslop-mcp/tests/cli.rs
+++ b/crates/deslop-mcp/tests/cli.rs
@@ -186,6 +186,42 @@ fn init_session(child: &mut McpChild) -> Result<Value> {
     )
 }
 
+#[test]
+fn prints_exact_version_contract() -> Result<()> {
+    let binary = env!("CARGO_BIN_EXE_deslop-mcp");
+    let output = Command::new(binary).arg("--version").output()?;
+    assert!(output.status.success(), "status was {}", output.status);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "deslop-mcp 0.1.0\n"
+    );
+    assert!(output.stderr.is_empty(), "stderr must stay empty");
+    Ok(())
+}
+
+#[test]
+fn prints_json_version_contract() -> Result<()> {
+    let binary = env!("CARGO_BIN_EXE_deslop-mcp");
+    let output = Command::new(binary)
+        .arg("--version")
+        .arg("--json")
+        .output()?;
+    assert!(output.status.success(), "status was {}", output.status);
+    let value: Value = serde_json::from_slice(&output.stdout)?;
+    assert_version_manifest(&value, "deslop-mcp", "mcp");
+    assert!(output.stderr.is_empty(), "stderr must stay empty");
+    Ok(())
+}
+
+fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
+    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
+    assert_eq!(value.get("name"), Some(&Value::from(name)));
+    assert_eq!(value.get("version"), Some(&Value::from("0.1.0")));
+    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
+    assert_eq!(value.get("language"), Some(&Value::from("rust")));
+    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
+}
+
 fn call_tool(child: &mut McpChild, name: &str, arguments: &Value) -> Result<Value> {
     let response = child.request(
         "tools/call",
@@ -245,6 +281,10 @@ fn initialize_returns_server_info_and_capabilities() -> Result<()> {
     assert_eq!(
         value_get(&response, "/result/serverInfo/name")?,
         json!("deslop-mcp")
+    );
+    assert_eq!(
+        value_get(&response, "/result/serverInfo/version")?,
+        json!("0.1.0")
     );
     assert!(
         value_get(&response, "/result/capabilities/tools")?.is_object(),

--- a/crates/deslop/src/main.rs
+++ b/crates/deslop/src/main.rs
@@ -8,6 +8,8 @@
 //! text and HTML views unless suppressed ([OUTPUT-SCHEMA-JSON]).
 
 mod logging;
+mod output;
+mod rerun;
 mod summary;
 
 use std::{env, fs, io::Write as _, path::PathBuf, str::FromStr};
@@ -15,21 +17,19 @@ use std::{env, fs, io::Write as _, path::PathBuf, str::FromStr};
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use deslop_core::{
-    classify_signals, debug_ast_dump, render::render_html, render::render_text,
-    validate_threshold_percent, EmbeddingMode, EmbeddingSettings, ExclusionConfig, OllamaProvider,
-    PipelineSession, Report, ReportDelta, StubProvider, ThresholdSource, ThresholdSummary,
-    DEFAULT_OLLAMA_ENDPOINT, DEFAULT_OLLAMA_MODEL, DEFAULT_PROVIDER_ID, STUB_PROVIDER_ID,
+    debug_ast_dump, validate_threshold_percent, version_contract_output, ComponentKind,
+    EmbeddingMode, EmbeddingSettings, ExclusionConfig, OllamaProvider, PipelineSession, Report,
+    ReportDelta, StubProvider, ThresholdSource, ThresholdSummary, DEFAULT_OLLAMA_ENDPOINT,
+    DEFAULT_OLLAMA_MODEL, DEFAULT_PROVIDER_ID, STUB_PROVIDER_ID,
 };
 use tracing::Level;
 
 use crate::{
     logging::LogSink,
+    output::{emit_all, load_report, write_file, FormatSelection, OutputPaths},
+    rerun::{assemble_touched, parse_rerun_adds},
     summary::{ColorChoice, PreambleKnobs, WrittenArtefacts},
 };
-
-/// Default base name for the three-format output written to CWD when
-/// `--output` is not provided.
-const DEFAULT_OUTPUT_STEM: &str = "deslop-report";
 
 /// Command-line interface for `Deslop`.
 #[derive(Debug, Parser)]
@@ -216,7 +216,12 @@ fn main() {
 /// be wrapped with a non-zero exit code without losing the
 /// `anyhow::Error` chain.
 fn run_cli() -> Result<()> {
-    let args = Cli::parse();
+    let raw_args: Vec<String> = env::args().collect();
+    if let Some(output) = version_contract_output(&raw_args, "deslop", ComponentKind::Cli)? {
+        print!("{output}");
+        return Ok(());
+    }
+    let args = Cli::parse_from(raw_args);
     if let Some(file) = args.debug_ast.as_deref() {
         return run_debug_ast(file);
     }
@@ -229,7 +234,7 @@ fn run_cli() -> Result<()> {
     summary::preamble(
         color,
         &args.path,
-        &output.base,
+        output.base_path(),
         &log_sink,
         &PreambleKnobs {
             min_nodes: args.min_nodes,
@@ -241,9 +246,9 @@ fn run_cli() -> Result<()> {
     tracing::info!(
         path = %args.path.display(),
         min_nodes = args.min_nodes,
-        json = formats.json,
-        text = formats.text,
-        html = formats.html,
+        json = formats.json_enabled(),
+        text = formats.text_enabled(),
+        html = formats.html_enabled(),
         embeddings = mode.as_str(),
         incremental = args.behaviour.incremental,
         "deslop invoked",
@@ -259,7 +264,7 @@ fn run_cli() -> Result<()> {
     apply_threshold(&args, &mut report)?;
     let mut written = emit_all(&report, &formats, &output, &args.path)?;
     if let Some(delta) = outcome.delta.as_ref() {
-        let delta_path = output.with_extension("delta.json");
+        let delta_path = output.path_with_extension("delta.json");
         let payload = serde_json::to_string_pretty(delta).context("serialise delta as JSON")?;
         write_file(&delta_path, payload.as_bytes())?;
         written.push(delta_path);
@@ -409,58 +414,6 @@ fn produce_report(
     })
 }
 
-/// Parsed `--rerun-add` entry: copy `src` to `dst` between the initial
-/// analysis and the rerun, then replay `dst` through `update_files`.
-#[derive(Debug)]
-struct RerunAdd {
-    /// Source path copied from (must exist at rerun time).
-    src: PathBuf,
-    /// Destination path copied to (inside the scan root).
-    dst: PathBuf,
-}
-
-/// Parses the `SRC=DST` spec. Rejects specs that do not contain exactly
-/// one `=` separator.
-fn parse_rerun_adds(specs: &[String]) -> Result<Vec<RerunAdd>> {
-    specs
-        .iter()
-        .map(|spec| {
-            let (src, dst) = spec
-                .split_once('=')
-                .ok_or_else(|| anyhow::anyhow!("--rerun-add spec must be SRC=DST, got {spec:?}"))?;
-            Ok(RerunAdd {
-                src: PathBuf::from(src),
-                dst: PathBuf::from(dst),
-            })
-        })
-        .collect()
-}
-
-/// Merges `--rerun-touch`, `--rerun-remove`, and `--rerun-add` paths
-/// into the single vector passed to [`PipelineSession::update_files`].
-/// Deletions and additions are implicitly touched so the session picks
-/// them up.
-fn assemble_touched(args: &Cli, adds: &[RerunAdd]) -> Vec<PathBuf> {
-    let capacity = args
-        .rerun_touch
-        .len()
-        .saturating_add(args.rerun_remove.len())
-        .saturating_add(adds.len());
-    let mut out: Vec<PathBuf> = Vec::with_capacity(capacity);
-    out.extend(args.rerun_touch.iter().cloned());
-    for path in &args.rerun_remove {
-        if !out.contains(path) {
-            out.push(path.clone());
-        }
-    }
-    for add in adds {
-        if !out.contains(&add.dst) {
-            out.push(add.dst.clone());
-        }
-    }
-    out
-}
-
 /// Parses and validates `--fail-over` at clap-time so invalid values
 /// exit `2` (clap's default for argument errors) instead of surfacing
 /// as a runtime `1`.
@@ -520,139 +473,4 @@ fn build_ollama_provider(
     }
     tracing::warn!(%source, "embedding provider unreachable — continuing without Type-4 recall");
     Ok(None)
-}
-
-/// Which of the three output formats are enabled for this run.
-#[derive(Debug)]
-struct FormatSelection {
-    /// Emit canonical JSON (`<base>.json`).
-    json: bool,
-    /// Emit terse text view (`<base>.txt`).
-    text: bool,
-    /// Emit human-readable HTML view (`<base>.html`).
-    html: bool,
-}
-
-impl FormatSelection {
-    /// Builds the selection from the three suppression flags. Errors
-    /// out when all three are suppressed — silent runs are never
-    /// helpful.
-    fn from_args(args: &Cli) -> Result<Self> {
-        let selection = Self {
-            json: !args.suppress.nojson,
-            text: !args.suppress.notext,
-            html: !args.suppress.nohtml,
-        };
-        if !selection.json && !selection.text && !selection.html {
-            bail!("at least one of --nojson/--notext/--nohtml must remain enabled");
-        }
-        Ok(selection)
-    }
-}
-
-/// Resolved output base path; renderers append their own extension.
-#[derive(Debug)]
-struct OutputPaths {
-    /// `<base>` such that `<base>.json` etc. are the final paths.
-    base: PathBuf,
-}
-
-impl OutputPaths {
-    /// Picks the base path. When the user passed `--output`, use it
-    /// verbatim; otherwise write into the current working directory
-    /// under [`DEFAULT_OUTPUT_STEM`].
-    fn new(explicit: Option<&std::path::Path>) -> Self {
-        let base = explicit.map_or_else(
-            || {
-                env::current_dir()
-                    .unwrap_or_default()
-                    .join(DEFAULT_OUTPUT_STEM)
-            },
-            std::path::Path::to_path_buf,
-        );
-        Self { base }
-    }
-
-    /// Returns the concrete on-disk path for a given extension.
-    fn with_extension(&self, extension: &str) -> PathBuf {
-        let mut path = self.base.clone();
-        let stem = path
-            .file_name()
-            .map(std::ffi::OsStr::to_os_string)
-            .unwrap_or_default();
-        let mut new_name = stem;
-        new_name.push(".");
-        new_name.push(extension);
-        path.set_file_name(new_name);
-        path
-    }
-
-    /// Directory that the report files sit in. Used as the default
-    /// location for the timestamped log file so all per-run output
-    /// lives together.
-    fn directory(&self) -> &std::path::Path {
-        self.base.parent().unwrap_or(std::path::Path::new("."))
-    }
-}
-
-/// Writes every enabled format for `report` to its derived path under
-/// `output`, returning the paths actually written (for the finish
-/// footer).
-fn emit_all(
-    report: &Report,
-    formats: &FormatSelection,
-    output: &OutputPaths,
-    scan_root: &std::path::Path,
-) -> Result<Vec<PathBuf>> {
-    let mut written: Vec<PathBuf> = Vec::with_capacity(3);
-    if formats.json {
-        let json = serde_json::to_string_pretty(report).context("serialise report as JSON")?;
-        let path = output.with_extension("json");
-        write_file(&path, json.as_bytes())?;
-        written.push(path);
-    }
-    if formats.text {
-        let text = render_text(report);
-        let path = output.with_extension("txt");
-        write_file(&path, text.as_bytes())?;
-        written.push(path);
-    }
-    if formats.html {
-        let html = render_html(report, Some(scan_root));
-        let path = output.with_extension("html");
-        write_file(&path, html.as_bytes())?;
-        written.push(path);
-    }
-    Ok(written)
-}
-
-/// Writes `payload` to `path`, creating parent directories as needed.
-fn write_file(path: &std::path::Path, payload: &[u8]) -> Result<()> {
-    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    fs::create_dir_all(parent).with_context(|| format!("create parent {}", parent.display()))?;
-    let mut file =
-        fs::File::create(path).with_context(|| format!("create report file {}", path.display()))?;
-    file.write_all(payload)
-        .with_context(|| format!("write report file {}", path.display()))?;
-    tracing::info!(path = %path.display(), bytes = payload.len(), "wrote report file");
-    Ok(())
-}
-
-/// Loads a canonical JSON report from disk for `--from-report`.
-fn load_report(path: &std::path::Path) -> Result<Report> {
-    let source =
-        fs::read_to_string(path).with_context(|| format!("read report {}", path.display()))?;
-    let mut report = serde_json::from_str::<Report>(&source)
-        .with_context(|| format!("parse report {}", path.display()))?;
-    // Reports predating [CLONE-BUCKETS] deserialise with an empty
-    // `cluster.bucket`. Re-route from the signal triple so renderers
-    // always see a non-empty canonical wire label.
-    for cluster in &mut report.clusters {
-        if cluster.bucket.is_empty() {
-            classify_signals(cluster.signals)
-                .wire_label()
-                .clone_into(&mut cluster.bucket);
-        }
-    }
-    Ok(report)
 }

--- a/crates/deslop/src/output.rs
+++ b/crates/deslop/src/output.rs
@@ -1,0 +1,202 @@
+//! Report output helpers for the `deslop` CLI.
+
+use std::{env, fs, io::Write as _, path::PathBuf};
+
+use anyhow::{bail, Context, Result};
+use deslop_core::{classify_signals, render::render_html, render::render_text, Report};
+
+use crate::Cli;
+
+/// Default base name for the three-format output written to CWD when
+/// `--output` is not provided.
+const DEFAULT_OUTPUT_STEM: &str = "deslop-report";
+
+/// Which of the three output formats are enabled for this run.
+#[derive(Debug)]
+pub(crate) struct FormatSelection {
+    /// Emit canonical JSON (`<base>.json`).
+    json: bool,
+    /// Emit terse text view (`<base>.txt`).
+    text: bool,
+    /// Emit human-readable HTML view (`<base>.html`).
+    html: bool,
+}
+
+impl FormatSelection {
+    /// Builds the selection from the three suppression flags.
+    pub(crate) fn from_args(args: &Cli) -> Result<Self> {
+        let selection = Self {
+            json: !args.suppress.nojson,
+            text: !args.suppress.notext,
+            html: !args.suppress.nohtml,
+        };
+        if !selection.json && !selection.text && !selection.html {
+            bail!("at least one of --nojson/--notext/--nohtml must remain enabled");
+        }
+        Ok(selection)
+    }
+
+    /// Whether canonical JSON output is enabled.
+    pub(crate) fn json_enabled(&self) -> bool {
+        self.json
+    }
+
+    /// Whether text output is enabled.
+    pub(crate) fn text_enabled(&self) -> bool {
+        self.text
+    }
+
+    /// Whether HTML output is enabled.
+    pub(crate) fn html_enabled(&self) -> bool {
+        self.html
+    }
+}
+
+/// Resolved output base path; renderers append their own extension.
+#[derive(Debug)]
+pub(crate) struct OutputPaths {
+    /// `<base>` such that `<base>.json` etc. are the final paths.
+    base: PathBuf,
+}
+
+impl OutputPaths {
+    /// Picks the base path for rendered reports.
+    pub(crate) fn new(explicit: Option<&std::path::Path>) -> Self {
+        let base = explicit.map_or_else(
+            || {
+                env::current_dir()
+                    .unwrap_or_default()
+                    .join(DEFAULT_OUTPUT_STEM)
+            },
+            std::path::Path::to_path_buf,
+        );
+        Self { base }
+    }
+
+    /// Returns the unresolved base path.
+    pub(crate) fn base_path(&self) -> &std::path::Path {
+        &self.base
+    }
+
+    /// Returns the concrete on-disk path for a given extension.
+    pub(crate) fn path_with_extension(&self, extension: &str) -> PathBuf {
+        let mut path = self.base.clone();
+        let stem = path
+            .file_name()
+            .map(std::ffi::OsStr::to_os_string)
+            .unwrap_or_default();
+        let mut new_name = stem;
+        new_name.push(".");
+        new_name.push(extension);
+        path.set_file_name(new_name);
+        path
+    }
+
+    /// Directory that the report files sit in.
+    pub(crate) fn directory(&self) -> &std::path::Path {
+        self.base.parent().unwrap_or(std::path::Path::new("."))
+    }
+}
+
+/// Writes every enabled format for `report`.
+pub(crate) fn emit_all(
+    report: &Report,
+    formats: &FormatSelection,
+    output: &OutputPaths,
+    scan_root: &std::path::Path,
+) -> Result<Vec<PathBuf>> {
+    let mut written: Vec<PathBuf> = Vec::with_capacity(3);
+    emit_json(report, formats, output, &mut written)?;
+    emit_text(report, formats, output, &mut written)?;
+    emit_html(report, formats, output, scan_root, &mut written)?;
+    Ok(written)
+}
+
+/// Writes canonical JSON when enabled.
+fn emit_json(
+    report: &Report,
+    formats: &FormatSelection,
+    output: &OutputPaths,
+    written: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if formats.json {
+        let json = serde_json::to_string_pretty(report).context("serialise report as JSON")?;
+        write_rendered(output, "json", json.as_bytes(), written)?;
+    }
+    Ok(())
+}
+
+/// Writes the terse text view when enabled.
+fn emit_text(
+    report: &Report,
+    formats: &FormatSelection,
+    output: &OutputPaths,
+    written: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if formats.text {
+        let text = render_text(report);
+        write_rendered(output, "txt", text.as_bytes(), written)?;
+    }
+    Ok(())
+}
+
+/// Writes the human-readable HTML view when enabled.
+fn emit_html(
+    report: &Report,
+    formats: &FormatSelection,
+    output: &OutputPaths,
+    scan_root: &std::path::Path,
+    written: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if formats.html {
+        let html = render_html(report, Some(scan_root));
+        write_rendered(output, "html", html.as_bytes(), written)?;
+    }
+    Ok(())
+}
+
+/// Writes a rendered payload and records its final path.
+fn write_rendered(
+    output: &OutputPaths,
+    extension: &str,
+    payload: &[u8],
+    written: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let path = output.path_with_extension(extension);
+    write_file(&path, payload)?;
+    written.push(path);
+    Ok(())
+}
+
+/// Writes `payload` to `path`, creating parent directories as needed.
+pub(crate) fn write_file(path: &std::path::Path, payload: &[u8]) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    fs::create_dir_all(parent).with_context(|| format!("create parent {}", parent.display()))?;
+    let mut file =
+        fs::File::create(path).with_context(|| format!("create report file {}", path.display()))?;
+    file.write_all(payload)
+        .with_context(|| format!("write report file {}", path.display()))?;
+    tracing::info!(path = %path.display(), bytes = payload.len(), "wrote report file");
+    Ok(())
+}
+
+/// Loads a canonical JSON report from disk for `--from-report`.
+pub(crate) fn load_report(path: &std::path::Path) -> Result<Report> {
+    let source =
+        fs::read_to_string(path).with_context(|| format!("read report {}", path.display()))?;
+    let mut report = serde_json::from_str::<Report>(&source)
+        .with_context(|| format!("parse report {}", path.display()))?;
+    fill_legacy_bucket_labels(&mut report);
+    Ok(report)
+}
+
+/// Backfills bucket labels in old reports.
+fn fill_legacy_bucket_labels(report: &mut Report) {
+    for cluster in &mut report.clusters {
+        if cluster.bucket.is_empty() {
+            classify_signals(cluster.signals)
+                .wire_label()
+                .clone_into(&mut cluster.bucket);
+        }
+    }
+}

--- a/crates/deslop/src/rerun.rs
+++ b/crates/deslop/src/rerun.rs
@@ -1,0 +1,55 @@
+//! Incremental rerun argument helpers for the `deslop` CLI.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::Cli;
+
+/// Parsed `--rerun-add` entry.
+#[derive(Debug)]
+pub(crate) struct RerunAdd {
+    /// Source path copied from.
+    pub(crate) src: PathBuf,
+    /// Destination path copied to.
+    pub(crate) dst: PathBuf,
+}
+
+/// Parses the `SRC=DST` spec.
+pub(crate) fn parse_rerun_adds(specs: &[String]) -> Result<Vec<RerunAdd>> {
+    specs
+        .iter()
+        .map(|spec| {
+            let (src, dst) = spec
+                .split_once('=')
+                .ok_or_else(|| anyhow::anyhow!("--rerun-add spec must be SRC=DST, got {spec:?}"))?;
+            Ok(RerunAdd {
+                src: PathBuf::from(src),
+                dst: PathBuf::from(dst),
+            })
+        })
+        .collect()
+}
+
+/// Merges all paths that must be replayed through `update_files`.
+pub(crate) fn assemble_touched(args: &Cli, adds: &[RerunAdd]) -> Vec<PathBuf> {
+    let capacity = args
+        .rerun_touch
+        .len()
+        .saturating_add(args.rerun_remove.len())
+        .saturating_add(adds.len());
+    let mut out: Vec<PathBuf> = Vec::with_capacity(capacity);
+    out.extend(args.rerun_touch.iter().cloned());
+    push_unique_paths(&mut out, &args.rerun_remove);
+    push_unique_paths(&mut out, adds.iter().map(|add| &add.dst));
+    out
+}
+
+/// Appends paths that are not already present.
+fn push_unique_paths<'a>(out: &mut Vec<PathBuf>, paths: impl IntoIterator<Item = &'a PathBuf>) {
+    for path in paths {
+        if !out.contains(path) {
+            out.push(path.clone());
+        }
+    }
+}

--- a/crates/deslop/tests/cli.rs
+++ b/crates/deslop/tests/cli.rs
@@ -18,6 +18,7 @@ use std::{fmt::Write as _, fs, path::Path, path::PathBuf};
 use anyhow::Result;
 use assert_cmd::Command;
 use predicates::str::contains;
+use serde_json::Value;
 
 /// Returns the absolute path of a fixture under `tests/fixtures/<name>`.
 fn fixture(name: &str) -> PathBuf {
@@ -104,8 +105,31 @@ fn prints_version_and_exits_zero() -> Result<()> {
         .arg("--version")
         .assert()
         .success()
-        .stdout(contains("deslop"));
+        .stdout("deslop 0.1.0\n")
+        .stderr("");
     Ok(())
+}
+
+#[test]
+fn prints_json_version_contract() -> Result<()> {
+    let output = Command::cargo_bin("deslop")?
+        .arg("--version")
+        .arg("--json")
+        .output()?;
+    assert!(output.status.success(), "status was {}", output.status);
+    let value: Value = serde_json::from_slice(&output.stdout)?;
+    assert_version_manifest(&value, "deslop", "cli");
+    assert!(output.stderr.is_empty(), "stderr must stay empty");
+    Ok(())
+}
+
+fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
+    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
+    assert_eq!(value.get("name"), Some(&Value::from(name)));
+    assert_eq!(value.get("version"), Some(&Value::from("0.1.0")));
+    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
+    assert_eq!(value.get("language"), Some(&Value::from("rust")));
+    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
 }
 
 // Implements [CLI-INVOCATION-HELP]: `--help` advertises the configurable

--- a/crates/deslop/tests/csharp_type1_type2_distinct_buckets.rs
+++ b/crates/deslop/tests/csharp_type1_type2_distinct_buckets.rs
@@ -1,0 +1,99 @@
+//! End-to-end regression coverage for issue #42: Type-1 exact clones
+//! (byte-identical code) must render a distinct action sentence from
+//! Type-2 renamed-identifier clones ([CLONE-BUCKETS]).
+//!
+//! Acceptance: csharp-small (two methods, same structure, renamed
+//! identifiers) must NOT claim "every copy is the same". csharp-type1
+//! (two methods that are byte-identical) MUST have at least one cluster
+//! claiming "every copy is the same".
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use assert_cmd::Command;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(tmp: &Path, scan_root: &Path) -> Result<serde_json::Value> {
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("30")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(tmp.join("report"))
+        .assert()
+        .success();
+    let mut json_path = tmp.join("report");
+    let _replaced = json_path.set_extension("json");
+    let body = fs::read_to_string(&json_path)?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn cluster_interpretations(report: &serde_json::Value) -> Vec<String> {
+    report
+        .get("clusters")
+        .and_then(serde_json::Value::as_array)
+        .map(|clusters| {
+            clusters
+                .iter()
+                .filter_map(|cluster| {
+                    cluster
+                        .get("interpretation")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// Issue #42: Type-2 clusters (renamed identifiers, identical structure)
+// must NOT claim "every copy is the same" since extraction requires
+// parameterisation. Type-1 clusters (byte-identical code) MUST claim
+// "every copy is the same". Currently both get the same Identical label.
+#[test]
+fn type2_clusters_render_distinct_action_from_type1() -> Result<()> {
+    let tmp1 = tempfile::tempdir()?;
+    let tmp2 = tempfile::tempdir()?;
+
+    let type2_report = run_report(tmp1.path(), &fixture("csharp-small"))?;
+    let type1_report = run_report(tmp2.path(), &fixture("csharp-type1"))?;
+
+    let type2_interpretations = cluster_interpretations(&type2_report);
+    let type1_interpretations = cluster_interpretations(&type1_report);
+
+    assert!(
+        !type2_interpretations.is_empty(),
+        "csharp-small must produce at least one cluster: {type2_report}",
+    );
+
+    // Type-2: renamed-identifier clones must not claim the copies are byte-identical
+    for interp in &type2_interpretations {
+        assert!(
+            !interp.contains("every copy is the same"),
+            "Type-2 cluster must not claim copies are identical (issue #42): {interp}",
+        );
+    }
+
+    // Type-1: at least one cluster is genuinely byte-identical (method-body level)
+    assert!(
+        type1_interpretations
+            .iter()
+            .any(|i| i.contains("every copy is the same")),
+        "Type-1 fixture must produce at least one genuinely-identical cluster \
+         (issue #42): {type1_interpretations:#?}",
+    );
+
+    Ok(())
+}

--- a/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
+++ b/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
@@ -87,8 +87,9 @@ fn cluster_bucket(cluster: &serde_json::Value) -> String {
 // completely unrelated test files share only generic xUnit
 // scaffolding kinds; LSH-only kind-gram Jaccard saturation must not
 // route the resulting pair into the [CLONE-BUCKETS] `NearlyIdentical`
-// bucket. They may legitimately surface as `LooselySimilar` (LSH-only
-// hint) but never as `NearlyIdentical`.
+// bucket. LooselySimilar is suppressed entirely in the ranked output
+// per issue #58, so neither bucket must appear for boilerplate-only
+// matches.
 #[test]
 fn unrelated_csharp_xunit_classes_are_never_nearly_identical() -> Result<()> {
     let tmp = tempfile::tempdir()?;

--- a/crates/deslop/tests/fixtures/csharp-type1/Eta.cs
+++ b/crates/deslop/tests/fixtures/csharp-type1/Eta.cs
@@ -1,0 +1,19 @@
+namespace Eta
+{
+    public class Beacon
+    {
+        public int Tally(int bound)
+        {
+            if (bound < 0)
+            {
+                return 0;
+            }
+            int total = 0;
+            for (int step = 0; step < bound; step = step + 1)
+            {
+                total = total + step;
+            }
+            return total;
+        }
+    }
+}

--- a/crates/deslop/tests/fixtures/csharp-type1/Zeta.cs
+++ b/crates/deslop/tests/fixtures/csharp-type1/Zeta.cs
@@ -1,0 +1,19 @@
+namespace Zeta
+{
+    public class Anchor
+    {
+        public int Tally(int bound)
+        {
+            if (bound < 0)
+            {
+                return 0;
+            }
+            int total = 0;
+            for (int step = 0; step < bound; step = step + 1)
+            {
+                total = total + step;
+            }
+            return total;
+        }
+    }
+}

--- a/crates/deslop/tests/fixtures/python-type3/alpha.py
+++ b/crates/deslop/tests/fixtures/python-type3/alpha.py
@@ -1,0 +1,8 @@
+def accumulate(bound):
+    if bound < 0:
+        return 0
+    running = 0
+    for step in range(bound):
+        running = running + step
+        running = running + 2
+    return running

--- a/crates/deslop/tests/fixtures/python-type3/beta.py
+++ b/crates/deslop/tests/fixtures/python-type3/beta.py
@@ -1,0 +1,7 @@
+def aggregate(limit):
+    if limit < 0:
+        return 0
+    accumulator = 0
+    for cursor in range(limit):
+        accumulator = accumulator + cursor
+    return accumulator

--- a/crates/deslop/tests/python_signatures.rs
+++ b/crates/deslop/tests/python_signatures.rs
@@ -1,4 +1,4 @@
-//! Tests proving that the MinHash signature pipeline works correctly for
+//! Tests proving that the `MinHash` signature pipeline works correctly for
 //! Python after the XOF-based fix ([FUSION-SIGNALS-THREE-LAYER]).
 //!
 //! Bug 1 — `minhash_signature` produced 128 separate blake3 calls per
@@ -8,7 +8,7 @@
 //!
 //! Bug 2 — `tree_for_file` did a linear scan through all trees per
 //! fingerprint.  Fixed by pre-building a `HashMap<FileId, &NormalizedNode>`
-//! once.  A wrong HashMap mapping contaminates token streams; the
+//! once.  A wrong `HashMap` mapping contaminates token streams; the
 //! cross-file Type-3 assertion catches that.
 
 use std::{fs, path::Path, path::PathBuf};
@@ -64,17 +64,19 @@ fn occurrence_files(cluster: &serde_json::Value) -> Vec<String> {
         .map(|occ| {
             occ.iter()
                 .filter_map(|o| {
-                    o.get("path")
-                        .and_then(serde_json::Value::as_str)
-                        .map(|p| {
-                            Path::new(p)
-                                .file_name()
-                                .map_or_else(|| p.to_owned(), |n| n.to_string_lossy().into_owned())
-                        })
+                    o.get("path").and_then(serde_json::Value::as_str).map(|p| {
+                        Path::new(p)
+                            .file_name()
+                            .map_or_else(|| p.to_owned(), |n| n.to_string_lossy().into_owned())
+                    })
                 })
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn is_exact_one(value: f64) -> bool {
+    (value - 1.0).abs() <= f64::EPSILON
 }
 
 // [FUSION-SIGNALS-THREE-LAYER] Type-2 Python clones (identical after
@@ -90,16 +92,19 @@ fn python_type2_clone_has_token_jaccard_of_one() -> Result<()> {
         !clusters.is_empty(),
         "python-small must produce at least one cluster",
     );
-    let top = clusters[0];
+    let top = clusters
+        .first()
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("python-small must produce at least one cluster"))?;
     let token_jaccard = signal(top, "token_jaccard");
-    assert_eq!(
-        token_jaccard, 1.0,
+    assert!(
+        is_exact_one(token_jaccard),
         "Type-2 Python clone must have token_jaccard = 1.0 (identical k-gram sets), \
          got {token_jaccard}"
     );
     let structural = signal(top, "structural");
-    assert_eq!(
-        structural, 1.0,
+    assert!(
+        is_exact_one(structural),
         "Type-2 Python clone must also have structural = 1.0, got {structural}",
     );
     Ok(())
@@ -133,12 +138,12 @@ fn python_multi_file_corpus_produces_cross_file_cluster_with_positive_token_jacc
             occurrence_files(cluster).into_iter().collect();
         files.contains("alpha.py") && files.contains("beta.py")
     });
-    let cluster = cross_file.unwrap_or_else(|| {
-        panic!(
+    let Some(cluster) = cross_file else {
+        anyhow::bail!(
             "python-type3 must produce a cross-file cluster spanning alpha.py and beta.py; \
              got clusters: {clusters:#?}"
-        )
-    });
+        );
+    };
     let token_jaccard = signal(cluster, "token_jaccard");
     assert!(
         token_jaccard > 0.0,
@@ -167,7 +172,10 @@ fn python_token_jaccard_is_deterministic_across_runs() -> Result<()> {
         .iter()
         .map(|c| signal(c, "token_jaccard").to_bits())
         .collect();
-    assert!(!jaccards1.is_empty(), "python-small must produce at least one cluster");
+    assert!(
+        !jaccards1.is_empty(),
+        "python-small must produce at least one cluster"
+    );
     assert_eq!(
         jaccards1, jaccards2,
         "token_jaccard values must be bit-identical across runs on the same corpus \

--- a/crates/deslop/tests/python_signatures.rs
+++ b/crates/deslop/tests/python_signatures.rs
@@ -1,0 +1,177 @@
+//! Tests proving that the MinHash signature pipeline works correctly for
+//! Python after the XOF-based fix ([FUSION-SIGNALS-THREE-LAYER]).
+//!
+//! Bug 1 — `minhash_signature` produced 128 separate blake3 calls per
+//! k-gram.  Fixed to use blake3 XOF (one call, 128 slots from extended
+//! output).  These tests fail if the signature path is broken (all-same
+//! values, all-sentinel, or cross-file tree contamination).
+//!
+//! Bug 2 — `tree_for_file` did a linear scan through all trees per
+//! fingerprint.  Fixed by pre-building a `HashMap<FileId, &NormalizedNode>`
+//! once.  A wrong HashMap mapping contaminates token streams; the
+//! cross-file Type-3 assertion catches that.
+
+use std::{fs, path::Path, path::PathBuf};
+
+use anyhow::Result;
+use assert_cmd::Command;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn json_output(tmp: &Path) -> PathBuf {
+    tmp.join("report.json")
+}
+
+fn run_cli(fixture_name: &str, min_nodes: u32) -> Result<serde_json::Value> {
+    let tmp = tempfile::tempdir()?;
+    let out = json_output(tmp.path());
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(fixture(fixture_name))
+        .arg("--min-nodes")
+        .arg(min_nodes.to_string())
+        .arg("--output")
+        .arg(tmp.path().join("report"))
+        .assert()
+        .success();
+    let json = fs::read_to_string(&out)?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+fn clusters(report: &serde_json::Value) -> Vec<&serde_json::Value> {
+    report
+        .pointer("/clusters")
+        .and_then(serde_json::Value::as_array)
+        .map(|v| v.iter().collect())
+        .unwrap_or_default()
+}
+
+fn signal(cluster: &serde_json::Value, key: &str) -> f64 {
+    cluster
+        .pointer(&format!("/signals/{key}"))
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(f64::NAN)
+}
+
+fn occurrence_files(cluster: &serde_json::Value) -> Vec<String> {
+    cluster
+        .pointer("/occurrences")
+        .and_then(serde_json::Value::as_array)
+        .map(|occ| {
+            occ.iter()
+                .filter_map(|o| {
+                    o.get("path")
+                        .and_then(serde_json::Value::as_str)
+                        .map(|p| {
+                            Path::new(p)
+                                .file_name()
+                                .map_or_else(|| p.to_owned(), |n| n.to_string_lossy().into_owned())
+                        })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// [FUSION-SIGNALS-THREE-LAYER] Type-2 Python clones (identical after
+// normalisation) must produce token_jaccard = 1.0 — proves
+// minhash_signature maps identical k-gram sets to identical signatures.
+// If the XOF produces wrong values (e.g. all-MAX sentinel), Jaccard
+// would be 1.0 trivially; the Type-3 test below distinguishes that case.
+#[test]
+fn python_type2_clone_has_token_jaccard_of_one() -> Result<()> {
+    let report = run_cli("python-small", 10)?;
+    let clusters = clusters(&report);
+    assert!(
+        !clusters.is_empty(),
+        "python-small must produce at least one cluster",
+    );
+    let top = clusters[0];
+    let token_jaccard = signal(top, "token_jaccard");
+    assert_eq!(
+        token_jaccard, 1.0,
+        "Type-2 Python clone must have token_jaccard = 1.0 (identical k-gram sets), \
+         got {token_jaccard}"
+    );
+    let structural = signal(top, "structural");
+    assert_eq!(
+        structural, 1.0,
+        "Type-2 Python clone must also have structural = 1.0, got {structural}",
+    );
+    Ok(())
+}
+
+// [FUSION-SIGNALS-THREE-LAYER] Two Python functions sharing structural
+// subtrees (normalised `_ = _ + _` and `if _ < _: return _` patterns)
+// must produce a cross-file cluster with token_jaccard > 0.
+//
+// alpha.py: accumulate() has `running + step` AND `running + 2` per
+// iteration.  beta.py: aggregate() has only `accumulator + cursor`.
+// Despite the whole-function structural difference, small shared
+// subtrees (`_ = _ + _`, `if _ < _: return _`) are structurally
+// identical and their k-grams are compared via minhash_signature.
+//
+// This proves both:
+//   Bug 1: minhash_signature (XOF) produces valid signature values —
+//          a broken implementation (garbage output) would produce
+//          near-zero Jaccard on shared k-gram sets.
+//   Bug 2: build_signatures_with_languages uses the correct tree per
+//          file (HashMap index).  A wrong mapping would give each
+//          fingerprint the wrong token stream, scrambling all Jaccard
+//          values and collapsing the cross-file cluster.
+#[test]
+fn python_multi_file_corpus_produces_cross_file_cluster_with_positive_token_jaccard() -> Result<()>
+{
+    let report = run_cli("python-type3", 8)?;
+    let clusters = clusters(&report);
+    let cross_file = clusters.iter().find(|cluster| {
+        let files: std::collections::BTreeSet<String> =
+            occurrence_files(cluster).into_iter().collect();
+        files.contains("alpha.py") && files.contains("beta.py")
+    });
+    let cluster = cross_file.unwrap_or_else(|| {
+        panic!(
+            "python-type3 must produce a cross-file cluster spanning alpha.py and beta.py; \
+             got clusters: {clusters:#?}"
+        )
+    });
+    let token_jaccard = signal(cluster, "token_jaccard");
+    assert!(
+        token_jaccard > 0.0,
+        "cross-file Python cluster must have token_jaccard > 0.0 \
+         (minhash_signature must produce meaningful signatures for shared subtrees), \
+         got token_jaccard = {token_jaccard}",
+    );
+    Ok(())
+}
+
+// [PIPELINE-DETERMINISM] Running the CLI twice on the same Python corpus
+// must produce identical token_jaccard values — proves minhash_signature
+// (XOF) is deterministic across process restarts.  Any non-determinism
+// in blake3 XOF output or k-gram ordering would cause differing Jaccard
+// values between runs.  Cluster IDs are structural (unaffected by
+// signatures), so checking token_jaccard is the direct proof.
+#[test]
+fn python_token_jaccard_is_deterministic_across_runs() -> Result<()> {
+    let run1 = run_cli("python-small", 10)?;
+    let run2 = run_cli("python-small", 10)?;
+    let jaccards1: Vec<u64> = clusters(&run1)
+        .iter()
+        .map(|c| signal(c, "token_jaccard").to_bits())
+        .collect();
+    let jaccards2: Vec<u64> = clusters(&run2)
+        .iter()
+        .map(|c| signal(c, "token_jaccard").to_bits())
+        .collect();
+    assert!(!jaccards1.is_empty(), "python-small must produce at least one cluster");
+    assert_eq!(
+        jaccards1, jaccards2,
+        "token_jaccard values must be bit-identical across runs on the same corpus \
+         (minhash_signature XOF must be deterministic)",
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
+++ b/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
@@ -1,0 +1,106 @@
+//! Regression test for issue #58: LooselySimilar catch-all surfaces
+//! boilerplate-only test-file matches as top offenders.
+//!
+//! The `deslop-core` test suite (`embedding_pairs.rs`, `report_api.rs`,
+//! `live.rs`) shares test boilerplate (function signatures, assertion
+//! macros, helper patterns) that pushes token Jaccard near 1.0 with
+//! structural ≈ 0.02. That puts their cluster in the
+//! `loosely_similar` bucket. Before the fix these files ranked **#1** in
+//! the report — a cluster the user correctly described as "bullshit."
+//!
+//! Acceptance: scanning the `deslop-core` test directory must not surface
+//! any `loosely_similar` cross-file cluster in the ranked output.
+
+use std::{fs, path::Path, path::PathBuf};
+
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+
+/// Path to the `deslop-core` test directory — the actual source of the
+/// false positive reported in issue #58.
+fn deslop_core_tests() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("deslop-core")
+        .join("tests")
+}
+
+fn run_report(tmp: &Path, scan_root: &Path) -> Result<Value> {
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(scan_root)
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(tmp.join("report"))
+        .assert()
+        .success();
+    let json_path = tmp.join("report.json");
+    let body = fs::read_to_string(&json_path)?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn cluster_bucket(cluster: &Value) -> &str {
+    cluster
+        .get("bucket")
+        .and_then(Value::as_str)
+        .unwrap_or("?")
+}
+
+fn cluster_paths(cluster: &Value) -> Vec<String> {
+    cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(|occurrences| {
+            occurrences
+                .iter()
+                .filter_map(|o| o.get("path").and_then(Value::as_str).map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// Issue #58: test files that share only boilerplate (assert macros, function
+// signatures, helper patterns) must not surface as `loosely_similar` top
+// offenders. The fused gate lets token-only matches through because the
+// additive formula allows token_jaccard alone to clear the threshold. The
+// fix excludes LooselySimilar clusters from the ranked report so users are
+// never misled by boilerplate-only noise at position #1.
+#[test]
+fn rust_test_boilerplate_files_never_surface_as_loosely_similar() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let scan_root = deslop_core_tests();
+    let report = run_report(tmp.path(), &scan_root)?;
+    let clusters = report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let offenders: Vec<String> = clusters
+        .iter()
+        .filter(|c| cluster_bucket(c) == "loosely_similar")
+        .filter(|c| cluster_paths(c).len() >= 2)
+        .map(|c| {
+            let paths = cluster_paths(c);
+            let structural = c
+                .pointer("/signals/structural")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            let token_j = c
+                .pointer("/signals/token_jaccard")
+                .and_then(Value::as_f64)
+                .unwrap_or(0.0);
+            format!(
+                "loosely_similar cluster spans {paths:?} (structural={structural:.3}, \
+                 token_jaccard={token_j:.3})"
+            )
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "test-boilerplate-only matches must not appear as loosely_similar top offenders \
+         (issue #58). Offending clusters: {offenders:#?}"
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
+++ b/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
@@ -42,10 +42,7 @@ fn run_report(tmp: &Path, scan_root: &Path) -> Result<Value> {
 }
 
 fn cluster_bucket(cluster: &Value) -> &str {
-    cluster
-        .get("bucket")
-        .and_then(Value::as_str)
-        .unwrap_or("?")
+    cluster.get("bucket").and_then(Value::as_str).unwrap_or("?")
 }
 
 fn cluster_paths(cluster: &Value) -> Vec<String> {

--- a/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
+++ b/crates/deslop/tests/rust_test_boilerplate_false_positive.rs
@@ -1,4 +1,4 @@
-//! Regression test for issue #58: LooselySimilar catch-all surfaces
+//! Regression test for issue #58: `LooselySimilar` catch-all surfaces
 //! boilerplate-only test-file matches as top offenders.
 //!
 //! The `deslop-core` test suite (`embedding_pairs.rs`, `report_api.rs`,

--- a/docs/plans/deployment-toolkit-migration-plan.md
+++ b/docs/plans/deployment-toolkit-migration-plan.md
@@ -129,7 +129,8 @@ Wire the release path so deployment drift fails before publish:
   `deslop-mcp`.
 - LSP and MCP initialize metadata verification.
 - VSIX package contents verification.
-- JetBrains package contents verification.
+- JetBrains package contents verification (implemented but temporarily
+  deferred to GitHub #55 pending the Gradle validation work in GitHub #56).
 
 Use shared `deploy-toolkit` commands when available. Until they are published,
 add product-local tests that prove the same behavior.
@@ -146,34 +147,37 @@ need authenticated `gh` access for referenced docs and fixture updates.
 
 ## TODO
 
-- [ ] Fetch and re-read all five GitHub issues plus private Deployment Toolkit
+- [x] Fetch and re-read all five GitHub issues plus private Deployment Toolkit
       docs before implementation.
-- [ ] Compare local `deployment-toolkit.json` with private
+- [x] Compare local `deployment-toolkit.json` with private
       `fixtures/manifests/deslop.json` and reconcile drift.
-- [ ] Add failing tests for `deslop`, `deslop-lsp`, and `deslop-mcp` plain
+- [x] Add failing tests for `deslop`, `deslop-lsp`, and `deslop-mcp` plain
       version output.
-- [ ] Add failing tests for `--version --json` schema output for all three
+- [x] Add failing tests for `--version --json` schema output for all three
       binaries.
-- [ ] Implement version flags before any runtime startup or workspace parsing.
-- [ ] Add LSP initialize metadata tests for `deslop-lsp`.
-- [ ] Add MCP initialize metadata tests for `deslop-mcp`.
-- [ ] Replace VS Code binary resolution with manifest-backed startup
+- [x] Implement version flags before any runtime startup or workspace parsing.
+- [x] Add LSP initialize metadata tests for `deslop-lsp`.
+- [x] Add MCP initialize metadata tests for `deslop-mcp`.
+- [x] Replace VS Code binary resolution with manifest-backed startup
       verification for `deslop-lsp` and `deslop-mcp`.
-- [ ] Add VS Code resolver tests for user setting, env path, env directory,
+- [x] Add VS Code resolver tests for user setting, env path, env directory,
       PATH fallback, bundled success, missing binary, component mismatch, and
       version mismatch.
-- [ ] Ensure VSIX packaging includes `deployment-toolkit.json` at extension
+- [x] Ensure VSIX packaging includes `deployment-toolkit.json` at extension
       root.
-- [ ] Add generated `.vsix` archive verification for manifest-listed binaries
+- [x] Add generated `.vsix` archive verification for manifest-listed binaries
       and undeclared executables.
-- [ ] Update JetBrains packaging to include `deployment-toolkit.json` at plugin
+- [x] Update JetBrains packaging to include `deployment-toolkit.json` at plugin
       root.
-- [ ] Add JetBrains resolver checks before LSP descriptor startup.
-- [ ] Add JetBrains tests for env directory, PATH, bundled, missing, mismatch,
+- [x] Add JetBrains resolver checks before LSP descriptor startup.
+- [x] Add JetBrains tests for env directory, PATH, bundled, missing, mismatch,
       and notification/Event Log behavior.
-- [ ] Add CI gates for manifest validation and built binary version checks.
-- [ ] Add CI gates for VSIX and JetBrains package verification.
-- [ ] Update private Deployment Toolkit fixtures and Deslop migration docs when
-      the product contract changes.
-- [ ] Update release/publish docs with private Deployment Toolkit access
+- [x] Add CI gates for manifest validation and built binary version checks.
+- [x] Add CI gates for VSIX package verification.
+- [ ] Re-enable JetBrains package archive verification in `make
+      jetbrains-package` (GitHub #55).
+- [ ] Restore a reliable local JetBrains Gradle validation path (GitHub #56).
+- [x] Inspect private Deployment Toolkit fixtures and Deslop migration docs;
+      no product manifest drift required.
+- [x] Update release/publish docs with private Deployment Toolkit access
       requirements.

--- a/docs/plans/deployment-toolkit-migration-plan.md
+++ b/docs/plans/deployment-toolkit-migration-plan.md
@@ -138,6 +138,65 @@ add product-local tests that prove the same behavior.
 Release/publish docs must state that Deployment Toolkit is private and agents
 need authenticated `gh` access for referenced docs and fixture updates.
 
+## Critical Invariants — Never Break These
+
+The following rules are non-negotiable. Every future Deployment Toolkit migration,
+test harness change, or CI update must preserve them. Violations here have
+historically been subtle (tests passing green while testing the wrong binary) and
+are therefore called out explicitly.
+
+### Rule 1: Binaries must be bundled inside the extension package
+
+Every extension that requires `deslop-lsp` or `deslop-mcp` must bundle those
+binaries inside the extension archive for every supported platform. A platform that
+lacks a bundled binary fails with a hard error at activation — it does not silently
+fall back to PATH. This is enforced by:
+
+- `_vsix-stage-bundled-binaries` (Makefile) — copies `target/release/deslop-lsp`
+  and `target/release/deslop-mcp` into `clients/vscode/bin/<platform>/` before
+  packaging and before running any VSIX tests.
+- `scripts/verify-vsix-package.mjs` — extracts the `.vsix` archive, verifies each
+  `activationVerifies` binary is present and executable, and runs `--version` on
+  the extracted binary to confirm its identity.
+- `BundledBinaryMissingError` in `binary.ts` — the resolver throws this error with
+  `hardFailure: true`, so there is no path-fallback when the bundled binary is
+  absent.
+
+### Rule 2: Extension tests must use the bundled binary, not target/release or PATH
+
+The resolver priority chain is:
+`user-setting → env-path → env-dir (DESLOP_BINARY_DIR) → bundled → path`
+
+`env-dir` is position 3 and beats `bundled` at position 4. Setting
+`DESLOP_BINARY_DIR` in the test environment to `target/release` (or any directory
+other than the staged extension bin) bypasses the bundled path entirely and makes
+tests meaningless for proving deployment correctness.
+
+**The law:**
+
+- `.vscode-test.mjs` must clear `DESLOP_BINARY_DIR: ""`, `DESLOP_LSP_PATH: ""`,
+  and `DESLOP_MCP_PATH: ""` so the resolver reaches the `bundled` candidate.
+- `_vsix-stage-bundled-binaries` must run before every `vsix-test`, `vsix-coverage`,
+  and `vsix-package` invocation so the staged binaries exist.
+- At least one E2E test must assert `resolvedLsp.source === "bundled"` and
+  `resolvedMcp.source === "bundled"` via the `ExtensionApi` returned by
+  `activate()`. This assertion is in `bubble.e2e.test.ts`.
+
+### Rule 3: make test must eliminate PATH-installed binaries before running
+
+`delete-path-binaries` (called by `make test`, `make vsix-test`, `make vsix-coverage`,
+and `make vsix-package`) removes cargo-installed copies of `deslop`, `deslop-lsp`,
+and `deslop-mcp` from `~/.cargo/bin`. It then checks `command -v <binary>` and
+fails the build if any binary is still reachable from PATH, EXCEPT binaries found
+inside a VS Code or Cursor extension directory (`*/.vscode/extensions/*` etc.) —
+those are extension-bundled copies that the resolver's `bundled` candidate already
+beats.
+
+If this target is ever changed to a no-op, softer check, or exception-added, the
+author must update this section with a dated rationale.
+
+---
+
 ## Open Decisions
 
 - Whether `--version --format json` should be accepted as an alias for the
@@ -167,6 +226,10 @@ need authenticated `gh` access for referenced docs and fixture updates.
       root.
 - [x] Add generated `.vsix` archive verification for manifest-listed binaries
       and undeclared executables.
+- [x] Force VSIX tests to stage and resolve bundled extension binaries instead
+      of `target/release` or PATH-installed binaries.
+- [x] Make test entry points scrub installed Deslop binaries from PATH before
+      tests run.
 - [x] Update JetBrains packaging to include `deployment-toolkit.json` at plugin
       root.
 - [x] Add JetBrains resolver checks before LSP descriptor startup.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,6 +11,11 @@ make vsix-package
 make jetbrains-package
 ```
 
+Test entry points remove cargo-installed `deslop`, `deslop-lsp`, and
+`deslop-mcp` binaries before running. VSIX tests stage the release binaries
+inside `clients/vscode/bin/<platform>/` and clear resolver override
+environment variables so activation proves the extension bundle, not PATH.
+
 `make jetbrains-package` currently builds the JetBrains plugin zip without the
 product-local archive verifier. Re-enable `scripts/verify-jetbrains-package.mjs`
 through GitHub #55 after the local JetBrains Gradle validation path in GitHub

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,31 @@
+# Release Gates
+
+Deslop uses `deployment-toolkit.json` as the source of truth for release
+artifacts and IDE startup checks.
+
+Before publishing, run:
+
+```bash
+make deployment-verify
+make vsix-package
+make jetbrains-package
+```
+
+`make jetbrains-package` currently builds the JetBrains plugin zip without the
+product-local archive verifier. Re-enable `scripts/verify-jetbrains-package.mjs`
+through GitHub #55 after the local JetBrains Gradle validation path in GitHub
+#56 is reliable.
+
+The shared Deployment Toolkit repository is private:
+`MelbourneDeveloper/deployment_toolkit`. Agents working from Deployment Toolkit
+migration issues must use authenticated `gh` access before relying on its docs
+or fixtures:
+
+```bash
+gh auth status
+gh repo view MelbourneDeveloper/deployment_toolkit --json nameWithOwner,isPrivate,url,defaultBranchRef
+```
+
+When Deslop changes its deployment contract, update the private toolkit fixtures
+for `fixtures/manifests/deslop.json` and the Rust version-output fixtures in the
+same release workflow.

--- a/docs/specs/deployment.md
+++ b/docs/specs/deployment.md
@@ -109,6 +109,24 @@ directory. They must fail on a missing manifest, missing binary, extra binary,
 non-executable binary where executability is meaningful, or wrong-version
 binary.
 
+### [DEPLOY-EXTENSION-BUNDLED-TESTS] Extension tests must use bundled binaries
+
+IDE extension tests must run against binaries bundled inside the extension
+artifact or extension development directory. They must not point resolver
+environment variables at `target/release`, cargo installs, package-manager
+installs, or any other PATH-visible binary.
+
+For VS Code, `vsix-test`, `vsix-coverage`, and `vsix-test-ollama` must stage
+`deslop`, `deslop-lsp`, and `deslop-mcp` under
+`clients/vscode/bin/<platform>/` before activation, clear
+`DESLOP_BINARY_DIR`, `DESLOP_LSP_PATH`, and `DESLOP_MCP_PATH`, and assert that
+the resolved LSP and MCP sources are `bundled`.
+
+Before test entry points run, the build must remove cargo-installed Deslop
+binaries and fail if `deslop`, `deslop-lsp`, or `deslop-mcp` still resolve on
+`PATH`. This keeps extension tests honest: a missing or stale bundle cannot be
+masked by a developer machine install.
+
 ### [DEPLOY-JETBRAINS-PACKAGE] JetBrains package contract
 
 The JetBrains plugin package must include `deployment-toolkit.json` at plugin

--- a/docs/specs/vsix.md
+++ b/docs/specs/vsix.md
@@ -88,6 +88,23 @@ If the verified bundled directory is selected, the extension may prepend that di
 
 Activation binaries are resolved once per session; a `Deslop: Reveal Active Binary` command (under [VSIX-COMMANDS]) shows the path, source, component id, and version that were accepted so a user debugging a mismatch can see the resolver result without reading logs. Package verification is covered by [DEPLOY-VSIX-PACKAGE] and release gates by [DEPLOY-CI-GATES].
 
+#### [VSIX-BUNDLED-BINARY-TESTS] Extension tests use the bundle
+
+VSIX tests must exercise the same binary layout the installed extension uses:
+`${extensionPath}/bin/${platform}/`. Test configuration must not point
+`DESLOP_BINARY_DIR`, `DESLOP_LSP_PATH`, or `DESLOP_MCP_PATH` at
+`target/release`, `~/.cargo/bin`, Homebrew, Scoop, or any other external
+install. The Makefile stages the release binaries into the extension bundle
+before `vsix-test`, `vsix-coverage`, and `vsix-test-ollama` run, then clears
+the override environment variables in the VS Code test host.
+
+Before test entry points run, installed `deslop`, `deslop-lsp`, and
+`deslop-mcp` binaries are removed from the cargo install path and the build
+fails if any of those commands still resolve on `PATH`. A passing extension
+test must prove `resolvedLsp.source = "bundled"` and
+`resolvedMcp.source = "bundled"` so a stale machine-level install cannot hide a
+broken VSIX package.
+
 ### [VSIX-ACTIVATION] Activation
 
 Activation events:

--- a/scripts/verify-deployment-binaries.mjs
+++ b/scripts/verify-deployment-binaries.mjs
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const manifestPath = resolveArg(process.argv[2] ?? "deployment-toolkit.json");
+const binDir = resolveArg(process.argv[3] ?? "target/release");
+const platform = process.argv[4] ?? currentPlatform();
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+for (const component of executableComponents(manifest)) verifyComponent(component);
+
+console.log(`Verified deployment binaries in ${binDir} for ${platform}`);
+
+function verifyComponent(component) {
+  const binaryPath = join(binDir, nameWithSuffix(component));
+  if (!existsSync(binaryPath)) throw new Error(`Missing ${component.id} at ${binaryPath}`);
+  assertExecutable(binaryPath);
+  assertPlainVersion(binaryPath, component);
+  assertJsonVersion(binaryPath, component);
+}
+
+function assertPlainVersion(binaryPath, component) {
+  const first = firstLine(run(binaryPath, ["--version"]));
+  const expected = `${component.id} ${component.expectedVersion}`;
+  if (first !== expected) throw new Error(`${binaryPath} reported ${first}; expected ${expected}`);
+}
+
+function assertJsonVersion(binaryPath, component) {
+  const value = JSON.parse(run(binaryPath, ["--version", "--json"]));
+  assertEqual(value.manifestVersion, 1, `${component.id}.manifestVersion`);
+  assertEqual(value.name, component.id, `${component.id}.name`);
+  assertEqual(value.version, component.expectedVersion, `${component.id}.version`);
+  assertEqual(value.kind, component.kind, `${component.id}.kind`);
+  assertEqual(value.language, component.language, `${component.id}.language`);
+  assertEqual(value.product, manifest.product.id, `${component.id}.product`);
+}
+
+function run(binaryPath, args) {
+  const result = spawnSync(binaryPath, args, { encoding: "utf8", timeout: 1500 });
+  if (result.status !== 0) throw new Error(`${binaryPath} ${args.join(" ")} failed`);
+  return String(result.stdout);
+}
+
+function executableComponents(manifest) {
+  return (manifest.components ?? [])
+    .filter((component) => ["cli", "lsp", "mcp"].includes(component.kind))
+    .filter((component) => component.required !== false);
+}
+
+function assertExecutable(binaryPath) {
+  if (platform.startsWith("win32")) return;
+  if ((statSync(binaryPath).mode & 0o111) === 0) throw new Error(`${binaryPath} is not executable`);
+}
+
+function firstLine(text) {
+  const end = text.indexOf("\n");
+  const line = end >= 0 ? text.slice(0, end) : text;
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label} must be ${expected}; got ${actual}`);
+}
+
+function nameWithSuffix(component) {
+  return `${component.binaryName}${platform.startsWith("win32") ? ".exe" : ""}`;
+}
+
+function resolveArg(value) {
+  return isAbsolute(value) ? value : resolve(value);
+}
+
+function currentPlatform() {
+  if (process.platform === "darwin" && process.arch === "arm64") return "darwin-arm64";
+  if (process.platform === "darwin" && process.arch === "x64") return "darwin-x64";
+  if (process.platform === "linux" && process.arch === "x64") return "linux-x64";
+  if (process.platform === "linux" && process.arch === "arm64") return "linux-arm64";
+  if (process.platform === "win32" && process.arch === "x64") return "win32-x64";
+  throw new Error(`unsupported platform ${process.platform}-${process.arch}`);
+}

--- a/scripts/verify-deployment-manifest.mjs
+++ b/scripts/verify-deployment-manifest.mjs
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+
+const manifestArg = process.argv[2] ?? "deployment-toolkit.json";
+const manifestPath = isAbsolute(manifestArg) ? manifestArg : resolve(manifestArg);
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+assertEqual(manifest.manifestVersion, 1, "manifestVersion");
+assertString(manifest.product?.id, "product.id");
+assertSemver(manifest.product?.version, "product.version");
+assertArray(manifest.components, "components");
+
+const componentIds = new Set();
+for (const component of manifest.components) verifyComponent(component, componentIds);
+for (const [hostName, host] of Object.entries(manifest.hosts ?? {})) {
+  verifyHost(hostName, host, componentIds);
+}
+
+console.log(`${manifestPath}: valid deployment manifest`);
+
+function verifyComponent(component, componentIds) {
+  assertString(component.id, "component.id");
+  if (componentIds.has(component.id)) throw new Error(`duplicate component id ${component.id}`);
+  componentIds.add(component.id);
+  assertString(component.kind, `${component.id}.kind`);
+  assertString(component.language, `${component.id}.language`);
+  assertSemver(component.expectedVersion, `${component.id}.expectedVersion`);
+  if (["cli", "lsp", "mcp"].includes(component.kind)) {
+    assertString(component.binaryName, `${component.id}.binaryName`);
+    assertEqual(component.versionCheckStrategy, "version-flag", `${component.id}.versionCheckStrategy`);
+  }
+}
+
+function verifyHost(hostName, host, componentIds) {
+  assertArray(host.activationVerifies, `${hostName}.activationVerifies`);
+  for (const id of host.activationVerifies) {
+    if (!componentIds.has(id)) throw new Error(`${hostName} verifies unknown component ${id}`);
+  }
+}
+
+function assertString(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a string`);
+}
+
+function assertArray(value, label) {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label} must be ${expected}; got ${actual}`);
+}
+
+function assertSemver(value, label) {
+  assertString(value, label);
+  const parts = value.split(".");
+  if (parts.length !== 3 || parts.some((part) => !allDigits(part))) {
+    throw new Error(`${label} must be a semantic version`);
+  }
+}
+
+function allDigits(value) {
+  return value.length > 0 && [...value].every((char) => char >= "0" && char <= "9");
+}

--- a/scripts/verify-jetbrains-package.mjs
+++ b/scripts/verify-jetbrains-package.mjs
@@ -1,0 +1,108 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, isAbsolute, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const packageArg = process.argv[2] ?? latestPackage();
+const packagePath = isAbsolute(packageArg) ? packageArg : resolve(packageArg);
+const platform = process.argv[3] ?? currentPlatform();
+const entries = unzipText(["-Z1", packagePath]).split("\n").filter(Boolean);
+const root = packageRoot(entries);
+const manifestEntry = `${root}/deployment-toolkit.json`;
+
+assertEntry(entries, manifestEntry);
+
+const manifest = JSON.parse(unzipText(["-p", packagePath, manifestEntry]));
+const component = componentById(manifest, "deslop-lsp");
+const lspEntry = `${root}/bin/${platform}/${nameWithSuffix(component)}`;
+assertEntry(entries, lspEntry);
+verifyBundledEntry(lspEntry, component);
+
+for (const entry of binEntries(entries, root)) {
+  if (!componentForEntry(entry, manifest)) throw new Error(`Undeclared JetBrains binary: ${entry}`);
+}
+
+console.log(`Verified JetBrains package ${packagePath} for ${platform}`);
+
+function verifyBundledEntry(entry, component) {
+  const temp = mkdtempSync(join(tmpdir(), "deslop-jetbrains-"));
+  try {
+    unzipText(["-q", packagePath, entry, "-d", temp]);
+    const binaryPath = join(temp, entry);
+    assertExecutable(binaryPath);
+    assertVersion(binaryPath, component);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+function assertVersion(binaryPath, component) {
+  const result = spawnSync(binaryPath, ["--version"], { encoding: "utf8", timeout: 1500 });
+  if (result.status !== 0) throw new Error(`${binaryPath} --version failed`);
+  const expected = `${component.id} ${component.expectedVersion}`;
+  const actual = firstLine(String(result.stdout));
+  if (actual !== expected) throw new Error(`${binaryPath} reported ${actual}; expected ${expected}`);
+}
+
+function latestPackage() {
+  const dir = resolve("clients/jetbrains/build/distributions");
+  const zips = existsSync(dir) ? readdirSync(dir).filter((name) => name.endsWith(".zip")) : [];
+  if (zips.length === 0) throw new Error(`No JetBrains package zip found under ${dir}`);
+  return join(dir, zips.sort().at(-1));
+}
+
+function packageRoot(entries) {
+  const root = entries[0]?.split("/")[0];
+  if (!root) throw new Error("JetBrains package is empty");
+  return root;
+}
+
+function componentById(manifest, id) {
+  const component = (manifest.components ?? []).find((candidate) => candidate.id === id);
+  if (!component) throw new Error(`Manifest is missing ${id}`);
+  return component;
+}
+
+function componentForEntry(entry, manifest) {
+  const fileName = basename(entry);
+  return (manifest.components ?? []).find((component) => nameWithSuffix(component) === fileName);
+}
+
+function binEntries(entries, root) {
+  const prefix = `${root}/bin/${platform}/`;
+  return entries.filter((entry) => entry.startsWith(prefix) && !entry.endsWith("/"));
+}
+
+function assertExecutable(binaryPath) {
+  if (platform.startsWith("win32")) return;
+  if ((statSync(binaryPath).mode & 0o111) === 0) throw new Error(`${binaryPath} is not executable`);
+}
+
+function assertEntry(entries, entry) {
+  if (!entries.includes(entry)) throw new Error(`Missing ${entry} in ${packagePath}`);
+}
+
+function unzipText(args) {
+  const result = spawnSync("unzip", args, { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`unzip failed: ${String(result.stderr)}`);
+  return String(result.stdout);
+}
+
+function nameWithSuffix(component) {
+  return `${component.binaryName}${platform.startsWith("win32") ? ".exe" : ""}`;
+}
+
+function firstLine(text) {
+  const end = text.indexOf("\n");
+  const line = end >= 0 ? text.slice(0, end) : text;
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+function currentPlatform() {
+  if (process.platform === "darwin" && process.arch === "arm64") return "darwin-arm64";
+  if (process.platform === "darwin" && process.arch === "x64") return "darwin-x64";
+  if (process.platform === "linux" && process.arch === "x64") return "linux-x64";
+  if (process.platform === "linux" && process.arch === "arm64") return "linux-arm64";
+  if (process.platform === "win32" && process.arch === "x64") return "win32-x64";
+  throw new Error(`unsupported platform ${process.platform}-${process.arch}`);
+}


### PR DESCRIPTION
<!-- agent-pmo:9a71cbf -->
## TLDR
Adds deployment-toolkit backed binary verification across CI, VSIX, JetBrains, and Deslop binaries while tightening clone reporting and live update behavior.

## Details
- Adds CI and Makefile release gates for `make deployment-verify`, `make vsix-package`, and `make jetbrains-package`, plus `delete-path-binaries` so extension tests cannot pass by resolving cargo-installed `deslop`, `deslop-lsp`, or `deslop-mcp` from PATH.
- Adds `scripts/verify-deployment-manifest.mjs`, `scripts/verify-deployment-binaries.mjs`, `clients/vscode/scripts/verify-vsix-package.mjs`, and `scripts/verify-jetbrains-package.mjs` to validate `deployment-toolkit.json`, executable presence, executable bits, and plain/JSON `--version` contracts.
- Adds `deslop-core::version_contract` and wires exact plain and JSON version output through `deslop`, `deslop-lsp`, and `deslop-mcp`; LSP/MCP initialize metadata now reports version `0.1.0`.
- Replaces VS Code binary resolution with manifest-backed host verification in `clients/vscode/src/binary.ts`, including user setting, env path, env directory, bundled, and PATH candidates. Configured/bundled mismatches are hard activation failures; PATH mismatches can fall back to bundled binaries.
- Updates VSIX startup/test packaging so `.vscode-test*.mjs` clears binary override env vars, VSIX tests assert bundled `resolvedLsp`/`resolvedMcp`, package verification checks `deployment-toolkit.json`, and `deslop.compareOccurrenceWithCanonical` compares occurrence tree rows against their canonical occurrence.
- Adds JetBrains manifest-backed `deslop-lsp` resolution, startup error notification, Gradle packaging of `deployment-toolkit.json` and the LSP binary, and resolver tests for env mismatch, bundled success, missing binary, and component mismatch.
- Changes `deslop-core` MinHash and fallback signatures to use blake3 XOF and indexes normalized trees by `FileId` in `build_signatures_with_languages`, covering [FUSION-SIGNALS-THREE-LAYER] and [PIPELINE-DETERMINISM].
- Changes report rendering so token-only `LooselySimilar` clusters are hidden from the ranked human-facing report, addressing issue #58, and Type-2 normalized clones no longer receive Type-1 “every copy is the same” extraction guidance for [CLONE-BUCKETS-DUAL-LABEL] and [AUTOFIX-EXTRACT-DEPENDENCIES].
- Adds LSP incremental mode by default, pushes `deslop/reportChanged` notifications, and adds `deslop/reportDelta` so clients can fetch deltas after a generation changes.
- Splits CLI output and rerun helpers into `crates/deslop/src/output.rs` and `crates/deslop/src/rerun.rs`.
- Updates deployment and VSIX specs with [DEPLOY-EXTENSION-BUNDLED-TESTS] and [VSIX-BUNDLED-BINARY-TESTS], adds `docs/release.md`, and records remaining JetBrains verifier work as GitHub #55/#56.
- Breaking/behavior changes: IDE activation now rejects explicitly configured or bundled binaries that do not match `deployment-toolkit.json`; VSIX tests no longer use `target/release` via `DESLOP_BINARY_DIR`; ranked reports no longer surface `loosely_similar` boilerplate-only clusters.

Closes #42.
Closes #58.
Refs #55.
Refs #56.

## How Do The Automated Tests Prove It Works?
- `crates/deslop/tests/python_signatures.rs` proves [FUSION-SIGNALS-THREE-LAYER] by asserting Python Type-2 clones produce `token_jaccard == 1.0`, Python Type-3 fixture clones produce positive cross-file token Jaccard, and repeated runs produce bit-identical token Jaccard values.
- `crates/deslop/tests/csharp_type1_type2_distinct_buckets.rs` proves issue #42 by comparing `csharp-small` Type-2 output against `csharp-type1` byte-identical output and asserting only true Type-1 clones claim every copy is the same.
- `crates/deslop/tests/rust_test_boilerplate_false_positive.rs` proves issue #58 by scanning the real `deslop-core` test directory and asserting no cross-file `loosely_similar` boilerplate cluster appears in ranked output.
- `crates/deslop-lsp/tests/notifications.rs::report_changed_fires_for_pure_removal_delta` proves a pure-removal edit emits `deslop/reportChanged` and that `deslop/reportDelta` returns removed cluster ids.
- `crates/deslop-lsp/tests/cli.rs`, `crates/deslop-mcp/tests/cli.rs`, and `crates/deslop/tests/cli.rs` prove every binary emits exact plain and JSON version contracts and that LSP/MCP initialize responses expose server version metadata.
- `clients/vscode/src/test/unit/binary.unit.test.ts`, `clients/vscode/src/test/suite/bubble.e2e.test.ts`, and `clients/vscode/scripts/verify-vsix-package.mjs` prove VS Code activation uses bundled binaries, rejects configured/bundled mismatches, falls back from stale PATH binaries, and packages verifiable manifest-listed executables.
- `clients/jetbrains/src/test/kotlin/com/nimblesite/deslop/jetbrains/DeslopBinaryResolverTest.kt` proves JetBrains startup rejects env mismatches, ignores stale PATH when bundled is valid, accepts bundled `deslop-lsp`, and reports missing/component-mismatched binaries.
