### PR TITLE
fix: 5 showstoppers (#153, #154, #156, #115, #97)

### DIFF
--- a/crates/deslop-core/src/cluster_filters/mod.rs
+++ b/crates/deslop-core/src/cluster_filters/mod.rs
@@ -52,6 +52,28 @@
 //! - **#147** — `xs.iter().map(|x| x.field.as_str()).collect()` is a
 //!   pure language idiom that clusters across unrelated element types.
 //!   Extracting it would require a cross-crate trait, not deduplication.
+//! - **#115a** [CLONE-NOISE-PY-STRENUM-CLASS-SHAPE] — `class X(StrEnum)`
+//!   declarations carry an identical docstring + assignment body shape
+//!   but each enum is a closed discriminator with distinct vocabulary.
+//! - **#115b** [CLONE-NOISE-PY-PYDANTIC-PARTIAL] — Pydantic's
+//!   `XCreate` / `XUpdate` mirror is mandated by the framework's lack
+//!   of a native `PartialModel`.
+//! - **#115c** [CLONE-NOISE-PY-WORKSPACE-LOCAL-MIRROR] — out of scope
+//!   for a generic filter. The cross-tree duplication between
+//!   `src/agent_backend/api/schemas.py` and a sandboxed
+//!   `workspaces/.../dispatcher.py` is mandated by the workspace's
+//!   inability to import from the backend. The architectural intent
+//!   is invisible to the analyser, so users suppress the FP via
+//!   `.deslop.toml` `[language.python] exclude = ["workspaces/.../*"]`
+//!   (the existing config exclude already supports this).
+//! - **#97**  [CLONE-NOISE-PY-PARAMETRIC-INVARIANT-TESTS] — `def
+//!   test_register_<variant>()` tests that vary only by enum-member
+//!   access tokens are spec assertions, not extractable duplication.
+//! - **#154** [CLONE-NOISE-SIGNATURE-ONLY] — every cluster member's
+//!   matched subtree is the *signature* (parameter list, return type) of
+//!   a function, never the body. After normalisation these collapse to
+//!   identical shape but the bodies are unrelated. Token Jaccard cannot
+//!   refute the match because identifiers normalise away too.
 //!
 //! The filter is purely additive: it never re-routes a `nearly_identical`
 //! cluster as `identical`, only suppresses noise. Any cluster whose
@@ -60,6 +82,7 @@
 
 mod calls;
 mod python;
+mod python_class_shapes;
 mod python_idioms;
 mod python_orm;
 mod rust;
@@ -88,6 +111,7 @@ pub(crate) fn is_noise_pattern<S: BuildHasher>(
         return false;
     };
     is_polymorphic_signature_cluster(&snippets)
+        || is_signature_only_cluster(&snippets)
         || rust::is_rust_language_parser_adapter_cluster(&snippets)
         || python_idioms::is_generated_template_output_cluster(&snippets)
         || python_idioms::is_jwt_hmac_independent_verifier_cluster(&snippets)
@@ -100,6 +124,9 @@ pub(crate) fn is_noise_pattern<S: BuildHasher>(
         || python_orm::is_sqlalchemy_mapped_column_cluster(&snippets)
         || python::is_test_dict_literal_cluster(&snippets)
         || python::is_pytest_fixture_boilerplate_cluster(&snippets)
+        || python_class_shapes::is_strenum_class_shape_cluster(&snippets)
+        || python_class_shapes::is_pydantic_partial_update_cluster(&snippets)
+        || python::is_parametric_invariant_test_cluster(&snippets)
         || rust::is_rust_top_level_decl_cluster(&snippets)
         || rust::is_rust_iter_collect_idiom_cluster(&snippets)
 }
@@ -218,6 +245,72 @@ fn collect_snippets<'a>(
             })
         })
         .collect()
+}
+
+/// Detects **issue #154** [CLONE-NOISE-SIGNATURE-ONLY]: every cluster
+/// member's matched subtree sits entirely inside a function/method
+/// signature — it does not overlap the body. After identifier and
+/// literal normalisation, `fn check_foo(ctx: &mut Ctx)` collapses to
+/// the same shape as `fn check_bar(ctx: &mut Ctx)`, so the structural
+/// fingerprint is 1.0 but the function bodies are unrelated. Token
+/// Jaccard cannot refute the match because identifier normalisation
+/// erases the distinguishing tokens too.
+///
+/// We suppress these clusters only when at least two of the enclosing
+/// function bodies differ in raw source bytes. A real Type-2 clone
+/// where two functions share the same signature and body would have
+/// identical body bytes, so this check keeps genuine duplication.
+fn is_signature_only_cluster(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 {
+        return false;
+    }
+    let shapes: Option<Vec<Vec<String>>> = snippets
+        .iter()
+        .map(snippet_body_shape_when_signature_only)
+        .collect();
+    let Some(shapes) = shapes else { return false };
+    let Some(first) = shapes.first() else {
+        return false;
+    };
+    shapes.iter().any(|shape| shape != first)
+}
+
+/// Returns the enclosing function body's AST node-kind sequence when
+/// `snippet.range` lies entirely inside that function's signature
+/// (before the body) — the signature-only match condition for
+/// [CLONE-NOISE-SIGNATURE-ONLY]. The node-kind sequence is the
+/// flattened, ordered list of every named descendant's kind so two
+/// bodies that share AST shape (and differ only by literals/identifiers)
+/// compare equal — i.e. a legitimate near-miss cluster keeps clustering.
+/// Returns `None` when the snippet is not contained in a function, when
+/// the function has no `body` field, or when the range intersects the
+/// body in any way.
+fn snippet_body_shape_when_signature_only(snippet: &Snippet<'_>) -> Option<Vec<String>> {
+    let tree = parse_for(snippet)?;
+    let function = enclosing_kind(
+        tree.root_node(),
+        snippet.range,
+        function_kinds(snippet.language),
+    )?;
+    let body = function.child_by_field_name("body")?;
+    if snippet.range.end > body.start_byte() {
+        return None;
+    }
+    let mut kinds: Vec<String> = Vec::new();
+    collect_named_kinds(body, &mut kinds);
+    Some(kinds)
+}
+
+/// Pushes every named descendant's `kind` into `kinds` in source order.
+/// Used by [`snippet_body_shape_when_signature_only`] so cluster members
+/// whose bodies share AST shape compare equal regardless of literal or
+/// identifier divergence.
+fn collect_named_kinds(node: Node<'_>, kinds: &mut Vec<String>) {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        kinds.push(child.kind().to_owned());
+        collect_named_kinds(child, kinds);
+    }
 }
 
 /// Detects **issue #69**: every cluster member is a function definition

--- a/crates/deslop-core/src/cluster_filters/python.rs
+++ b/crates/deslop-core/src/cluster_filters/python.rs
@@ -13,6 +13,8 @@
 //! - **#112** [CLONE-NOISE-PY-DICT-FIXTURE] — small nested-dict literals
 //!   across pytest fixture files.
 //! - **#121** [CLONE-NOISE-PY-PYTEST-FIXTURE] — pytest fixture boilerplate.
+//! - **#97**  [CLONE-NOISE-PY-PARAMETRIC-INVARIANT-TESTS] — `test_*`
+//!   bodies that vary only by enum-member access (`X.K8S` vs `X.DOCKER`).
 
 use std::collections::BTreeSet;
 
@@ -380,4 +382,122 @@ fn dict_literal_key_sets_differ(shapes: &[DictLiteralShape]) -> bool {
         return false;
     };
     shapes.iter().any(|shape| shape.keys != first.keys)
+}
+
+/// Detects **issue #97**: every cluster occurrence is fully enclosed by
+/// a `test_*` pytest function AND every occurrence contains at least
+/// one `Capitalised.UPPER_SNAKE` enum-member access token. Each test
+/// name records a distinct spec assertion; collapsing the cluster would
+/// silently lose coverage granularity even when the Type-2 normalised
+/// bodies are identical across unrelated discriminators.
+pub(super) fn is_parametric_invariant_test_cluster(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 || !snippets.iter().all(|snippet| snippet.language == "python") {
+        return false;
+    }
+    snippets.iter().all(snippet_inside_parametric_test)
+}
+
+/// Returns true when `snippet` lives inside a pytest `test_*` function
+/// AND its byte range carries at least one `Capitalised.UPPER_SNAKE`
+/// enum-member access token. The enum signal guards against suppressing
+/// genuine non-parametric copy-paste inside test files.
+fn snippet_inside_parametric_test(snippet: &Snippet<'_>) -> bool {
+    let Some(tree) = parse_for(snippet) else {
+        return false;
+    };
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let Some(function) = enclosing_kind(tree.root_node(), range, &["function_definition"]) else {
+        return false;
+    };
+    if !python_function_name_starts_with(function, snippet.source, b"test_") {
+        return false;
+    }
+    let Some(text) = snippet.source.get(range.start..range.end) else {
+        return false;
+    };
+    contains_enum_member_access_token(text)
+}
+
+/// Returns true when `text` contains at least one `Capitalised.UPPER_SNAKE`
+/// token (e.g. `Kind.K8S`). Scans bytes only — never regex on source.
+fn contains_enum_member_access_token(text: &[u8]) -> bool {
+    (0..text.len()).any(|index| consume_enum_access_at(text, index).is_some())
+}
+
+/// Tries to consume a `Capitalised.UPPER_SNAKE` token at `index`,
+/// returning the number of bytes consumed when matched.
+fn consume_enum_access_at(body: &[u8], index: usize) -> Option<usize> {
+    if !at_token_boundary(body, index) {
+        return None;
+    }
+    let prefix_len = identifier_run_len(body, index)?;
+    if !ident_starts_capitalised(body, index) {
+        return None;
+    }
+    let dot = index.checked_add(prefix_len)?;
+    if body.get(dot).copied() != Some(b'.') {
+        return None;
+    }
+    let suffix_start = dot.checked_add(1)?;
+    let suffix_len = identifier_run_len(body, suffix_start)?;
+    if !ident_is_upper_snake(body, suffix_start, suffix_len) {
+        return None;
+    }
+    prefix_len.checked_add(1)?.checked_add(suffix_len)
+}
+
+/// Returns true when the previous byte is not an identifier-continuation
+/// byte — i.e. `index` sits at the start of a fresh token.
+fn at_token_boundary(body: &[u8], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    let previous = index.checked_sub(1).and_then(|prev| body.get(prev));
+    previous.is_some_and(|byte| !is_ident_cont(*byte))
+}
+
+/// Returns the length of the contiguous identifier-byte run starting at
+/// `start`, or `None` when no identifier byte sits there.
+fn identifier_run_len(body: &[u8], start: usize) -> Option<usize> {
+    if start >= body.len() {
+        return None;
+    }
+    let first = *body.get(start)?;
+    if !is_ident_start(first) {
+        return None;
+    }
+    let mut end = start.checked_add(1)?;
+    while end < body.len() && body.get(end).is_some_and(|byte| is_ident_cont(*byte)) {
+        end = end.checked_add(1)?;
+    }
+    end.checked_sub(start)
+}
+
+/// ASCII identifier-start predicate (letters and `_`).
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_'
+}
+
+/// ASCII identifier-continuation predicate (letters, digits, `_`).
+fn is_ident_cont(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+/// Returns true when the identifier byte at `start` is an ASCII
+/// uppercase letter.
+fn ident_starts_capitalised(body: &[u8], start: usize) -> bool {
+    body.get(start).is_some_and(u8::is_ascii_uppercase)
+}
+
+/// Returns true when the identifier at `[start, start+len)` consists of
+/// uppercase ASCII letters, digits, or underscores, with at least one
+/// uppercase letter present.
+fn ident_is_upper_snake(body: &[u8], start: usize, len: usize) -> bool {
+    let Some(slice) = body.get(start..start.saturating_add(len)) else {
+        return false;
+    };
+    slice.iter().any(u8::is_ascii_uppercase)
+        && slice
+            .iter()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || *byte == b'_')
 }

--- a/crates/deslop-core/src/cluster_filters/python_class_shapes.rs
+++ b/crates/deslop-core/src/cluster_filters/python_class_shapes.rs
@@ -1,0 +1,317 @@
+//! Python class-shape cluster filters split out of `python.rs` to keep
+//! every file under the 500-LOC budget.
+//!
+//! Issues addressed (see parent `mod.rs` header):
+//! - **#115a** [CLONE-NOISE-PY-STRENUM-CLASS-SHAPE] — every `class X(StrEnum)`
+//!   carries a docstring + assignment-only body. After identifier
+//!   normalisation those bodies collapse and the enums cluster as
+//!   duplicates, but each enum is a closed discriminator the program
+//!   depends on by name.
+//! - **#115b** [CLONE-NOISE-PY-PYDANTIC-PARTIAL] — Pydantic's `XCreate`
+//!   model and matching `XUpdate` mirror cluster after normalisation
+//!   because every `XUpdate` field reuses the `XCreate` field name with
+//!   `T | None = None`. Pydantic has no native `PartialModel`, so the
+//!   mirror is mandated by the framework and not extractable.
+
+use tree_sitter::Node;
+
+use super::{enclosing_kind, parse_for, trimmed_snippet_range, Snippet};
+use crate::ast::ByteRange;
+
+/// Detects **issue #115a**: every cluster occurrence is a Python
+/// `class X(StrEnum)` (or `class X(str, Enum)`) declaration whose body
+/// consists only of a docstring and member assignments. Returning true
+/// drops the cluster — distinct enum vocabularies are not duplication.
+pub(super) fn is_strenum_class_shape_cluster(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 || !snippets.iter().all(|snippet| snippet.language == "python") {
+        return false;
+    }
+    snippets.iter().all(is_strenum_class_snippet)
+}
+
+/// Returns true when `snippet` covers exactly one `class_definition`
+/// whose superclass list contains `StrEnum` (or `str` + `Enum`) and
+/// whose body is docstring + assignments only.
+fn is_strenum_class_snippet(snippet: &Snippet<'_>) -> bool {
+    let Some(tree) = parse_for(snippet) else {
+        return false;
+    };
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let Some(class) = sole_class_in_range(tree.root_node(), range) else {
+        return false;
+    };
+    class_has_strenum_base(class, snippet.source) && class_body_is_docstring_and_assignments(class)
+}
+
+/// Walks `root` collecting `class_definition` nodes fully enclosed by
+/// `range` and returns the only one, or `None`.
+fn sole_class_in_range(root: Node<'_>, range: ByteRange) -> Option<Node<'_>> {
+    let mut classes = Vec::new();
+    collect_classes_in_range(root, range, &mut classes);
+    let [class] = classes.as_slice() else {
+        return None;
+    };
+    Some(*class)
+}
+
+/// Walks the tree appending `class_definition` nodes fully contained in
+/// `range`. Stops descending once a class is captured so nested classes
+/// are not double-counted.
+fn collect_classes_in_range<'tree>(
+    node: Node<'tree>,
+    range: ByteRange,
+    out: &mut Vec<Node<'tree>>,
+) {
+    if node.end_byte() <= range.start || node.start_byte() >= range.end {
+        return;
+    }
+    if node.kind() == "class_definition"
+        && node.start_byte() >= range.start
+        && node.end_byte() <= range.end
+    {
+        out.push(node);
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        collect_classes_in_range(child, range, out);
+    }
+}
+
+/// Returns true when `class.superclasses` contains an `StrEnum`
+/// identifier, or the pair `str` + `Enum`.
+fn class_has_strenum_base(class: Node<'_>, source: &[u8]) -> bool {
+    let Some(supers) = class.child_by_field_name("superclasses") else {
+        return false;
+    };
+    let mut cursor = supers.walk();
+    let mut has_str = false;
+    let mut has_enum = false;
+    for child in supers.named_children(&mut cursor) {
+        let Some(name) = identifier_bytes(child, source) else {
+            continue;
+        };
+        if name == b"StrEnum" {
+            return true;
+        }
+        has_str = has_str || name == b"str";
+        has_enum = has_enum || name == b"Enum";
+    }
+    has_str && has_enum
+}
+
+/// Returns the bytes of `node` when it (or its sole child) is an
+/// `identifier`; supports bare-name superclasses only.
+fn identifier_bytes<'a>(node: Node<'_>, source: &'a [u8]) -> Option<&'a [u8]> {
+    if node.kind() != "identifier" {
+        return None;
+    }
+    source.get(node.start_byte()..node.end_byte())
+}
+
+/// Returns true when `class.body` (a `block`) contains only an optional
+/// leading docstring `expression_statement` whose inner is a `string`,
+/// followed by `expression_statement`s wrapping `assignment` nodes.
+fn class_body_is_docstring_and_assignments(class: Node<'_>) -> bool {
+    let Some(body) = class.child_by_field_name("body") else {
+        return false;
+    };
+    let mut cursor = body.walk();
+    let mut saw_assignment = false;
+    for child in body.named_children(&mut cursor) {
+        match expression_statement_inner_kind(child) {
+            Some("string") => {}
+            Some("assignment") => saw_assignment = true,
+            _ => return false,
+        }
+    }
+    saw_assignment
+}
+
+/// Returns the kind of the inner expression for an `expression_statement`
+/// node, or `None` when the input is not such a statement or has no
+/// inner child.
+fn expression_statement_inner_kind(node: Node<'_>) -> Option<&'static str> {
+    if node.kind() != "expression_statement" {
+        return None;
+    }
+    let mut cursor = node.walk();
+    let inner = node.named_children(&mut cursor).next()?;
+    Some(inner.kind())
+}
+
+/// Detects **issue #115b**: a cluster of Pydantic `BaseModel` subclasses
+/// where every member is a class whose every field is annotated `T | None`
+/// (or `Optional[T]`) with a `None` default. Returns true to drop the
+/// cluster — the `XUpdate` mirror is mandated by Pydantic's PATCH
+/// semantics, not extractable duplication.
+pub(super) fn is_pydantic_partial_update_cluster(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 || !snippets.iter().all(|snippet| snippet.language == "python") {
+        return false;
+    }
+    let shapes: Option<Vec<PartialUpdateShape>> =
+        snippets.iter().map(partial_update_shape).collect();
+    let Some(shapes) = shapes else { return false };
+    shapes.iter().all(|shape| shape.is_partial_basemodel)
+}
+
+/// Per-member partial-update detection result.
+struct PartialUpdateShape {
+    /// True when this occurrence is a single `class X(BaseModel)` whose
+    /// every field is `T | None`-style optional with a `None` default.
+    is_partial_basemodel: bool,
+}
+
+/// Returns the shape for `snippet` when its range falls inside a
+/// `class_definition` inheriting from `BaseModel`. Accepts both whole-
+/// class fingerprints and sub-class fingerprints that cover only a run
+/// of field declarations (which is the common case after Type-2
+/// normalisation collapses each `T | None = None` field).
+fn partial_update_shape(snippet: &Snippet<'_>) -> Option<PartialUpdateShape> {
+    let tree = parse_for(snippet)?;
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let class = enclosing_or_sole_class(tree.root_node(), range)?;
+    if !class_has_base_named(class, snippet.source, b"BaseModel") {
+        return None;
+    }
+    Some(PartialUpdateShape {
+        is_partial_basemodel: class_body_is_all_optional_fields(class, snippet.source),
+    })
+}
+
+/// Returns the `class_definition` either fully containing or fully
+/// contained by `range`, preferring the enclosing one when the range
+/// is a sub-class fingerprint.
+fn enclosing_or_sole_class(root: Node<'_>, range: ByteRange) -> Option<Node<'_>> {
+    enclosing_kind(root, range, &["class_definition"]).or_else(|| sole_class_in_range(root, range))
+}
+
+/// Returns true when `class.superclasses` contains the bare identifier
+/// `needle`.
+fn class_has_base_named(class: Node<'_>, source: &[u8], needle: &[u8]) -> bool {
+    let Some(supers) = class.child_by_field_name("superclasses") else {
+        return false;
+    };
+    let mut cursor = supers.walk();
+    let found = supers
+        .named_children(&mut cursor)
+        .any(|child| identifier_bytes(child, source) == Some(needle));
+    found
+}
+
+/// Returns true when every body statement is `field: T | None = None`
+/// (or `field: Optional[T] = None`) and at least one such field exists.
+fn class_body_is_all_optional_fields(class: Node<'_>, source: &[u8]) -> bool {
+    let Some(body) = class.child_by_field_name("body") else {
+        return false;
+    };
+    let mut cursor = body.walk();
+    let mut saw_field = false;
+    for child in body.named_children(&mut cursor) {
+        if !child_is_optional_field_or_docstring(child, source, &mut saw_field) {
+            return false;
+        }
+    }
+    saw_field
+}
+
+/// Returns true when `child` is either a docstring `expression_statement`
+/// or an optional-field assignment statement. Sets `saw_field` to true
+/// for the latter.
+fn child_is_optional_field_or_docstring(
+    child: Node<'_>,
+    source: &[u8],
+    saw_field: &mut bool,
+) -> bool {
+    if child.kind() != "expression_statement" {
+        return false;
+    }
+    let mut inner_cursor = child.walk();
+    let Some(inner) = child.named_children(&mut inner_cursor).next() else {
+        return false;
+    };
+    if inner.kind() == "string" {
+        return true;
+    }
+    if inner.kind() != "assignment" || !assignment_is_optional_field(inner, source) {
+        return false;
+    }
+    *saw_field = true;
+    true
+}
+
+/// Returns true when `assignment` declares `name: T | None = None` or
+/// `name: Optional[T] = None`.
+fn assignment_is_optional_field(assignment: Node<'_>, source: &[u8]) -> bool {
+    let Some(left) = assignment.child_by_field_name("left") else {
+        return false;
+    };
+    if left.kind() != "identifier" {
+        return false;
+    }
+    let Some(type_node) = assignment.child_by_field_name("type") else {
+        return false;
+    };
+    let Some(right) = assignment.child_by_field_name("right") else {
+        return false;
+    };
+    if !is_none_literal(right, source) {
+        return false;
+    }
+    type_is_optional_annotation(type_node, source)
+}
+
+/// Returns true when `node` is the bare `None` identifier.
+fn is_none_literal(node: Node<'_>, source: &[u8]) -> bool {
+    matches!(node.kind(), "none") || source.get(node.start_byte()..node.end_byte()) == Some(b"None")
+}
+
+/// Returns true when `type_node` is `T | None`, `None | T`, or
+/// `Optional[T]`.
+fn type_is_optional_annotation(type_node: Node<'_>, source: &[u8]) -> bool {
+    let mut cursor = type_node.walk();
+    let Some(inner) = type_node.named_children(&mut cursor).next() else {
+        return false;
+    };
+    annotation_inner_is_optional(inner, source)
+}
+
+/// Inspects an annotation expression for the `T | None` / `Optional[T]`
+/// shape. Handles both PEP 604 unions and the classic `Optional` form.
+fn annotation_inner_is_optional(node: Node<'_>, source: &[u8]) -> bool {
+    if node.kind() == "binary_operator" {
+        return binary_union_has_none(node, source);
+    }
+    if node.kind() == "subscript" {
+        let Some(value) = node.child_by_field_name("value") else {
+            return false;
+        };
+        return source.get(value.start_byte()..value.end_byte()) == Some(b"Optional");
+    }
+    false
+}
+
+/// Returns true for `T | None` (or `None | T`) PEP 604 unions.
+fn binary_union_has_none(node: Node<'_>, source: &[u8]) -> bool {
+    let Some(operator_byte) = node
+        .child_by_field_name("operator")
+        .and_then(|operator| source.get(operator.start_byte()..operator.end_byte()))
+    else {
+        return false;
+    };
+    if operator_byte != b"|" {
+        return false;
+    }
+    let left = node.child_by_field_name("left");
+    let right = node.child_by_field_name("right");
+    side_is_none(left, source) || side_is_none(right, source)
+}
+
+/// Returns true when one side of a union annotation is the `None` type.
+fn side_is_none(side: Option<Node<'_>>, source: &[u8]) -> bool {
+    let Some(node) = side else { return false };
+    if matches!(node.kind(), "none") {
+        return true;
+    }
+    source.get(node.start_byte()..node.end_byte()) == Some(b"None")
+}

--- a/crates/deslop-core/src/live/api.rs
+++ b/crates/deslop-core/src/live/api.rs
@@ -173,13 +173,15 @@ impl LiveService {
 #[async_trait]
 impl LiveApi for LiveService {
     async fn report_get(&self) -> Arc<Report> {
-        let guard = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        guard.refresh_if_stale();
         guard.report()
     }
 
     async fn report_delta(&self, since: u64) -> Option<ReportDelta> {
         let (current_gen, current_report) = {
-            let guard = self.inner.lock().await;
+            let mut guard = self.inner.lock().await;
+            guard.refresh_if_stale();
             (guard.generation(), guard.report())
         };
         if since == current_gen {
@@ -198,7 +200,8 @@ impl LiveApi for LiveService {
     }
 
     async fn report_for_file(&self, path: &Path) -> FileReport {
-        let guard = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        guard.refresh_if_stale();
         guard.report_for_file(path)
     }
 
@@ -208,12 +211,14 @@ impl LiveApi for LiveService {
         start_byte: usize,
         end_byte: usize,
     ) -> Vec<ReportCluster> {
-        let guard = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        guard.refresh_if_stale();
         guard.report_for_range(path, start_byte, end_byte)
     }
 
     async fn cluster_by_id(&self, id: &str) -> Result<ReportCluster, LiveError> {
-        let guard = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        guard.refresh_if_stale();
         guard.cluster_by_id(id)
     }
 
@@ -221,7 +226,8 @@ impl LiveApi for LiveService {
         &self,
         request: &FindSimilarRequest,
     ) -> Result<FindSimilarResult, LiveError> {
-        let guard = self.inner.lock().await;
+        let mut guard = self.inner.lock().await;
+        guard.refresh_if_stale();
         guard.find_similar(request)
     }
 

--- a/crates/deslop-core/src/live/freshness.rs
+++ b/crates/deslop-core/src/live/freshness.rs
@@ -1,0 +1,119 @@
+//! Mtime-based read freshness for live reports
+//! ([LIVE-READ-FRESHNESS], [Deslop#153], [Deslop#156]).
+//!
+//! The watcher-driven scheduler is asynchronous and debounced: when a
+//! file changes on disk there is a ~250 ms window before the
+//! corresponding `apply_changes` pass commits. During that window any
+//! IPC read (`report/get`, `cluster/byId`, `report/forFile`,
+//! `report/forRange`) would return cluster occurrences whose byte
+//! ranges no longer match the file on disk. Agents reading those
+//! ranges either edit unrelated code or conclude a duplicate they just
+//! eliminated is still present.
+//!
+//! [`FreshnessTracker`] records the on-disk mtime of every file the
+//! analysis pass touched. Before serving a read, the session calls
+//! [`FreshnessTracker::detect_stale_paths`] against the live report's
+//! occurrence paths. Any path whose on-disk mtime is newer (or whose
+//! file vanished) is funnelled through `apply_changes` synchronously,
+//! so every read after a synchronous edit reflects the current file
+//! contents — without relying on the watcher having fired.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use crate::report::Report;
+
+/// Per-file mtime ledger consulted before serving any read.
+#[derive(Debug, Default, Clone)]
+pub struct FreshnessTracker {
+    /// Mtime of each file as last observed by the analysis pipeline.
+    /// Missing entries are treated as "never analysed" — the read
+    /// path triggers a fresh `apply_changes` on first encounter.
+    analyzed_mtimes: HashMap<PathBuf, SystemTime>,
+}
+
+impl FreshnessTracker {
+    /// Constructs an empty tracker.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records the current on-disk mtime for `path`. A missing file
+    /// clears the entry so the next read picks up the deletion.
+    pub fn record_path(&mut self, root: &Path, path: &Path) {
+        let absolute = absolutise(root, path);
+        match std::fs::metadata(&absolute).and_then(|metadata| metadata.modified()) {
+            Ok(mtime) => {
+                let _previous = self.analyzed_mtimes.insert(absolute, mtime);
+            }
+            Err(_) => {
+                let _removed = self.analyzed_mtimes.remove(&absolute);
+            }
+        }
+    }
+
+    /// Records the current mtime of every file referenced by `report`.
+    /// Called after every analysis pass commits a new snapshot.
+    pub fn record_from_report(&mut self, root: &Path, report: &Report) {
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        for cluster in &report.clusters {
+            for occurrence in &cluster.occurrences {
+                if seen.insert(occurrence.path.clone()) {
+                    self.record_path(root, &occurrence.path);
+                }
+            }
+        }
+    }
+
+    /// Returns the set of `report` occurrence paths whose on-disk
+    /// mtime is newer than the analysed mtime — or whose file
+    /// vanished. Each path is returned exactly once, in deterministic
+    /// (path-sorted) order so callers can pass them straight to
+    /// `apply_changes` without surprising the registry.
+    #[must_use]
+    pub fn detect_stale_paths(&self, root: &Path, report: &Report) -> Vec<PathBuf> {
+        let mut stale: HashSet<PathBuf> = HashSet::new();
+        for cluster in &report.clusters {
+            for occurrence in &cluster.occurrences {
+                let absolute = absolutise(root, &occurrence.path);
+                if self.is_stale(&absolute) {
+                    let _inserted = stale.insert(absolute);
+                }
+            }
+        }
+        let mut ordered: Vec<PathBuf> = stale.into_iter().collect();
+        ordered.sort();
+        ordered
+    }
+
+    /// Returns true when `absolute` has a different on-disk mtime
+    /// than the recorded value, when the file has vanished, or when
+    /// the file has never been recorded. The "never recorded" case
+    /// is a conservative miss — it asks the caller to refresh once
+    /// so the ledger catches up.
+    fn is_stale(&self, absolute: &Path) -> bool {
+        let recorded = self.analyzed_mtimes.get(absolute);
+        let metadata = std::fs::metadata(absolute);
+        match (recorded, metadata) {
+            (Some(recorded_mtime), Ok(meta)) => meta
+                .modified()
+                .map_or(true, |on_disk| &on_disk != recorded_mtime),
+            (Some(_), Err(_)) | (None, _) => true,
+        }
+    }
+}
+
+/// Resolves `path` against `root` when it is relative. Used so the
+/// tracker stores one canonical absolute key per file regardless of
+/// whether the watcher or the IPC caller used a relative form.
+fn absolutise(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}

--- a/crates/deslop-core/src/live/mod.rs
+++ b/crates/deslop-core/src/live/mod.rs
@@ -13,6 +13,7 @@ pub mod cluster_lookup;
 pub mod debouncer;
 pub mod embedding_refresh;
 pub mod errors;
+pub mod freshness;
 pub mod notifications;
 pub mod scheduler;
 pub mod session;

--- a/crates/deslop-core/src/live/session.rs
+++ b/crates/deslop-core/src/live/session.rs
@@ -22,6 +22,7 @@ use super::{
     cluster_lookup::resolve_cluster_by_id_prefix,
     embedding_refresh::{CommittedEmbeddingRefresh, EmbeddingRefreshInput, EmbeddingRefreshJob},
     errors::LiveError,
+    freshness::FreshnessTracker,
     session_helpers::{
         append_ollama_models, cluster_matches_any_hash, cluster_overlaps_range,
         cluster_touches_path, collapse_overlapping_clusters_for_range, earliest_byte_for_path,
@@ -92,6 +93,11 @@ pub struct AnalysisSession {
     embedding_progress_reporter: Option<EmbeddingProgressReporter>,
     /// Monotonic id for queued embedding refreshes.
     embedding_refresh_revision: u64,
+    /// Mtime ledger consulted before every IPC read
+    /// ([LIVE-READ-FRESHNESS], [Deslop#153], [Deslop#156]). Refreshed
+    /// after every analysis pass so a stale-mtime read forces a
+    /// synchronous `apply_changes` ahead of serving the response.
+    freshness: FreshnessTracker,
 }
 
 impl std::fmt::Debug for AnalysisSession {
@@ -209,6 +215,11 @@ impl AnalysisSession {
         self.pipeline = Some(pipeline);
         self.generation = self.generation.saturating_add(1);
         self.latest_report = Arc::new(report);
+        // [LIVE-READ-FRESHNESS] / [Deslop#153] Record the on-disk mtime
+        // of every file in the freshly-installed report so the next
+        // read does not falsely refire a refresh.
+        self.freshness
+            .record_from_report(&self.root, &self.latest_report);
         let pending = std::mem::take(&mut self.pending_changes);
         if !pending.is_empty() {
             let _delta = self.apply_changes(&pending)?;
@@ -276,6 +287,8 @@ impl AnalysisSession {
 
     /// Assembles the session struct.
     fn finalise(init: SessionInit) -> Self {
+        let mut freshness = FreshnessTracker::new();
+        freshness.record_from_report(&init.root, &init.report);
         Self {
             root: init.root,
             min_nodes: init.min_nodes,
@@ -289,6 +302,7 @@ impl AnalysisSession {
             config_path: init.config_path,
             embedding_progress_reporter: None,
             embedding_refresh_revision: 0,
+            freshness,
         }
     }
 
@@ -376,6 +390,10 @@ impl AnalysisSession {
         self.generation = self.generation.saturating_add(1);
         let next_arc = Arc::new(next);
         self.latest_report = Arc::clone(&next_arc);
+        // [LIVE-READ-FRESHNESS] Refresh the mtime ledger so a follow-up
+        // read of the same files does not re-trigger this same pass.
+        self.freshness
+            .record_from_report(&self.root, &self.latest_report);
         // Per-keystroke writes were the dominant source of inotify
         // chatter on large workspaces. The seed-cache file is now
         // persisted only on cold-pass install ([LIVE-SEED-CACHE]); the
@@ -385,6 +403,43 @@ impl AnalysisSession {
             self.generation,
             &next_arc,
         ))
+    }
+
+    /// [LIVE-READ-FRESHNESS] / [Deslop#153] / [Deslop#156].
+    ///
+    /// Detects files whose on-disk mtime is newer than what the
+    /// analyser last observed, and runs a synchronous
+    /// [`Self::apply_changes`] pass for those paths before any IPC
+    /// read serves cluster occurrences. The cost is one `stat` per
+    /// occurrence path per read — well under a millisecond even on
+    /// monorepo-scale workspaces — and it eliminates the stale-data
+    /// window between a synchronous edit and the next debounced
+    /// watcher tick.
+    ///
+    /// Failures are logged but never propagated: a stale-data read
+    /// is bad, but a failed read is worse. The caller continues with
+    /// whatever the previous pass produced.
+    pub fn refresh_if_stale(&mut self) {
+        let stale = self
+            .freshness
+            .detect_stale_paths(&self.root, &self.latest_report);
+        if stale.is_empty() {
+            return;
+        }
+        tracing::debug!(
+            stale_count = stale.len(),
+            "live_read_freshness_apply_changes",
+        );
+        match self.apply_changes(&stale) {
+            Ok(_delta) => {}
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    stale_count = stale.len(),
+                    "live_read_freshness_refresh_failed; serving prior snapshot",
+                );
+            }
+        }
     }
 
     /// Resolves a `find_similar` request.
@@ -523,6 +578,10 @@ impl AnalysisSession {
         self.generation = self.generation.saturating_add(1);
         let provenance = report.embedding_provenance.clone();
         self.latest_report = Arc::new(report);
+        // [LIVE-READ-FRESHNESS] keep the mtime ledger aligned with the
+        // freshly-committed report so reads do not loop-refire.
+        self.freshness
+            .record_from_report(&self.root, &self.latest_report);
         // Embedding refresh writes are still per-pass and noisy; seed
         // cache only updates on cold-pass install.
         Some(CommittedEmbeddingRefresh {

--- a/crates/deslop-mcp/tests/issue_153_rescan_freshness.rs
+++ b/crates/deslop-mcp/tests/issue_153_rescan_freshness.rs
@@ -1,0 +1,190 @@
+//! Regression test for issue #153 ([LIVE-RESCAN-FRESHNESS]).
+//!
+//! Reported bug: after editing files to eliminate a cluster,
+//! `mcp__deslop__rescan` frequently returns the same cluster id and
+//! pre-edit byte offsets. A second `rescan` call eventually yields
+//! fresh data.
+//!
+//! The contract of `rescan` is: block until a fresh scan completes,
+//! then return *that* scan's report — never one from before the
+//! refresh. The MCP `rescan` payload contains both `generation` and
+//! `clusters`, and both must come from the same generation.
+
+#![cfg(unix)]
+
+use anyhow::{anyhow, ensure, Context, Result};
+use serde_json::{json, Value};
+
+mod common;
+use common::{
+    copied_fixture, initialized_mcp, spawn_lsp_and_initialize, structured_content, wait_for_path,
+    ChildKillOnDrop, McpHandle, SOCKET_TIMEOUT,
+};
+
+/// One unique C# file body that shares no normalised subtrees with
+/// the rest of the corpus, so writing it eliminates any cluster the
+/// original file belonged to.
+fn unique_body(seed: u32) -> String {
+    format!(
+        "namespace Unique{seed} {{ public class Once{seed} {{ public string Tag() => \"{seed}\"; }} }}\n",
+    )
+}
+
+/// Issue #153: a single `rescan` call must return clusters from the
+/// post-refresh generation. After overwriting every fixture file with
+/// unique content, the response must show zero clusters in the same
+/// payload that reports the post-refresh generation.
+#[test]
+fn issue_153_single_rescan_reflects_post_edit_state() -> Result<()> {
+    let workspace = copied_fixture()?;
+    let lsp = spawn_lsp_and_initialize(workspace.path())?;
+    let _lsp_guard = ChildKillOnDrop(lsp);
+
+    let socket = workspace.path().join(".deslop-cache/deslop.sock");
+    wait_for_path(&socket, SOCKET_TIMEOUT).context("wait for ipc socket")?;
+    let state_file = workspace.path().join(".deslop-cache/live-report.json");
+    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
+
+    let mut mcp = initialized_mcp(workspace.path())?;
+
+    // Baseline must have at least one cluster — otherwise the test
+    // cannot prove the rescan is doing real work.
+    let baseline = rescan_call(&mut mcp, &[])?;
+    let baseline_clusters = clusters_array(&baseline)?;
+    ensure!(
+        !baseline_clusters.is_empty(),
+        "fixture must produce at least one cluster before edits; baseline={baseline}",
+    );
+
+    // Eliminate every cluster: overwrite every fixture file with
+    // body that shares no normalised subtrees.
+    let names = ["Alpha.cs", "Beta.cs", "Gamma.cs", "Delta.cs"];
+    let mut paths = Vec::new();
+    for (index, name) in names.iter().enumerate() {
+        let file = workspace.path().join(name);
+        let seed = u32::try_from(index).unwrap_or(0);
+        std::fs::write(&file, unique_body(seed)).with_context(|| format!("overwrite {name}"))?;
+        paths.push(file.to_string_lossy().into_owned());
+    }
+
+    let rescan = rescan_call(&mut mcp, &paths)?;
+    let after_clusters = clusters_array(&rescan)?;
+    let after_generation = rescan
+        .get("generation")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("rescan response missing generation field: {rescan}"))?;
+    ensure!(
+        after_generation > 0,
+        "rescan generation must advance past zero: {rescan}",
+    );
+    ensure!(
+        after_clusters.is_empty(),
+        "issue #153: a single `rescan` call must surface the post-edit state. \
+         Got {count} stale cluster(s) at generation {after_generation}: {rescan}",
+        count = after_clusters.len(),
+    );
+    Ok(())
+}
+
+/// Issue #153 companion: a single `rescan` call must surface the
+/// post-edit byte/line ranges for surviving clusters. When a comment
+/// block is inserted in front of Alpha.cs the cluster id is stable
+/// (content hash), but every byte offset for the Alpha occurrence
+/// must shift forward by the padding length. Today the first rescan
+/// returns the pre-edit offsets and only a second call eventually
+/// catches up.
+#[test]
+fn issue_153_rescan_occurrence_offsets_reflect_post_edit_file() -> Result<()> {
+    let workspace = copied_fixture()?;
+    let lsp = spawn_lsp_and_initialize(workspace.path())?;
+    let _lsp_guard = ChildKillOnDrop(lsp);
+
+    let socket = workspace.path().join(".deslop-cache/deslop.sock");
+    wait_for_path(&socket, SOCKET_TIMEOUT).context("wait for ipc socket")?;
+    let state_file = workspace.path().join(".deslop-cache/live-report.json");
+    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
+
+    let mut mcp = initialized_mcp(workspace.path())?;
+
+    // Insert a long leading comment block into Alpha.cs so the
+    // surviving Alpha occurrence shifts down by many bytes. The
+    // cluster id is stable (content hash) but every byte offset for
+    // the Alpha occurrence must move forward.
+    let alpha = workspace.path().join("Alpha.cs");
+    let original_alpha = std::fs::read_to_string(&alpha)?;
+    let inserted_prefix = "// padding line\n".repeat(40);
+    let new_alpha = format!("{inserted_prefix}{original_alpha}");
+    std::fs::write(&alpha, &new_alpha)?;
+
+    // Call rescan without listing the path explicitly — the MCP wire
+    // contract is that rescan does a full refresh regardless of args
+    // (the `paths` argument is informational). The first call must
+    // already reflect the post-edit Alpha offsets, never the second.
+    let rescan = rescan_call(&mut mcp, &[])?;
+    let after_clusters = clusters_array(&rescan)?;
+    ensure!(
+        !after_clusters.is_empty(),
+        "Alpha/Beta cluster must survive a comment-only edit: {rescan}",
+    );
+
+    // Find the Alpha occurrence in the first surviving cluster and
+    // assert its byte/line range matches the post-edit file. The
+    // surviving Alpha occurrence must start AFTER the inserted
+    // padding bytes — otherwise the offsets are stale.
+    let padding_bytes = inserted_prefix.len();
+    let mut found_alpha = false;
+    for cluster in &after_clusters {
+        let Some(occurrences) = cluster.get("occurrences").and_then(Value::as_array) else {
+            continue;
+        };
+        for occurrence in occurrences {
+            let path = occurrence
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if !path.ends_with("Alpha.cs") {
+                continue;
+            }
+            found_alpha = true;
+            let start_byte = occurrence
+                .get("start_byte")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            let start_usize = usize::try_from(start_byte)
+                .with_context(|| format!("start_byte overflow at {path}"))?;
+            ensure!(
+                start_usize >= padding_bytes,
+                "issue #153: surviving Alpha occurrence reports stale start_byte={start_byte} but padding shifted the cluster by {padding_bytes} bytes. Full cluster: {cluster}",
+            );
+        }
+    }
+    ensure!(
+        found_alpha,
+        "Alpha.cs must appear in at least one cluster after edit: {rescan}",
+    );
+    Ok(())
+}
+
+/// Calls the `rescan` MCP tool and returns the structured payload.
+fn rescan_call(mcp: &mut McpHandle, paths: &[String]) -> Result<Value> {
+    let response = mcp.request(
+        "tools/call",
+        &json!({
+            "name": "rescan",
+            "arguments": {
+                "paths": paths,
+                "n": 8,
+            }
+        }),
+    )?;
+    structured_content(&response, "rescan")
+}
+
+/// Extracts the `clusters` JSON array from a rescan payload.
+fn clusters_array(structured: &Value) -> Result<Vec<Value>> {
+    structured
+        .get("clusters")
+        .and_then(Value::as_array)
+        .cloned()
+        .ok_or_else(|| anyhow!("rescan payload missing clusters array: {structured}"))
+}

--- a/crates/deslop-mcp/tests/issue_156_cluster_id_stale_offsets.rs
+++ b/crates/deslop-mcp/tests/issue_156_cluster_id_stale_offsets.rs
@@ -1,0 +1,158 @@
+//! Regression test for issue #156 ([LIVE-CLUSTER-OFFSET-FRESHNESS]).
+//!
+//! Reported bug: `cluster-by-id` (and the `top-offenders` cluster
+//! payload) returns `start_byte`/`end_byte` and
+//! `start_line`/`end_line` that point at where the duplicate **used
+//! to be**, not where it is now. After several edits the offsets
+//! drift far enough that reading the file at the reported range
+//! surfaces unrelated code.
+//!
+//! Once the file has been re-analysed, every offset on the cluster
+//! returned by `cluster-by-id` must point at code that is still part
+//! of the duplicate region.
+
+#![cfg(unix)]
+
+use anyhow::{anyhow, ensure, Context, Result};
+use serde_json::{json, Value};
+
+mod common;
+use common::{
+    copied_fixture, initialized_mcp, spawn_lsp_and_initialize, structured_content, wait_for_path,
+    ChildKillOnDrop, McpHandle, SOCKET_TIMEOUT,
+};
+
+/// Issue #156: after rescanning, the cluster payload returned by
+/// `cluster-by-id` must contain occurrence byte ranges that map onto
+/// the post-edit file. Today the offsets stay at their pre-edit
+/// values for at least one MCP cycle.
+#[test]
+fn issue_156_cluster_by_id_returns_post_edit_offsets() -> Result<()> {
+    let workspace = copied_fixture()?;
+    let lsp = spawn_lsp_and_initialize(workspace.path())?;
+    let _lsp_guard = ChildKillOnDrop(lsp);
+
+    let socket = workspace.path().join(".deslop-cache/deslop.sock");
+    wait_for_path(&socket, SOCKET_TIMEOUT).context("wait for ipc socket")?;
+    let state_file = workspace.path().join(".deslop-cache/live-report.json");
+    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
+
+    let mut mcp = initialized_mcp(workspace.path())?;
+
+    // Force a refresh first so the baseline is deterministic.
+    let baseline = rescan_call(&mut mcp, &[])?;
+    let baseline_clusters = baseline
+        .get("clusters")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("baseline rescan missing clusters: {baseline}"))?;
+    ensure!(
+        !baseline_clusters.is_empty(),
+        "fixture must produce at least one cluster: {baseline}",
+    );
+
+    // Pick the first cluster's id and remember the alpha occurrence
+    // bytes for the assertion message later.
+    let target_id = baseline_clusters
+        .first()
+        .and_then(|cluster| cluster.get("id"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("baseline cluster missing id: {baseline}"))?
+        .to_owned();
+
+    // Insert a long padding block at the top of every fixture file so
+    // every byte offset on the surviving cluster must shift forward.
+    // Make several rounds of edits before the next rescan — the
+    // reported failure mode is that several intervening edits drift
+    // the offsets without the LSP ever catching up.
+    let names = ["Alpha.cs", "Beta.cs", "Gamma.cs", "Delta.cs"];
+    let mut padding = String::new();
+    for round in 0..5_u32 {
+        padding.push_str(&format!("// padding round {round}\n").repeat(20));
+        for name in names {
+            let path = workspace.path().join(name);
+            let original =
+                std::fs::read_to_string(&path).with_context(|| format!("read {name}"))?;
+            // strip any prior padding lines so the cumulative
+            // shift stays exactly `padding.len()`.
+            let body = original
+                .lines()
+                .skip_while(|line| line.starts_with("// padding round "))
+                .collect::<Vec<&str>>()
+                .join("\n");
+            let shifted = format!("{padding}{body}\n");
+            std::fs::write(&path, shifted).with_context(|| format!("rewrite {name}"))?;
+        }
+    }
+
+    // Do NOT call rescan — issue #156 is that cluster-by-id must
+    // serve offsets consistent with the on-disk content even when
+    // the agent has not explicitly forced a refresh between read
+    // calls. Either re-resolve offsets at read time or invalidate
+    // stale clusters; either fix keeps the agent from being misled.
+    let response = mcp.request(
+        "tools/call",
+        &json!({
+            "name": "cluster-by-id",
+            "arguments": { "id": target_id }
+        }),
+    )?;
+    let cluster = structured_content(&response, "cluster-by-id")?;
+    let occurrences = cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("cluster-by-id payload missing occurrences: {cluster}"))?;
+    ensure!(
+        !occurrences.is_empty(),
+        "cluster {target_id} returned zero occurrences: {cluster}",
+    );
+
+    let padding_bytes = padding.len();
+    for occurrence in occurrences {
+        let path = occurrence
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let start_byte = occurrence
+            .get("start_byte")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let end_byte = occurrence
+            .get("end_byte")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        let start_usize = usize::try_from(start_byte)
+            .with_context(|| format!("start_byte overflow at {path}"))?;
+        let end_usize =
+            usize::try_from(end_byte).with_context(|| format!("end_byte overflow at {path}"))?;
+        ensure!(
+            start_usize >= padding_bytes,
+            "issue #156: occurrence at {path} reports stale start_byte={start_byte}; padding shifted every cluster by {padding_bytes} bytes. Full cluster: {cluster}",
+        );
+        // Read the file and assert the reported byte range still
+        // lives inside the file — a stale end_byte often overshoots
+        // the new file length and would corrupt agent context.
+        let on_disk_path = workspace.path().join(path);
+        let body = std::fs::read(&on_disk_path).with_context(|| format!("read on-disk {path}"))?;
+        ensure!(
+            end_usize <= body.len(),
+            "issue #156: occurrence {path} end_byte={end_byte} overruns the post-edit file length {len}: {cluster}",
+            len = body.len(),
+        );
+    }
+    Ok(())
+}
+
+/// Calls the `rescan` MCP tool and returns the structured payload.
+fn rescan_call(mcp: &mut McpHandle, paths: &[String]) -> Result<Value> {
+    let response = mcp.request(
+        "tools/call",
+        &json!({
+            "name": "rescan",
+            "arguments": {
+                "paths": paths,
+                "n": 8,
+            }
+        }),
+    )?;
+    structured_content(&response, "rescan")
+}

--- a/crates/deslop/tests/fixtures/python-issue-115-pydantic-partial/agent_schemas.py
+++ b/crates/deslop/tests/fixtures/python-issue-115-pydantic-partial/agent_schemas.py
@@ -1,0 +1,31 @@
+"""Pydantic create/update model pair for an Agent resource.
+
+`AgentCreate` lists every required field by its concrete type; the
+matching `AgentUpdate` mirrors the same field names with every annotation
+wrapped in `T | None = None` so a partial PATCH payload validates. This
+mirror is unavoidable because Pydantic has no native `PartialModel` —
+extracting the shared fields into a base class would defeat the
+"every field optional on update" rule.
+"""
+
+from pydantic import BaseModel
+
+
+class AgentCreate(BaseModel):
+    """Required fields for creating an Agent."""
+
+    display_name: str
+    description: str
+    model_id: str
+    temperature: float
+    max_tokens: int
+
+
+class AgentUpdate(BaseModel):
+    """Optional-field mirror of `AgentCreate` for PATCH semantics."""
+
+    display_name: str | None = None
+    description: str | None = None
+    model_id: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None

--- a/crates/deslop/tests/fixtures/python-issue-115-pydantic-partial/workspace_schemas.py
+++ b/crates/deslop/tests/fixtures/python-issue-115-pydantic-partial/workspace_schemas.py
@@ -1,0 +1,28 @@
+"""Second Pydantic create/update pair, distinct field set.
+
+Same intentional mirror as `agent_schemas.py`. After identifier
+normalisation the two `*Update` classes cluster with each other AND
+with their own `*Create` siblings. None of those clusters are
+extractable — every PATCH model is required to mirror its sibling
+verbatim with optional fields.
+"""
+
+from pydantic import BaseModel
+
+
+class WorkspaceCreate(BaseModel):
+    """Required fields for creating a Workspace."""
+
+    workspace_slug: str
+    region: str
+    cpu_limit: int
+    memory_limit_gb: int
+
+
+class WorkspaceUpdate(BaseModel):
+    """Optional-field mirror of `WorkspaceCreate` for PATCH semantics."""
+
+    workspace_slug: str | None = None
+    region: str | None = None
+    cpu_limit: int | None = None
+    memory_limit_gb: int | None = None

--- a/crates/deslop/tests/fixtures/python-issue-115-strenum/agent_types.py
+++ b/crates/deslop/tests/fixtures/python-issue-115-strenum/agent_types.py
@@ -1,0 +1,28 @@
+"""StrEnum declarations modelling agent types.
+
+Each `class X(StrEnum)` has a different alphabet of members but the AST
+shape (docstring + assignments only) is identical to every other
+`StrEnum`. After identifier normalisation the bodies collapse and the
+classes cluster as duplicates, when in reality each enum is a closed
+discriminator the application code depends on by name.
+"""
+
+from enum import StrEnum
+
+
+class AgentType(StrEnum):
+    """Top-level agent dispatcher kinds."""
+
+    CLAUDE = "claude"
+    GPT = "gpt"
+    GEMINI = "gemini"
+    LOCAL = "local"
+
+
+class WorkspaceHostKind(StrEnum):
+    """Workspace host runtime kinds."""
+
+    K8S = "k8s"
+    DOCKER = "docker"
+    LOCAL_FS = "local_fs"
+    REMOTE_SSH = "remote_ssh"

--- a/crates/deslop/tests/fixtures/python-issue-115-strenum/host_kinds.py
+++ b/crates/deslop/tests/fixtures/python-issue-115-strenum/host_kinds.py
@@ -1,0 +1,25 @@
+"""More StrEnum declarations on a separate module.
+
+Cross-file cluster forms when these enum classes share the same
+docstring + assignment-only shape with the ones in `agent_types.py`.
+The filter must drop these so each enum stays as an independent contract.
+"""
+
+from enum import StrEnum
+
+
+class AgentWorkspaceHostKind(StrEnum):
+    """Agent-side workspace host discriminator."""
+
+    K8S = "k8s"
+    DOCKER = "docker"
+    PODMAN = "podman"
+
+
+class TaskState(StrEnum):
+    """Lifecycle states for a scheduled task."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"

--- a/crates/deslop/tests/fixtures/python-issue-97-parametric-invariant-tests/test_dispatcher_registry.py
+++ b/crates/deslop/tests/fixtures/python-issue-97-parametric-invariant-tests/test_dispatcher_registry.py
@@ -1,0 +1,26 @@
+"""Companion test module so the cluster spans at least two files."""
+
+from dispatcher_support import (
+    DispatcherKind,
+    MockDispatcher,
+    get_dispatcher,
+    register_dispatcher,
+)
+
+
+def test_register_sync() -> None:
+    mock = MockDispatcher()
+    register_dispatcher(DispatcherKind.SYNC, mock)
+    assert get_dispatcher(DispatcherKind.SYNC) is mock
+
+
+def test_register_async() -> None:
+    mock = MockDispatcher()
+    register_dispatcher(DispatcherKind.ASYNC, mock)
+    assert get_dispatcher(DispatcherKind.ASYNC) is mock
+
+
+def test_register_batch() -> None:
+    mock = MockDispatcher()
+    register_dispatcher(DispatcherKind.BATCH, mock)
+    assert get_dispatcher(DispatcherKind.BATCH) is mock

--- a/crates/deslop/tests/fixtures/python-issue-97-parametric-invariant-tests/test_host_registry.py
+++ b/crates/deslop/tests/fixtures/python-issue-97-parametric-invariant-tests/test_host_registry.py
@@ -1,0 +1,36 @@
+"""Pytest invariants across each variant of an enum discriminator.
+
+Each test verifies that `register_host(KIND, mock)` followed by
+`get_host(KIND)` returns the same mock. After identifier normalisation
+the bodies all become structurally and tokenwise identical — the only
+varying token is the enum member access `AgentWorkspaceHostKind.K8S`
+vs `AgentWorkspaceHostKind.DOCKER` etc. Each test asserts a distinct
+spec point: merging them into one parametrised test is the right
+refactor in some shops but is intentionally rejected here because
+each test name appears verbatim in coverage dashboards and CI titles.
+"""
+
+from host_support import (
+    AgentWorkspaceHostKind,
+    MockAgentWorkspaceHost,
+    get_host,
+    register_host,
+)
+
+
+def test_register_k8s() -> None:
+    mock = MockAgentWorkspaceHost()
+    register_host(AgentWorkspaceHostKind.K8S, mock)
+    assert get_host(AgentWorkspaceHostKind.K8S) is mock
+
+
+def test_register_docker() -> None:
+    mock = MockAgentWorkspaceHost()
+    register_host(AgentWorkspaceHostKind.DOCKER, mock)
+    assert get_host(AgentWorkspaceHostKind.DOCKER) is mock
+
+
+def test_register_podman() -> None:
+    mock = MockAgentWorkspaceHost()
+    register_host(AgentWorkspaceHostKind.PODMAN, mock)
+    assert get_host(AgentWorkspaceHostKind.PODMAN) is mock

--- a/crates/deslop/tests/fixtures/rust-issue-154-structural-only/protocol_checks.rs
+++ b/crates/deslop/tests/fixtures/rust-issue-154-structural-only/protocol_checks.rs
@@ -1,0 +1,72 @@
+//! Fixture for GH #154 — three functions sharing a `(ctx: &mut Ctx)`
+//! signature shape collapse to identical structural fingerprints after
+//! normalisation. The bodies are wildly different so token_jaccard is
+//! zero. The cluster must not surface as duplication.
+
+use std::collections::BTreeMap;
+
+pub struct ProtoCheckCtx<'a> {
+    pub messages: &'a mut Vec<String>,
+    pub seen_flags: BTreeMap<String, bool>,
+    pub counts: (usize, usize),
+}
+
+pub fn check_protocol_varargs_kwargs(ctx: &mut ProtoCheckCtx<'_>) -> bool {
+    let varargs = ctx
+        .seen_flags
+        .get("varargs")
+        .copied()
+        .unwrap_or_default();
+    let kwargs = ctx
+        .seen_flags
+        .get("kwargs")
+        .copied()
+        .unwrap_or_default();
+    if varargs && kwargs {
+        ctx.messages
+            .push("protocol declares both *args and **kwargs".to_owned());
+        return false;
+    }
+    if varargs {
+        ctx.messages
+            .push("protocol declares *args without **kwargs".to_owned());
+    }
+    if kwargs {
+        ctx.messages
+            .push("protocol declares **kwargs without *args".to_owned());
+    }
+    true
+}
+
+pub fn check_protocol_param_counts(ctx: &mut ProtoCheckCtx<'_>) -> bool {
+    let (param_count, max_param_count) = ctx.counts;
+    let diff = max_param_count.saturating_sub(param_count);
+    if diff > 3 {
+        ctx.messages.push(format!(
+            "parameter count diverges by {diff} between protocol members",
+        ));
+        return false;
+    }
+    if param_count == 0 {
+        ctx.messages
+            .push("protocol member declares no parameters".to_owned());
+    }
+    true
+}
+
+pub fn check_positional_defaults(ctx: &mut ProtoCheckCtx<'_>) {
+    let positional_defaults = ctx
+        .seen_flags
+        .get("positional_defaults")
+        .copied()
+        .unwrap_or_default();
+    if positional_defaults {
+        let summary = format!(
+            "{} positional parameters carry implicit defaults",
+            ctx.counts.0,
+        );
+        ctx.messages.push(summary);
+        let _ = ctx.seen_flags.insert("positional_defaults".to_owned(), false);
+    }
+    let _ = ctx.messages.len();
+}

--- a/crates/deslop/tests/python_issue_115_pydantic_partial.rs
+++ b/crates/deslop/tests/python_issue_115_pydantic_partial.rs
@@ -1,0 +1,106 @@
+//! E2E regression for GH #115 [CLONE-NOISE-PY-PYDANTIC-PARTIAL].
+//!
+//! Pydantic's create/update pattern declares `XCreate(BaseModel)` with
+//! required fields and `XUpdate(BaseModel)` mirroring the same fields
+//! with every annotation wrapped in `T | None = None`. Pydantic has no
+//! native `PartialModel`, so this mirror is unavoidable and shows up
+//! as a cluster after identifier normalisation. The cluster filter
+//! must drop those `*Create` / `*Update` mirrors.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("4")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn clusters(report: &Value) -> &[Value] {
+    report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrences(cluster: &Value) -> &[Value] {
+    cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
+    let path = occurrence
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("reported occurrence is missing path"))?;
+    let source = fs::read_to_string(scan_root.join(path))?;
+    let start = occurrence_byte(occurrence, "start_byte")?;
+    let end = occurrence_byte(occurrence, "end_byte")?;
+    source
+        .get(start..end)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("reported occurrence range is invalid"))
+}
+
+fn occurrence_byte(occurrence: &Value, field: &str) -> Result<usize> {
+    occurrence
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("reported occurrence is missing {field}"))
+}
+
+fn pydantic_partial_offenders(report: &Value, scan_root: &Path) -> Result<Vec<String>> {
+    let mut summaries = Vec::new();
+    for cluster in clusters(report) {
+        for occurrence in occurrences(cluster) {
+            let text = occurrence_text(scan_root, occurrence)?;
+            if text.contains("BaseModel") || text.contains("| None = None") {
+                summaries.push(text.replace('\n', " "));
+            }
+        }
+    }
+    Ok(summaries)
+}
+
+#[test]
+fn pydantic_create_update_mirrors_do_not_cluster() -> Result<()> {
+    let scan_root = fixture("python-issue-115-pydantic-partial");
+    let report = run_report(&scan_root)?;
+    let offenders = pydantic_partial_offenders(&report, &scan_root)?;
+    assert!(
+        offenders.is_empty(),
+        "Pydantic `*Create` / `*Update` partial-mirror pairs must not \
+         surface as duplicate logic — the mirror is mandated by the \
+         framework: {offenders:#?}"
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/python_issue_115_strenum.rs
+++ b/crates/deslop/tests/python_issue_115_strenum.rs
@@ -1,0 +1,103 @@
+//! E2E regression for GH #115 [CLONE-NOISE-PY-STRENUM-CLASS-SHAPE].
+//!
+//! Different `class X(StrEnum)` declarations carry the same AST shape
+//! — docstring + member assignments — even though every enum encodes a
+//! distinct closed discriminator. After identifier normalisation they
+//! cluster as duplicates. The cluster filter must drop them.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("4")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn clusters(report: &Value) -> &[Value] {
+    report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrences(cluster: &Value) -> &[Value] {
+    cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
+    let path = occurrence
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("reported occurrence is missing path"))?;
+    let source = fs::read_to_string(scan_root.join(path))?;
+    let start = occurrence_byte(occurrence, "start_byte")?;
+    let end = occurrence_byte(occurrence, "end_byte")?;
+    source
+        .get(start..end)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("reported occurrence range is invalid"))
+}
+
+fn occurrence_byte(occurrence: &Value, field: &str) -> Result<usize> {
+    occurrence
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("reported occurrence is missing {field}"))
+}
+
+fn strenum_offenders(report: &Value, scan_root: &Path) -> Result<Vec<String>> {
+    let mut summaries = Vec::new();
+    for cluster in clusters(report) {
+        for occurrence in occurrences(cluster) {
+            let text = occurrence_text(scan_root, occurrence)?;
+            if text.contains("StrEnum") {
+                summaries.push(text.replace('\n', " "));
+            }
+        }
+    }
+    Ok(summaries)
+}
+
+#[test]
+fn strenum_class_shapes_do_not_cluster() -> Result<()> {
+    let scan_root = fixture("python-issue-115-strenum");
+    let report = run_report(&scan_root)?;
+    let offenders = strenum_offenders(&report, &scan_root)?;
+    assert!(
+        offenders.is_empty(),
+        "`class X(StrEnum)` declarations must not surface as duplicate \
+         logic — each enum is a closed discriminator: {offenders:#?}"
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/python_issue_97_parametric_invariant_tests.rs
+++ b/crates/deslop/tests/python_issue_97_parametric_invariant_tests.rs
@@ -1,0 +1,107 @@
+//! E2E regression for GH #97 [CLONE-NOISE-PY-PARAMETRIC-INVARIANT-TESTS].
+//!
+//! `def test_register_<variant>()` style tests assert the same invariant
+//! against each value of an enum discriminator. After identifier
+//! normalisation the bodies collapse to identical Type-2 clones, but
+//! each test name records a distinct spec assertion: collapsing them
+//! into one cluster would silently lose coverage granularity. Bodies
+//! that vary only by enum-style identifier access (`X.K8S` vs
+//! `X.DOCKER`) inside `test_*` functions must be dropped.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("4")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn clusters(report: &Value) -> &[Value] {
+    report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrences(cluster: &Value) -> &[Value] {
+    cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
+    let path = occurrence
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("reported occurrence is missing path"))?;
+    let source = fs::read_to_string(scan_root.join(path))?;
+    let start = occurrence_byte(occurrence, "start_byte")?;
+    let end = occurrence_byte(occurrence, "end_byte")?;
+    source
+        .get(start..end)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("reported occurrence range is invalid"))
+}
+
+fn occurrence_byte(occurrence: &Value, field: &str) -> Result<usize> {
+    occurrence
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("reported occurrence is missing {field}"))
+}
+
+fn parametric_test_offenders(report: &Value, scan_root: &Path) -> Result<Vec<String>> {
+    let mut summaries = Vec::new();
+    for cluster in clusters(report) {
+        for occurrence in occurrences(cluster) {
+            let text = occurrence_text(scan_root, occurrence)?;
+            if text.contains("register_host(") || text.contains("register_dispatcher(") {
+                summaries.push(text.replace('\n', " "));
+            }
+        }
+    }
+    Ok(summaries)
+}
+
+#[test]
+fn parametric_enum_invariant_tests_do_not_cluster() -> Result<()> {
+    let scan_root = fixture("python-issue-97-parametric-invariant-tests");
+    let report = run_report(&scan_root)?;
+    let offenders = parametric_test_offenders(&report, &scan_root)?;
+    assert!(
+        offenders.is_empty(),
+        "`test_register_<variant>` bodies varying only by enum member \
+         access must not surface as duplicates — each test name is its \
+         own spec assertion: {offenders:#?}"
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
+++ b/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
@@ -1,0 +1,112 @@
+//! E2E regression for GH #154.
+//!
+//! `top-offenders` was surfacing `structural_only` clusters
+//! (`structural=1.00, token_jaccard=0.00, embedding_cos=0.00`) that
+//! matched function signatures whose bodies were entirely unrelated.
+//! The pattern is unavoidable in any codebase that uses shared-context
+//! structs (`fn check_*(ctx: &mut Ctx)`), so refactoring the source to
+//! silence deslop would hurt readability. The pipeline must drop these
+//! evidence-free clusters from the ranked report.
+//!
+//! Acceptance: the rendered report MUST NOT contain any cluster with
+//! `bucket="structural_only"` AND `token_jaccard < 0.1`. By construction
+//! every `structural_only` cluster the renderer emits already satisfies
+//! the second condition, so this assertion really demands that the
+//! whole bucket be filtered from `clusters`.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("4")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn cluster_bucket(cluster: &Value) -> &str {
+    cluster.get("bucket").and_then(Value::as_str).unwrap_or("?")
+}
+
+fn signal(cluster: &Value, key: &str) -> f64 {
+    cluster
+        .pointer(&format!("/signals/{key}"))
+        .and_then(Value::as_f64)
+        .unwrap_or_default()
+}
+
+#[test]
+fn structural_only_signature_clusters_are_dropped_from_the_report() -> Result<()> {
+    let scan_root = fixture("rust-issue-154-structural-only");
+    let report = run_report(&scan_root)?;
+    let total_clusters = report
+        .pointer("/metrics/clusters_total")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    assert!(
+        total_clusters >= 1,
+        "fixture must produce at least one cluster (visible or hidden) so \
+         the structural_only filter is actually exercised: {report:#}"
+    );
+    let clusters = report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let offenders: Vec<String> = clusters
+        .iter()
+        .filter(|cluster| cluster_bucket(cluster) == "structural_only")
+        .filter(|cluster| signal(cluster, "token_jaccard") < 0.1)
+        .map(|cluster| {
+            format!(
+                "cluster {id} signals={{structural={s:.2}, token_jaccard={t:.2}, \
+                 embedding_cos={e:.2}}} size={size}",
+                id = cluster.get("id").and_then(Value::as_str).unwrap_or("?"),
+                s = signal(cluster, "structural"),
+                t = signal(cluster, "token_jaccard"),
+                e = signal(cluster, "embedding_cos"),
+                size = cluster.get("size").and_then(Value::as_u64).unwrap_or(0),
+            )
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "issue #154: structural_only clusters with token_jaccard < 0.1 \
+         have no real evidence and must not appear in the ranked report. \
+         Offending clusters: {offenders:#?}"
+    );
+    let hidden = report
+        .get("clusters_hidden")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    assert!(
+        hidden >= 1,
+        "the fixture's structural_only clusters must be suppressed via \
+         the hidden-cluster path so they still count toward visibility \
+         telemetry: clusters_hidden={hidden}, report={report:#}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## TLDR
Fixes five showstopper false-positive / freshness bugs: live IPC reads now see post-edit byte ranges (#153, #156), signature-only Rust clusters with divergent bodies are suppressed (#154), and Python StrEnum / Pydantic partial-update / parametric-invariant-test false positives are dropped (#115, #97).

Closes #97
Closes #115
Closes #153
Closes #154
Closes #156

## Details

**#153 / #156 — Live read freshness ([LIVE-READ-FRESHNESS])**
- New `crates/deslop-core/src/live/freshness.rs` `FreshnessTracker` — per-file mtime ledger.
- Recorded inside `AnalysisSession::finalise` and after every `apply_changes` / `install_pipeline` commit.
- `LiveService` calls `refresh_if_stale()` before serving every IPC read (`report/get`, `report/delta`, `report/forFile`, `report/forRange`, `cluster/byId`, `duplicates/findSimilar`). Stale paths are funnelled through `apply_changes` synchronously so reads never see pre-edit byte ranges.

**#154 — Signature-only structural cluster suppression ([CLONE-NOISE-SIGNATURE-ONLY])**
- New filter in `crates/deslop-core/src/cluster_filters/mod.rs::is_signature_only_cluster`.
- Drops the cluster when every member's matched subtree sits entirely inside a function signature AND the enclosing bodies have a divergent AST node-kind sequence (not just literal/identifier differences).
- Comparing *AST shape* (not raw bytes) keeps legitimate near-miss clusters where the bodies are identical-shape with literal differences (e.g. the issue #50 acceptance fixture).

**#115 — Python class-shape false positives**
- New `crates/deslop-core/src/cluster_filters/python_class_shapes.rs`:
  - `is_strenum_class_shape_cluster` — `class X(StrEnum)` docstring + assignment-only bodies.
  - `is_pydantic_partial_update_cluster` — `XCreate` / `XUpdate` mirror mandated by Pydantic.
- (Workspace local-mirror is out of scope for a generic filter — users suppress via `.deslop.toml` `[language.python] exclude`.)

**#97 — Python parametric invariant tests ([CLONE-NOISE-PY-PARAMETRIC-INVARIANT-TESTS])**
- New `is_parametric_invariant_test_cluster` in `cluster_filters/python.rs` — drops `def test_register_<variant>()` siblings that vary only by `Capitalised.UPPER_SNAKE` enum-member access tokens.

## How Do The Automated Tests Prove It Works?

Seven new end-to-end regression tests, each one asserting the *observable* behaviour the GitHub issue described:

- `crates/deslop-mcp/tests/issue_153_rescan_freshness.rs`:
  - `issue_153_single_rescan_reflects_post_edit_state` — overwrites four fixture files, calls `rescan` once, asserts the response carries zero stale clusters.
  - `issue_153_rescan_occurrence_offsets_reflect_post_edit_file` — inserts 40 padding lines into Alpha.cs, calls `rescan` once, asserts the surviving Alpha occurrence `start_byte >= padding_bytes`.
- `crates/deslop-mcp/tests/issue_156_cluster_id_stale_offsets.rs::issue_156_cluster_by_id_returns_post_edit_offsets` — without an explicit refresh, asserts `cluster-by-id` returns occurrences whose byte ranges still fall inside the post-edit file.
- `crates/deslop/tests/rust_issue_154_structural_only_signatures.rs::structural_only_signature_clusters_are_dropped_from_the_report` — Rust fixture with three `check_*(ctx: &mut ProtoCheckCtx<'_>)` functions whose bodies differ structurally; asserts no cluster surfaces.
- `crates/deslop/tests/python_issue_115_strenum.rs::strenum_class_shapes_do_not_cluster` — two `class X(StrEnum)` files with disjoint vocab; asserts no cluster.
- `crates/deslop/tests/python_issue_115_pydantic_partial.rs::pydantic_create_update_mirrors_do_not_cluster` — `XCreate`/`XUpdate` siblings; asserts no cluster.
- `crates/deslop/tests/python_issue_97_parametric_invariant_tests.rs::parametric_enum_invariant_tests_do_not_cluster` — `test_register_<variant>()` test family; asserts no cluster.

The existing issue #50 acceptance test (`cross_cluster_collapse::fact_decorated_identical_methods_produce_one_cluster`) still passes — the AST-shape comparison in the #154 filter preserves legitimate near-miss clusters whose bodies share AST shape but differ in literals.

`make ci` is green locally: fmt clean, clippy `-D warnings` clean, all suites pass, workspace coverage 95.0% with every per-crate floor satisfied (1% slack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
