### PR TITLE
fix: false-positive filters (#104, #119) + MCP -32004 recovery data (#157)

### DIFF
--- a/crates/deslop-core/src/cluster_filters/mod.rs
+++ b/crates/deslop-core/src/cluster_filters/mod.rs
@@ -74,6 +74,11 @@
 //!   a function, never the body. After normalisation these collapse to
 //!   identical shape but the bodies are unrelated. Token Jaccard cannot
 //!   refute the match because identifiers normalise away too.
+//! - **#104** [CLONE-NOISE-PY-MODULE-PREAMBLE] — a sibling-window
+//!   fingerprint can span a run of >=2 module-level helper/fixture
+//!   definitions. Two test files whose preambles share that shape cluster
+//!   even though every helper body differs. Suppressed only when no two
+//!   members share identical bodies, so a verbatim/renamed copy survives.
 //!
 //! The filter is purely additive: it never re-routes a `nearly_identical`
 //! cluster as `identical`, only suppresses noise. Any cluster whose
@@ -84,7 +89,9 @@ mod calls;
 mod python;
 mod python_class_shapes;
 mod python_idioms;
+mod python_module_preamble;
 mod python_orm;
+mod role_compat;
 mod rust;
 
 use std::{
@@ -129,6 +136,29 @@ pub(crate) fn is_noise_pattern<S: BuildHasher>(
         || python::is_parametric_invariant_test_cluster(&snippets)
         || rust::is_rust_top_level_decl_cluster(&snippets)
         || rust::is_rust_iter_collect_idiom_cluster(&snippets)
+        || python_module_preamble::is_module_preamble_sequence_cluster(&snippets)
+}
+
+/// Decides whether an embedding-dominant `same_behavior` cluster pairs
+/// members of incompatible top-level roles — a class/type definition
+/// with a function/method (issue **#119**
+/// [CLONE-NOISE-EMBEDDING-ROLE-MISMATCH]). Returns `true` when the
+/// cluster should be hidden. The caller restricts this to the
+/// `same_behavior` bucket so deterministic Type-1/2/3 clusters are
+/// untouched. Falls through to `false` when sources or a uniform
+/// language are unavailable.
+pub(crate) fn is_embedding_role_mismatch<S: BuildHasher>(
+    members: &[Fingerprint],
+    sources: &HashMap<FileId, Vec<u8>>,
+    file_languages: &HashMap<FileId, &'static str, S>,
+) -> bool {
+    let Some(language) = uniform_language(members, file_languages) else {
+        return false;
+    };
+    let Some(snippets) = collect_snippets(members, sources, language) else {
+        return false;
+    };
+    role_compat::is_role_incompatible_embedding_match(&snippets)
 }
 
 /// Trims surrounding ASCII whitespace from a reported snippet range so

--- a/crates/deslop-core/src/cluster_filters/python_module_preamble.rs
+++ b/crates/deslop-core/src/cluster_filters/python_module_preamble.rs
@@ -1,0 +1,110 @@
+//! Module-preamble sibling-window filter for Python test files.
+//!
+//! Issue **#104** [CLONE-NOISE-PY-MODULE-PREAMBLE]: the sibling-window
+//! fingerprinter emits a fingerprint over a contiguous run of >=2
+//! module-level definitions. A test module that opens with several small
+//! helpers/fixtures therefore matches any other test module whose
+//! preamble has the same number of equally-shaped definitions, reaching
+//! `structural=1.00, token_jaccard=1.00` after Type-2 normalisation. The
+//! match unit is a "block of declarations", not a coherent code unit —
+//! the embedding pass correctly scores it ~0.
+//!
+//! We suppress such a cluster **only** when no two members share
+//! identical definition bodies. A helper module copied verbatim across
+//! files (or copy-pasted then renamed, since renaming leaves the body
+//! bytes intact) has body-equivalent members and is kept — that is real,
+//! extractable duplication. Keying on body divergence rather than name
+//! divergence is what distinguishes a coincidental preamble shape from a
+//! genuine copy, mirroring [`super::enclosing_function_bodies_differ`].
+
+use std::collections::BTreeSet;
+
+use tree_sitter::Node;
+
+use super::{parse_for, trimmed_snippet_range, Snippet};
+use crate::ast::ByteRange;
+
+/// Top-level definition kinds that make up a Python test-module preamble.
+/// `class_definition` is intentionally excluded: class-shape false
+/// positives are handled by [`super::python_class_shapes`], and counting
+/// classes here would widen the detector beyond the function-preamble
+/// target (e.g. distinct ORM model classes).
+const PREAMBLE_KINDS: &[&str] = &["function_definition", "decorated_definition"];
+
+/// Returns true when every member's matched range spans a run of >=2
+/// sibling top-level definitions and no two members share identical
+/// definition bodies — the coincidental-preamble-shape signature of
+/// issue **#104**. Returns false (keeps the cluster) when any member is
+/// not such a multi-definition run, or when two members are body
+/// equivalent (a genuine copy that must still surface).
+pub(super) fn is_module_preamble_sequence_cluster(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 || !snippets.iter().all(|snippet| snippet.language == "python") {
+        return false;
+    }
+    let mut files = BTreeSet::new();
+    for snippet in snippets {
+        let _inserted = files.insert(snippet.file_id);
+    }
+    if files.len() < 2 {
+        return false;
+    }
+    let bodies: Option<Vec<Vec<u8>>> = snippets.iter().map(member_preamble_bodies).collect();
+    let Some(bodies) = bodies else { return false };
+    all_member_bodies_distinct(&bodies)
+}
+
+/// Concatenates the bodies of the >=2 sibling top-level definitions the
+/// member's trimmed range spans, in source order. Returns `None` when the
+/// range covers fewer than two such definitions or a body is unreadable.
+fn member_preamble_bodies(snippet: &Snippet<'_>) -> Option<Vec<u8>> {
+    let tree = parse_for(snippet)?;
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let definitions = top_level_definitions_in_range(tree.root_node(), range);
+    if definitions.len() < 2 {
+        return None;
+    }
+    let mut bytes = Vec::new();
+    for node in definitions {
+        bytes.extend_from_slice(definition_body_bytes(node, snippet.source)?);
+    }
+    Some(bytes)
+}
+
+/// Collects the direct `module` children of a preamble definition kind
+/// whose byte span lies fully inside `range`, in source order. Does not
+/// recurse, so nested definitions never count toward the run.
+fn top_level_definitions_in_range(root: Node<'_>, range: ByteRange) -> Vec<Node<'_>> {
+    let mut cursor = root.walk();
+    root.named_children(&mut cursor)
+        .filter(|child| PREAMBLE_KINDS.contains(&child.kind()))
+        .filter(|child| child.start_byte() >= range.start && child.end_byte() <= range.end)
+        .collect()
+}
+
+/// Returns the body bytes of a definition node, descending one level into
+/// a `decorated_definition` to reach its wrapped `function_definition`.
+fn definition_body_bytes<'a>(node: Node<'_>, source: &'a [u8]) -> Option<&'a [u8]> {
+    let function = function_node(node)?;
+    let body = function.child_by_field_name("body")?;
+    source.get(body.start_byte()..body.end_byte())
+}
+
+/// Resolves a preamble definition node to its `function_definition`,
+/// unwrapping a `decorated_definition` if needed.
+fn function_node(node: Node<'_>) -> Option<Node<'_>> {
+    if node.kind() == "function_definition" {
+        return Some(node);
+    }
+    let mut cursor = node.walk();
+    let function = node
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "function_definition");
+    function
+}
+
+/// Returns true when every member's concatenated body bytes are unique —
+/// i.e. no two members are body-equivalent copies of each other.
+fn all_member_bodies_distinct(bodies: &[Vec<u8>]) -> bool {
+    let unique: BTreeSet<&Vec<u8>> = bodies.iter().collect();
+    unique.len() == bodies.len()
+}

--- a/crates/deslop-core/src/cluster_filters/role_compat.rs
+++ b/crates/deslop-core/src/cluster_filters/role_compat.rs
@@ -1,0 +1,103 @@
+//! Role-compatibility gate for embedding-dominant `same_behavior`
+//! clusters.
+//!
+//! Issue **#119** [CLONE-NOISE-EMBEDDING-ROLE-MISMATCH]: the embedding
+//! pass can pair two snippets that share a topic vocabulary but live in
+//! structurally incompatible constructs — e.g. a reusable transport
+//! helper *class* and a constructor-storage *test method*. Such a pair
+//! reaches `structural=0.00`, `embedding_cos>=0.80`, and surfaces as
+//! "Same behavior, different code". There is no safe extraction across
+//! a class definition and a function/method: their roles differ.
+//!
+//! This filter engages **only** for embedding-dominant matches (the
+//! caller restricts it to the `same_behavior` bucket). It suppresses a
+//! cluster when its members do not all share one top-level construct
+//! role — all classes, or all functions/methods. Two genuinely
+//! behaviour-equivalent functions (same role) that the embedding
+//! correctly pairs keep clustering.
+
+use tree_sitter::Node;
+
+use super::{enclosing_kind, function_kinds, parse_for, trimmed_snippet_range, Snippet};
+
+/// Top-level construct role a cluster member resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MemberRole {
+    /// The matched range's innermost enclosing construct is a class or
+    /// other type definition (`class_definition`, `class_declaration`,
+    /// `struct_item`, …).
+    TypeDef,
+    /// The matched range's innermost enclosing construct is a
+    /// function or method definition.
+    Function,
+}
+
+/// Returns true when this embedding-dominant cluster pairs members of
+/// incompatible top-level roles (a class/type definition with a
+/// function/method). The caller restricts this to `same_behavior`
+/// clusters so deterministic Type-1/2/3 buckets are untouched.
+///
+/// Returns false (does not suppress) when any member's role cannot be
+/// resolved — an unknown role is never grounds to hide duplication.
+pub(super) fn is_role_incompatible_embedding_match(snippets: &[Snippet<'_>]) -> bool {
+    if snippets.len() < 2 {
+        return false;
+    }
+    let roles: Option<Vec<MemberRole>> = snippets.iter().map(member_role).collect();
+    let Some(roles) = roles else { return false };
+    let Some(first) = roles.first() else {
+        return false;
+    };
+    roles.iter().any(|role| role != first)
+}
+
+/// Resolves the innermost enclosing top-level construct role for one
+/// member by re-parsing its source and picking the tightest enclosing
+/// node that is either a type definition or a function. Returns `None`
+/// when the language has no registered grammar or the range is not
+/// inside any such construct.
+fn member_role(snippet: &Snippet<'_>) -> Option<MemberRole> {
+    let tree = parse_for(snippet)?;
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let node = enclosing_kind(tree.root_node(), range, &role_kinds(snippet.language))?;
+    Some(role_of(node, snippet.language))
+}
+
+/// Classifies an enclosing construct node into its [`MemberRole`].
+fn role_of(node: Node<'_>, language: &str) -> MemberRole {
+    if function_kinds(language).contains(&node.kind()) {
+        MemberRole::Function
+    } else {
+        MemberRole::TypeDef
+    }
+}
+
+/// All node kinds that count as a top-level construct for role
+/// resolution: every function kind plus every type-definition kind for
+/// the language.
+fn role_kinds(language: &str) -> Vec<&'static str> {
+    let mut kinds = function_kinds(language).to_vec();
+    kinds.extend_from_slice(type_kinds(language));
+    kinds
+}
+
+/// Type-definition node kinds per language. A member enclosed by one of
+/// these (and by no tighter function) resolves to [`MemberRole::TypeDef`].
+const fn type_kinds(language: &str) -> &'static [&'static str] {
+    match language.as_bytes() {
+        b"python" => &["class_definition"],
+        b"csharp" => &[
+            "class_declaration",
+            "struct_declaration",
+            "record_declaration",
+        ],
+        b"rust" => &[
+            "struct_item",
+            "enum_item",
+            "trait_item",
+            "impl_item",
+            "union_item",
+        ],
+        _ => &[],
+    }
+}

--- a/crates/deslop-core/src/live/mod.rs
+++ b/crates/deslop-core/src/live/mod.rs
@@ -30,6 +30,7 @@ pub use notifications::{
 };
 pub use scheduler::Scheduler;
 pub use session::{AnalysisSession, EmbeddingProgressReporter};
+pub use session_helpers::STATE_FILE_NAME as LIVE_REPORT_FILE_NAME;
 pub use watcher::LiveWatcher;
 pub use wire::{
     AnalysisState, ChangeSummary, EmbeddingModelInfo, EmbeddingPhase, EmbeddingProgress,

--- a/crates/deslop-core/src/live/session_helpers.rs
+++ b/crates/deslop-core/src/live/session_helpers.rs
@@ -243,8 +243,11 @@ pub(super) fn cluster_matches_any_hash(
 
 /// [LIVE-CACHE-SEED] Default name of the cache file the LSP writes
 /// after every analysis pass. The MCP and any cache-seed startup path
-/// read from this same file.
-pub(super) const STATE_FILE_NAME: &str = "live-report.json";
+/// read from this same file. Re-exported as
+/// [`crate::live::LIVE_REPORT_FILE_NAME`] so the MCP can name the
+/// on-disk fallback in its `LspNotRunning` recovery payload without
+/// duplicating the literal ([Deslop#157]).
+pub const STATE_FILE_NAME: &str = "live-report.json";
 
 /// [LIVE-SEED-CACHE] Writes `bytes` to `{dir}/live-report.json` via an
 /// atomic tmp-then-rename so readers never see a partial file.

--- a/crates/deslop-core/src/report.rs
+++ b/crates/deslop-core/src/report.rs
@@ -13,7 +13,7 @@ use crate::{
     boilerplate::BoilerplateRange,
     buckets::{classify, ClusterKind},
     cluster::Cluster,
-    cluster_filters::is_noise_pattern,
+    cluster_filters::{is_embedding_role_mismatch, is_noise_pattern},
     config::ExclusionConfig,
     pair::PairScore,
     report_boilerplate::build_boilerplate_hints,
@@ -154,7 +154,8 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
             // causing these to rank as #1 offenders despite containing no
             // actionable duplication. Exclude them from the human-facing ranked
             // output; the raw analysis data remains available via the pipeline.
-            let loosely_similar = classify(&report_cluster) == ClusterKind::LooselySimilar;
+            let kind = classify(&report_cluster);
+            let loosely_similar = kind == ClusterKind::LooselySimilar;
             // GH #120/#122: embedding can pull broad, module-level same-topic
             // regions into one giant Type-4 component. Near-zero structure,
             // high semantic score, large size, and a large canonical span is
@@ -169,9 +170,22 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
             // monkeypatch.setenv scaffolding) that survive Type-2
             // normalisation but are not real duplication.
             let noise = is_noise_pattern(&cluster.members, inputs.sources, inputs.file_languages);
+            // GH #119 [CLONE-NOISE-EMBEDDING-ROLE-MISMATCH]: an
+            // embedding-dominant `same_behavior` pair must be role/context
+            // compatible (all classes, or all functions) before surfacing.
+            // A class definition paired with a function/method has no safe
+            // extraction, so suppress it. Restricted to the `same_behavior`
+            // bucket so deterministic Type-1/2/3 clusters are untouched.
+            let role_mismatch = kind == ClusterKind::SameBehavior
+                && is_embedding_role_mismatch(
+                    &cluster.members,
+                    inputs.sources,
+                    inputs.file_languages,
+                );
             let all_hidden = ((loosely_similar || low_structure_embedding_mega_cluster)
                 && !cross_language_audit)
                 || noise
+                || role_mismatch
                 || (!report_cluster.occurrences.is_empty()
                     && report_cluster.occurrences.iter().all(|occ| occ.hidden));
             (report_cluster, all_hidden)

--- a/crates/deslop-mcp/src/tools/mod.rs
+++ b/crates/deslop-mcp/src/tools/mod.rs
@@ -215,6 +215,44 @@ pub fn backend_to_rpc(err: crate::backend::BackendError) -> JsonRpcError {
             ErrorCode::InvalidParams,
             format!("no cluster with id {id:?}"),
         ),
+        BackendError::LspNotRunning { socket_path } => lsp_not_running_rpc(&socket_path),
         other => jsonrpc_error(ErrorCode::BackendError, other.to_string()),
     }
+}
+
+/// Builds the `-32004` error for a missing LSP, attaching a structured
+/// recovery payload so agents can decide whether to retry and where the
+/// on-disk fallback lives ([Deslop#157]). The numeric code and the
+/// human message ([Deslop#151]) are reproduced verbatim for wire
+/// back-compat; only the previously-`null` `data` field is enriched.
+fn lsp_not_running_rpc(socket_path: &std::path::Path) -> JsonRpcError {
+    let message = crate::backend::BackendError::LspNotRunning {
+        socket_path: socket_path.to_path_buf(),
+    }
+    .to_string();
+    JsonRpcError {
+        code: crate::protocol::ErrorCode::BackendError as i32,
+        message,
+        data: Some(lsp_recovery_data(socket_path)),
+    }
+}
+
+/// Assembles the machine-readable recovery payload for a missing LSP.
+/// The cache-fallback path is derived from the socket's parent directory
+/// (the `.deslop-cache` dir) joined with the canonical live-report file
+/// name, so an agent can read the last analysis while the LSP is down.
+fn lsp_recovery_data(socket_path: &std::path::Path) -> Value {
+    let cache_fallback = socket_path
+        .parent()
+        .map(|dir| dir.join(deslop_core::live::LIVE_REPORT_FILE_NAME));
+    json!({
+        "reason": "lsp_not_running",
+        "retry_after_ms": 500,
+        "socket_path": socket_path.display().to_string(),
+        "cache_fallback": {
+            "path": cache_fallback.map(|path| path.display().to_string()),
+            "format": "live-report-json",
+            "note": "If the LSP stays down after retry, read this on-disk live-report cache for the last analysis.",
+        },
+    })
 }

--- a/crates/deslop-mcp/tests/issue_157_lsp_not_running_recovery_data.rs
+++ b/crates/deslop-mcp/tests/issue_157_lsp_not_running_recovery_data.rs
@@ -1,0 +1,89 @@
+//! [Deslop#157] When the LSP is not running, the `-32004` error must
+//! carry structured recovery guidance in its `data` field so an agent
+//! can decide whether to retry and where the on-disk fallback lives.
+//!
+//! Before this fix the error carried only a human message (`data: null`),
+//! leaving agents to discover the `.deslop-cache/live-report.json`
+//! fallback by accident. The numeric code and the existing human message
+//! (socket path + `--root`, per [Deslop#151]) must be preserved verbatim.
+
+#![cfg(unix)]
+
+use anyhow::{anyhow, ensure, Result};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+mod common;
+use common::initialized_mcp;
+
+#[test]
+fn issue_157_lsp_not_running_carries_structured_recovery_data() -> Result<()> {
+    let workspace = TempDir::new()?;
+    // Intentionally do NOT spawn an LSP. The socket file is absent, so
+    // every tool call returns BackendError::LspNotRunning (-32004).
+    let mut mcp = initialized_mcp(workspace.path())?;
+    let response = mcp.request(
+        "tools/call",
+        &json!({ "name": "top-offenders", "arguments": { "n": 5 } }),
+    )?;
+    let error = response
+        .pointer("/error")
+        .ok_or_else(|| anyhow!("expected error frame, got: {response}"))?;
+
+    // Wire back-compat: numeric code and the [Deslop#151] message are intact.
+    ensure!(
+        error.get("code").and_then(Value::as_i64) == Some(-32_004),
+        "numeric error code must stay -32004 for wire back-compat: {error}"
+    );
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("error missing string message: {error}"))?;
+    let canonical = std::fs::canonicalize(workspace.path())?;
+    let socket_fragment = canonical
+        .join(".deslop-cache")
+        .join("deslop.sock")
+        .display()
+        .to_string();
+    ensure!(
+        message.contains(&socket_fragment) && message.contains("--root"),
+        "message must still name the socket path and --root ([Deslop#151]): {message}"
+    );
+
+    // New: structured recovery payload.
+    let data = error
+        .get("data")
+        .ok_or_else(|| anyhow!("LspNotRunning error must carry a data payload: {error}"))?;
+    ensure!(
+        data.get("reason").and_then(Value::as_str) == Some("lsp_not_running"),
+        "data.reason must be the stable machine-readable id: {data}"
+    );
+    let retry = data
+        .get("retry_after_ms")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| anyhow!("data.retry_after_ms must be a positive integer: {data}"))?;
+    ensure!(retry > 0, "retry_after_ms must be positive: {data}");
+    ensure!(
+        data.get("socket_path")
+            .and_then(Value::as_str)
+            .is_some_and(|path| path.contains(".deslop-cache")),
+        "data.socket_path must name the IPC socket: {data}"
+    );
+    let fallback = data
+        .get("cache_fallback")
+        .ok_or_else(|| anyhow!("data.cache_fallback must document the on-disk fallback: {data}"))?;
+    ensure!(
+        fallback.is_object(),
+        "cache_fallback must be a structured object agents can dispatch on: {fallback}"
+    );
+    ensure!(
+        fallback
+            .get("path")
+            .and_then(Value::as_str)
+            .is_some_and(
+                |path| path.ends_with("live-report.json") && path.contains(".deslop-cache")
+            ),
+        "cache_fallback.path must point at .deslop-cache/live-report.json: {fallback}"
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/fixtures/python-issue-104-genuine-copy/billing_helpers.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-genuine-copy/billing_helpers.py
@@ -1,0 +1,11 @@
+import base64
+
+
+def checksum(raw):
+    digest = base64.b64encode(raw)
+    return digest
+
+
+def verify(blob):
+    decoded = base64.b64decode(blob)
+    return decoded

--- a/crates/deslop/tests/fixtures/python-issue-104-genuine-copy/billing_helpers_copy.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-genuine-copy/billing_helpers_copy.py
@@ -1,0 +1,11 @@
+import base64
+
+
+def checksum(raw):
+    digest = base64.b64encode(raw)
+    return digest
+
+
+def verify(blob):
+    decoded = base64.b64decode(blob)
+    return decoded

--- a/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/service_a.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/service_a.py
@@ -1,0 +1,11 @@
+import codec
+
+
+def encode_token(raw):
+    packed = codec.encode(raw)
+    return packed
+
+
+def decode_token(blob):
+    unpacked = codec.decode(blob)
+    return unpacked

--- a/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/service_b.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/service_b.py
@@ -1,0 +1,11 @@
+import codec
+
+
+def encode_token(raw):
+    packed = codec.encode(raw)
+    return packed
+
+
+def decode_token(blob):
+    unpacked = codec.decode(blob)
+    return unpacked

--- a/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/widget_helpers.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-mixed-copy-lookalike/widget_helpers.py
@@ -1,0 +1,11 @@
+import router
+
+
+def build_url(host):
+    joined = router.join(host)
+    return joined
+
+
+def split_path(text):
+    parts = router.split(text)
+    return parts

--- a/crates/deslop/tests/fixtures/python-issue-104-module-preamble/test_vision_http_e2e.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-module-preamble/test_vision_http_e2e.py
@@ -1,0 +1,23 @@
+import json
+
+import pytest
+
+
+def build_url(host):
+    address = json.dumps(host)
+    return address
+
+
+def split_lines(text):
+    rows = json.loads(text)
+    return rows
+
+
+@pytest.fixture
+def http_session():
+    return {"timeout": 30}
+
+
+@pytest.fixture
+def sample_headers():
+    return b"Accept: */*"

--- a/crates/deslop/tests/fixtures/python-issue-104-module-preamble/test_vision_ollama_e2e.py
+++ b/crates/deslop/tests/fixtures/python-issue-104-module-preamble/test_vision_ollama_e2e.py
@@ -1,0 +1,23 @@
+import base64
+
+import pytest
+
+
+def encode_payload(raw):
+    encoded = base64.b64encode(raw)
+    return encoded
+
+
+def decode_payload(blob):
+    decoded = base64.b64decode(blob)
+    return decoded
+
+
+@pytest.fixture
+def ollama_client():
+    return {"endpoint": "http://localhost:11434"}
+
+
+@pytest.fixture
+def sample_image():
+    return b"\x89PNG"

--- a/crates/deslop/tests/fixtures/python-issue-119-role-mismatch/transport.py
+++ b/crates/deslop/tests/fixtures/python-issue-119-role-mismatch/transport.py
@@ -1,0 +1,13 @@
+@traced
+class BoomTransport:
+    alpha = 0
+    bravo = 0
+    charlie = 0
+    delta = "xx"
+
+
+@traced
+def test_transport_keep(stub):
+    saved = wrap(stub)
+    saved.bind(stub)
+    assert saved.n == 0

--- a/crates/deslop/tests/fixtures/python-issue-119-same-role/helpers.py
+++ b/crates/deslop/tests/fixtures/python-issue-119-same-role/helpers.py
@@ -1,0 +1,13 @@
+def total_recursive(limit):
+    if limit <= 0:
+        return 0
+    return limit + total_recursive(limit - 1)
+
+
+def total_iterative(limit):
+    running = 0
+    index = 1
+    while index <= limit:
+        running = running + index
+        index = index + 1
+    return running

--- a/crates/deslop/tests/python_issue_104_module_preamble.rs
+++ b/crates/deslop/tests/python_issue_104_module_preamble.rs
@@ -1,0 +1,199 @@
+//! E2E regression for GH #104 [CLONE-NOISE-PY-MODULE-PREAMBLE].
+//!
+//! A sibling-window fingerprint can cover a contiguous run of >=2
+//! module-level definitions — a test-module preamble of several small
+//! helpers/fixtures. Two unrelated test files that happen to open with
+//! the same number of equally-shaped helpers then cluster as duplicates
+//! (`structural=1.00`, `token_jaccard=1.00`) even though every helper's
+//! body differs. Matching a "block of declarations" is not duplication.
+//!
+//! The fix suppresses such a cluster ONLY when no two members share
+//! identical definition bodies — so a genuinely copy-pasted helper
+//! module (same bodies across files) still surfaces. This test pins both
+//! directions: the differently-bodied preamble is hidden, and the
+//! verbatim-copied helper module stays visible.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use assert_cmd::Command;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("4")
+        .arg("--embeddings")
+        .arg("off")
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn clusters(report: &Value) -> &[Value] {
+    report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
+    cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .map(|occurrence| occurrence_text(scan_root, occurrence))
+        .collect()
+}
+
+fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
+    let path = occurrence
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("occurrence missing path"))?;
+    let source = fs::read_to_string(scan_root.join(path))?;
+    let start = occurrence_byte(occurrence, "start_byte")?;
+    let end = occurrence_byte(occurrence, "end_byte")?;
+    source
+        .get(start..end)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("occurrence range invalid"))
+}
+
+fn occurrence_byte(occurrence: &Value, field: &str) -> Result<usize> {
+    occurrence
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("occurrence missing {field}"))
+}
+
+/// Collects every visible cluster whose occurrences contain `needle`.
+fn clusters_touching(report: &Value, scan_root: &Path, needle: &str) -> Result<Vec<Vec<String>>> {
+    let mut hits = Vec::new();
+    for cluster in clusters(report) {
+        let texts = occurrence_texts(scan_root, cluster)?;
+        if texts.iter().any(|text| text.contains(needle)) {
+            hits.push(texts);
+        }
+    }
+    Ok(hits)
+}
+
+// GH #104 acceptance: a module preamble of differently-bodied helpers
+// from two unrelated test files must NOT surface as duplicate logic.
+#[test]
+fn differently_bodied_module_preamble_does_not_surface() -> Result<()> {
+    let scan_root = fixture("python-issue-104-module-preamble");
+    let report = run_report(&scan_root)?;
+    let encode = clusters_touching(&report, &scan_root, "def encode_payload(")?;
+    let build = clusters_touching(&report, &scan_root, "def build_url(")?;
+    assert!(
+        encode.is_empty() && build.is_empty(),
+        "two test files that merely open with the same number of equally \
+         shaped — but differently bodied — helpers must not cluster as \
+         duplication: encode={encode:#?} build={build:#?}"
+    );
+    Ok(())
+}
+
+// GH #104 over-suppression guard: a helper module copied verbatim into
+// two files (identical bodies) IS real duplication and must still
+// surface — the suppression keys on body divergence, not name divergence.
+#[test]
+fn verbatim_copied_helper_module_still_surfaces() -> Result<()> {
+    let scan_root = fixture("python-issue-104-genuine-copy");
+    let report = run_report(&scan_root)?;
+    let copied = clusters_touching(&report, &scan_root, "def checksum(")?;
+    assert!(
+        !copied.is_empty(),
+        "a verbatim-copied helper module must still surface as duplication: \
+         {:#?}",
+        clusters(&report)
+    );
+    let spans_both_files = clusters(&report).iter().try_fold(false, |found, cluster| {
+        let paths: Vec<String> = cluster
+            .get("occurrences")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|occ| {
+                occ.get("path")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .collect();
+        let texts = occurrence_texts(&scan_root, cluster)?;
+        let touches_checksum = texts.iter().any(|text| text.contains("checksum"));
+        let left = paths.iter().any(|path| path.contains("billing_helpers.py"));
+        let right = paths
+            .iter()
+            .any(|path| path.contains("billing_helpers_copy.py"));
+        Ok::<bool, anyhow::Error>(found || (touches_checksum && left && right))
+    })?;
+    assert!(
+        spans_both_files,
+        "the surviving clone must span both copies of the helper module: {:#?}",
+        clusters(&report)
+    );
+    Ok(())
+}
+
+// GH #104 hardest case: a verbatim-copied preamble (service_a/service_b)
+// and a same-shaped-but-differently-bodied lookalike (widget_helpers) all
+// share one structural fingerprint, so the clusterer merges them into a
+// single cluster. A names-only guard would suppress the whole cluster —
+// destroying the genuine service_a/service_b clone. The body-equivalence
+// guard must keep it: two members share identical bodies, so the cluster
+// carries real duplication and stays visible.
+#[test]
+fn verbatim_copy_among_lookalikes_still_surfaces() -> Result<()> {
+    let scan_root = fixture("python-issue-104-mixed-copy-lookalike");
+    let report = run_report(&scan_root)?;
+    let surfaces_genuine_copy = clusters(&report).iter().try_fold(false, |found, cluster| {
+        let paths: Vec<String> = cluster
+            .get("occurrences")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|occ| {
+                occ.get("path")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .collect();
+        let texts = occurrence_texts(&scan_root, cluster)?;
+        let touches_token = texts.iter().any(|text| text.contains("encode_token"));
+        let a = paths.iter().any(|path| path.contains("service_a.py"));
+        let b = paths.iter().any(|path| path.contains("service_b.py"));
+        Ok::<bool, anyhow::Error>(found || (touches_token && a && b))
+    })?;
+    assert!(
+        surfaces_genuine_copy,
+        "a verbatim copy hiding among same-shape lookalikes must still \
+         surface — the guard keys on body divergence, not names: {:#?}",
+        clusters(&report)
+    );
+    Ok(())
+}

--- a/crates/deslop/tests/python_issue_119_embedding_role_mismatch.rs
+++ b/crates/deslop/tests/python_issue_119_embedding_role_mismatch.rs
@@ -1,0 +1,199 @@
+//! E2E regression for GH #119 [CLONE-NOISE-EMBEDDING-ROLE-MISMATCH].
+//!
+//! The embedding pass can pair two snippets that share a topic
+//! vocabulary but live in structurally incompatible constructs — a
+//! reusable helper *class* and a constructor-storage *test method*.
+//! Such a pair reaches `structural=0.00`, `embedding_cos>=0.80`, and
+//! surfaces as "Same behavior, different code" even though a class
+//! definition and a function/method have no safe shared extraction.
+//!
+//! The fix requires an embedding-dominant `same_behavior` cluster to be
+//! role/context compatible (all classes, or all functions) before
+//! surfacing. A class-def paired with a function/method is suppressed.
+//! Two genuinely behaviour-equivalent functions (same role) that the
+//! embedding correctly pairs must still surface.
+//!
+//! Determinism: the in-process [`MockOllama`] embeds each snippet to a
+//! 4-lane vector seeded by its byte length and first byte, so two
+//! snippets of equal length give cosine ~= 1.0. The fixtures are tuned
+//! so the cross-role and same-role pairs both clear the embedding gate
+//! while structural overlap stays at zero.
+
+#[path = "cli/mock_ollama.rs"]
+mod mock_ollama;
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use assert_cmd::Command;
+use mock_ollama::MockOllama;
+use serde_json::Value;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+/// Runs the CLI against `scan_root` with the deterministic mock Ollama
+/// wired in via `--embeddings required`, returning the parsed JSON.
+fn run_report(scan_root: &Path) -> Result<Value> {
+    let server = MockOllama::spawn()?;
+    let tmp = tempfile::tempdir()?;
+    let output = tmp.path().join("report");
+    let _assertion = Command::cargo_bin("deslop")?
+        .arg(scan_root)
+        .arg("--min-nodes")
+        .arg("5")
+        .arg("--embeddings")
+        .arg("required")
+        .arg("--embedding-provider")
+        .arg("ollama")
+        .arg("--embedding-model")
+        .arg("nomic-embed-text")
+        .arg("--embedding-endpoint")
+        .arg(server.endpoint())
+        .arg("--output")
+        .arg(&output)
+        .assert()
+        .success();
+    let body = fs::read_to_string(output.with_extension("json"))?;
+    Ok(serde_json::from_str(&body)?)
+}
+
+fn clusters(report: &Value) -> &[Value] {
+    report
+        .get("clusters")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+fn bucket(cluster: &Value) -> &str {
+    cluster.get("bucket").and_then(Value::as_str).unwrap_or("")
+}
+
+fn clusters_hidden(report: &Value) -> u64 {
+    report
+        .get("clusters_hidden")
+        .and_then(Value::as_u64)
+        .unwrap_or_default()
+}
+
+/// Collects the raw source text of every occurrence in `cluster`.
+fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
+    let occurrences = cluster
+        .get("occurrences")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    occurrences
+        .iter()
+        .map(|occurrence| occurrence_text(scan_root, occurrence))
+        .collect()
+}
+
+fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
+    let path = occurrence
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("occurrence missing path"))?;
+    let source = fs::read_to_string(scan_root.join(path))?;
+    let start = occurrence_byte(occurrence, "start_byte")?;
+    let end = occurrence_byte(occurrence, "end_byte")?;
+    source
+        .get(start..end)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("occurrence range invalid"))
+}
+
+fn occurrence_byte(occurrence: &Value, field: &str) -> Result<usize> {
+    occurrence
+        .get(field)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        .ok_or_else(|| anyhow!("occurrence missing {field}"))
+}
+
+/// Returns visible clusters that pair the helper class with the test
+/// function. Either occurrence covering the class keyword and another
+/// covering the test function body is the role-mismatch signature.
+fn class_function_role_pairs(report: &Value, scan_root: &Path) -> Result<Vec<Vec<String>>> {
+    let mut offenders = Vec::new();
+    for cluster in clusters(report) {
+        let texts = occurrence_texts(scan_root, cluster)?;
+        let touches_class = texts.iter().any(|text| text.contains("alpha = 0"));
+        let touches_function = texts.iter().any(|text| text.contains("saved.bind"));
+        if touches_class && touches_function {
+            offenders.push(texts);
+        }
+    }
+    Ok(offenders)
+}
+
+// GH #119 acceptance: an embedding-dominant pair whose members have
+// different top-level roles (a `class` definition and a function body)
+// must NOT surface. The cluster is suppressed into `clusters_hidden`.
+#[test]
+fn class_function_role_mismatch_does_not_surface() -> Result<()> {
+    let scan_root = fixture("python-issue-119-role-mismatch");
+    let report = run_report(&scan_root)?;
+    let offenders = class_function_role_pairs(&report, &scan_root)?;
+    assert!(
+        offenders.is_empty(),
+        "a helper class paired with a test function by the embedding pass \
+         must not surface as duplication — there is no safe cross-role \
+         extraction: {offenders:#?}"
+    );
+    assert!(
+        clusters_hidden(&report) >= 1,
+        "the role-incompatible embedding pair must be counted in \
+         clusters_hidden, got {}",
+        clusters_hidden(&report)
+    );
+    assert!(
+        clusters(&report)
+            .iter()
+            .all(|cluster| bucket(cluster) != "same_behavior"),
+        "no same_behavior cluster may remain visible for the role-mismatch \
+         fixture: {:#?}",
+        clusters(&report)
+    );
+    Ok(())
+}
+
+// GH #119 guard against over-suppression: two genuinely behaviour-
+// equivalent FUNCTIONS (recursive vs iterative sum) that the embedding
+// pass pairs share one top-level role, so the role gate must NOT hide
+// them. They must still surface as "Same behavior, different code".
+#[test]
+fn same_role_function_pair_still_surfaces() -> Result<()> {
+    let scan_root = fixture("python-issue-119-same-role");
+    let report = run_report(&scan_root)?;
+    let same_behavior: Vec<&Value> = clusters(&report)
+        .iter()
+        .filter(|cluster| bucket(cluster) == "same_behavior")
+        .collect();
+    assert!(
+        !same_behavior.is_empty(),
+        "two same-role behaviour-equivalent functions must still surface as \
+         same_behavior — the role gate must not over-suppress: {:#?}",
+        clusters(&report)
+    );
+    let pairs_both_functions = same_behavior.iter().try_fold(false, |found, cluster| {
+        let texts = occurrence_texts(&scan_root, cluster)?;
+        let touches_recursive = texts.iter().any(|text| text.contains("total_recursive"));
+        let touches_iterative = texts.iter().any(|text| text.contains("while index"));
+        Ok::<bool, anyhow::Error>(found || (touches_recursive && touches_iterative))
+    })?;
+    assert!(
+        pairs_both_functions,
+        "the surviving same_behavior cluster must pair the recursive and \
+         iterative functions: {same_behavior:#?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## TLDR
Eliminates two duplicate-detection false positives (#104, #119) and adds structured recovery guidance to the MCP "LSP not running" error (#157), so the ranked report stops surfacing unrelated code as clones and agents can recover when the LSP is down.

## Details

Rebased onto current `main` (the prior showstopper batch #153/#154/#156/#115/#97 already landed via #158); this PR is **only** the three new fixes.

- **#104 `[CLONE-NOISE-PY-MODULE-PREAMBLE]`** — new `crates/deslop-core/src/cluster_filters/python_module_preamble.rs`, wired into `is_noise_pattern` (`cluster_filters/mod.rs`). The sibling-window fingerprinter can emit a fingerprint spanning a contiguous run of ≥2 module-level Python definitions (a test-module preamble of small helpers/fixtures), so two unrelated test files cluster on that "block of declarations" shape (`structural=1.00, token_jaccard=1.00, embedding_cos=0.00`). The detector suppresses such a cluster **only when no two members share identical definition bodies** — keying on body divergence, not names. A verbatim or copy-pasted-then-renamed helper module (identical bodies) still surfaces, even when it co-inhabits a merged cluster with same-shape lookalikes. `class_definition` is deliberately excluded so ORM/class-shape clusters are untouched.

- **#119 `[CLONE-NOISE-EMBEDDING-ROLE-MISMATCH]`** — new `crates/deslop-core/src/cluster_filters/role_compat.rs` plus a `same_behavior`-only gate in `render_report` (`report.rs`) via the new `is_embedding_role_mismatch`. An embedding-dominant pair (`structural=0.00, embedding_cos≥0.80`) that pairs a helper **class** with a constructor **test method** has no safe cross-role extraction. The gate suppresses a `same_behavior` cluster whose members resolve to incompatible top-level roles (a type definition vs a function/method); two genuinely behaviour-equivalent functions (same role) still surface. Unresolved roles or non-uniform language fall through to "do not suppress". Scoped to the `SameBehavior` bucket so deterministic Type-1/2/3 clusters are never affected; `classify()` is hoisted to a single call.

- **#157** — `crates/deslop-mcp/src/tools/mod.rs` `backend_to_rpc` now maps `BackendError::LspNotRunning` to a `-32004` error carrying a structured `data` payload: `{ reason: "lsp_not_running", retry_after_ms, socket_path, cache_fallback: { path, format, note } }`. The cache-fallback path is derived from the socket's parent dir + the canonical live-report file name, pointing agents at `.deslop-cache/live-report.json`. The numeric code and the existing human message (socket path + `--root`, #151) are preserved verbatim for wire back-compat — no typeDiagram wire-model change (the `data` field is already `Option<Value>`). To honour DRY, `STATE_FILE_NAME` is promoted to `pub` in `live/session_helpers.rs` and re-exported from `deslop-core::live` as `LIVE_REPORT_FILE_NAME` (single source of truth for the file name).

No public CLI flags, report format, or spec IDs were removed. New `deslop-core` public item: `LIVE_REPORT_FILE_NAME`.

## How Do The Automated Tests Prove It Works?

All tests are black-box E2E against fixture repos; `make ci` is green locally (fmt + lint + Rust test/coverage + build + deployment-verify + vsix-coverage), `deslop-core` at 94.5%.

- **#104** — `crates/deslop/tests/python_issue_104_module_preamble.rs` (3 tests): `differently_bodied_module_preamble_does_not_surface` asserts no visible cluster contains `def encode_payload(` / `def build_url(` (the coincidental preamble is hidden); `verbatim_copied_helper_module_still_surfaces` asserts a cluster containing `def checksum(` spans both `billing_helpers.py` and `billing_helpers_copy.py`; `verbatim_copy_among_lookalikes_still_surfaces` puts two verbatim copies + one same-shape lookalike in one merged cluster and asserts the genuine `service_a`/`service_b` copy still surfaces — the exact case a names-only guard would have wrongly suppressed. Verified test-first: the first test fails against the unfixed pipeline because the 2-def span clusters.
- **#119** — `crates/deslop/tests/python_issue_119_embedding_role_mismatch.rs` (2 tests, deterministic via the in-process MockOllama length/first-byte vectors): `class_function_role_mismatch_does_not_surface` asserts the class-vs-function pair is gone, `clusters_hidden ≥ 1`, and no `same_behavior` cluster remains; `same_role_function_pair_still_surfaces` asserts a `same_behavior` cluster pairing the recursive and iterative functions survives (no over-suppression). Verified test-first by inverting the gate.
- **#157** — `crates/deslop-mcp/tests/issue_157_lsp_not_running_recovery_data.rs`: with no LSP spawned, a `top-offenders` call returns code `-32004`, the message still names the socket path and `--root`, and `data.reason == "lsp_not_running"`, `data.retry_after_ms > 0`, `data.socket_path` names the socket, and `data.cache_fallback` is an object whose `path` ends with `live-report.json` under `.deslop-cache`. Regression tests `issue_151`, `issue_148`, and `issue_136` still pass (code/message/key-allowlist intact).

Closes #104
Closes #119
Closes #157
