### PR TITLE
Fix #189: live .deslop.toml exclude edits re-evaluate the corpus

### DIFF
--- a/crates/deslop-core/src/config.rs
+++ b/crates/deslop-core/src/config.rs
@@ -696,6 +696,38 @@ fn matches(matcher: &Gitignore, path: &Path) -> bool {
     matcher.matched(path, false).is_ignore()
 }
 
+/// Builds the canonical set of config paths that should trigger a live
+/// exclusion reload — `<root>/.deslop.toml` plus the explicit override
+/// (if any) ([LIVE-CONFIG-LIVE], #139).
+#[must_use]
+pub fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
+    let default = root.join(DEFAULT_CONFIG_FILENAME);
+    let mut paths = vec![canonicalise_or_clone(&default)];
+    if let Some(explicit) = override_path {
+        paths.push(canonicalise_or_clone(explicit));
+    }
+    paths
+}
+
+/// Returns `true` when `candidate` matches one of the watched config
+/// paths in either canonical or as-given form.
+#[must_use]
+pub fn is_config_path(candidate: &Path, watched: &[PathBuf]) -> bool {
+    if watched.iter().any(|watched_path| watched_path == candidate) {
+        return true;
+    }
+    let canonical = canonicalise_or_clone(candidate);
+    watched
+        .iter()
+        .any(|watched_path| watched_path == &canonical)
+}
+
+/// Canonicalises `path` when possible; otherwise returns a clone so
+/// non-existent override paths still compare predictably.
+fn canonicalise_or_clone(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Compiles a list of glob patterns into an [`ignore::gitignore::Gitignore`]
 /// matcher. The builder is rooted at the scan root when known so user
 /// patterns are scan-root-relative — `subdir/**` matches

--- a/crates/deslop-core/src/live/session.rs
+++ b/crates/deslop-core/src/live/session.rs
@@ -343,13 +343,12 @@ impl AnalysisSession {
     /// empty delta — the queued paths are replayed inside
     /// [`Self::install_pipeline`].
     ///
-    /// When any entry in `changed` is a watched config file
-    /// (`<root>/.deslop.toml` or the explicit override), the live
-    /// exclusion config is reloaded before re-rendering so a
-    /// `report_hide` edit hides the matching cluster on the next
-    /// generation ([LIVE-CONFIG-LIVE], #139). Source-file entries are
-    /// re-fingerprinted as before; config-file entries are dropped
-    /// from the per-file pass because they are not source.
+    /// Watched config files (`<root>/.deslop.toml` or the explicit
+    /// override) in `changed` are detected inside
+    /// [`crate::PipelineSession::update_files`], which reloads the
+    /// exclusion config and re-evaluates the existing corpus against
+    /// it — dropping newly-excluded files and re-discovering newly
+    /// re-included ones ([LIVE-CONFIG-LIVE], #139, #189).
     ///
     /// # Errors
     ///
@@ -365,28 +364,9 @@ impl AnalysisSession {
                 &self.latest_report,
             ));
         }
-        let watched = watched_config_paths(&self.root, self.config_path.as_deref());
-        let config_changed = changed.iter().any(|path| is_config_path(path, &watched));
-        if config_changed {
-            if let Some(pipeline) = self.pipeline.as_mut() {
-                if let Err(err) = pipeline.reload_exclusion() {
-                    tracing::warn!(
-                        error = %err,
-                        "deslop_toml_reload_failed; keeping prior exclusion config",
-                    );
-                } else {
-                    tracing::info!("deslop_toml_reloaded mode=rerender-only");
-                }
-            }
-        }
-        let source_changed: Vec<PathBuf> = changed
-            .iter()
-            .filter(|path| !is_config_path(path, &watched))
-            .cloned()
-            .collect();
         let previous = Arc::clone(&self.latest_report);
         let prev_generation = self.generation;
-        let next = self.run_pipeline(&source_changed)?;
+        let next = self.run_pipeline(changed)?;
         self.generation = self.generation.saturating_add(1);
         let next_arc = Arc::new(next);
         self.latest_report = Arc::clone(&next_arc);
@@ -772,34 +752,4 @@ fn extension_to_language(path: &Path) -> Option<&'static str> {
         "py" => Some("python"),
         _ => None,
     }
-}
-
-/// Builds the canonical set of config paths that should trigger a live
-/// exclusion reload — `<root>/.deslop.toml` plus the explicit override
-/// (if any) ([LIVE-CONFIG-LIVE], #139).
-fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
-    let default = root.join(crate::config::DEFAULT_CONFIG_FILENAME);
-    let mut paths = vec![canonicalise_or_clone(&default)];
-    if let Some(explicit) = override_path {
-        paths.push(canonicalise_or_clone(explicit));
-    }
-    paths
-}
-
-/// Returns `true` when `candidate` matches one of the watched config
-/// paths in either canonical or as-given form.
-fn is_config_path(candidate: &Path, watched: &[PathBuf]) -> bool {
-    if watched.iter().any(|watched_path| watched_path == candidate) {
-        return true;
-    }
-    let canonical = canonicalise_or_clone(candidate);
-    watched
-        .iter()
-        .any(|watched_path| watched_path == &canonical)
-}
-
-/// Canonicalises `path` when possible; otherwise returns a clone so
-/// non-existent override paths still compare predictably.
-fn canonicalise_or_clone(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/deslop-core/src/pipeline/session/change.rs
+++ b/crates/deslop-core/src/pipeline/session/change.rs
@@ -4,11 +4,14 @@
 //! resolution, path canonicalisation, and pipeline config construction.
 //! All methods are `pub(super)` — they are called only from `session/mod.rs`.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use crate::{
-    boilerplate::collect_import_boilerplate_ranges, error::CoreError, report::CacheStats,
-    state::FileId,
+    boilerplate::collect_import_boilerplate_ranges, discover::discover_files, error::CoreError,
+    report::CacheStats, state::FileId,
 };
 
 use super::{
@@ -68,6 +71,70 @@ impl PipelineSession {
         let _prev_lang = self.file_languages.insert(file_id, language);
         self.files_analysed = self.live_paths.len();
         Ok(())
+    }
+
+    /// Reloads `.deslop.toml` and re-evaluates the existing corpus
+    /// against it: drops files the new `exclude` patterns now match
+    /// and re-discovers files a removed pattern re-admits
+    /// ([LIVE-CONFIG-LIVE], #189). A malformed config is logged and
+    /// the prior exclusion is kept — a typo never bricks the daemon.
+    pub(super) fn refresh_exclusion(
+        &mut self,
+        stats: &mut CacheStats,
+        embedding: &EmbeddingSettings<'_>,
+    ) -> Result<(), CoreError> {
+        if let Err(error) = self.reload_exclusion() {
+            tracing::warn!(
+                %error,
+                "deslop_toml_reload_failed; keeping prior exclusion config",
+            );
+            return Ok(());
+        }
+        let dropped = self.drop_newly_excluded();
+        let added = self.apply_newly_included(stats, embedding)?;
+        tracing::info!(dropped, added, "deslop_toml_reloaded corpus re-evaluated");
+        Ok(())
+    }
+
+    /// Drops every live file the reloaded exclusion config now
+    /// matches. Returns the number of dropped paths.
+    fn drop_newly_excluded(&mut self) -> usize {
+        let doomed: Vec<PathBuf> = self
+            .live_paths
+            .iter()
+            .filter_map(|(file_id, path)| {
+                let language = self.file_languages.get(file_id).copied();
+                self.exclusion
+                    .is_excluded(path, language)
+                    .then(|| path.clone())
+            })
+            .collect();
+        for path in &doomed {
+            self.drop_path(path);
+        }
+        doomed.len()
+    }
+
+    /// Re-runs discovery and applies every path the reloaded exclusion
+    /// config re-admits but the corpus does not yet contain. Returns
+    /// the number of newly-applied paths.
+    fn apply_newly_included(
+        &mut self,
+        stats: &mut CacheStats,
+        embedding: &EmbeddingSettings<'_>,
+    ) -> Result<usize, CoreError> {
+        let discovery = discover_files(&self.root, &self.extension_to_language, &self.exclusion);
+        let known: HashSet<PathBuf> = self.live_paths.values().cloned().collect();
+        let fresh: Vec<PathBuf> = discovery
+            .files
+            .into_iter()
+            .map(|file| file.path)
+            .filter(|path| !known.contains(path))
+            .collect();
+        for path in &fresh {
+            self.apply_one_change(path, stats, embedding)?;
+        }
+        Ok(fresh.len())
     }
 
     /// Removes a path from every in-memory map if present.

--- a/crates/deslop-core/src/pipeline/session/mod.rs
+++ b/crates/deslop-core/src/pipeline/session/mod.rs
@@ -18,7 +18,7 @@ use std::{
 
 use crate::{
     boilerplate::BoilerplateRange,
-    config::ExclusionConfig,
+    config::{is_config_path, watched_config_paths, ExclusionConfig},
     discover::{discover_files, DiscoveryResult},
     error::CoreError,
     fpcache::CachedFile,
@@ -174,6 +174,12 @@ impl PipelineSession {
     /// root or with unsupported extensions are silently skipped — a
     /// watcher can fire on any file, not only interesting ones.
     ///
+    /// A `changed` entry naming a watched config file
+    /// (`<root>/.deslop.toml` or the explicit override) reloads the
+    /// exclusion config and re-evaluates the whole corpus against it:
+    /// newly-excluded files are dropped, newly re-included files are
+    /// re-discovered ([LIVE-CONFIG-LIVE], #189).
+    ///
     /// # Errors
     ///
     /// Same error surface as [`Self::initialise`].
@@ -183,7 +189,14 @@ impl PipelineSession {
         embedding: EmbeddingSettings<'_>,
     ) -> Result<Report, CoreError> {
         let mut stats = CacheStats::default();
-        for path in changed {
+        let watched = watched_config_paths(&self.root, self.config_path.as_deref());
+        if changed.iter().any(|path| is_config_path(path, &watched)) {
+            self.refresh_exclusion(&mut stats, &embedding)?;
+        }
+        for path in changed
+            .iter()
+            .filter(|path| !is_config_path(path, &watched))
+        {
             self.apply_one_change(path, &mut stats, &embedding)?;
         }
         self.cumulative_stats.hits = self.cumulative_stats.hits.saturating_add(stats.hits);
@@ -280,15 +293,16 @@ impl PipelineSession {
         self.files_analysed
     }
 
-    /// Reloads the exclusion config from disk. Called by the daemon
-    /// when `.deslop.toml` itself changes.
+    /// Reloads the exclusion config from disk. Called from
+    /// [`Self::update_files`] when a watched config path is in the
+    /// changed set ([LIVE-CONFIG-LIVE], #189).
     ///
     /// # Errors
     ///
     /// Returns [`CoreError::ConfigParse`] or [`CoreError::ConfigPattern`]
     /// when the new config is malformed. The session keeps the old
     /// config on failure so a bad edit does not brick the daemon.
-    pub fn reload_exclusion(&mut self) -> Result<(), CoreError> {
+    fn reload_exclusion(&mut self) -> Result<(), CoreError> {
         self.exclusion = load_exclusion(&self.root, self.config_path.as_deref())?;
         Ok(())
     }

--- a/crates/deslop-lsp/src/file_watch.rs
+++ b/crates/deslop-lsp/src/file_watch.rs
@@ -18,13 +18,10 @@
 //! decorations, bubble, status bar) refreshes immediately without any
 //! editor action ([LSP-PUSH-NOTIFICATIONS], [VSIX-REACTIVITY-INVARIANT]).
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
 use deslop_core::{
-    config::DEFAULT_CONFIG_FILENAME,
+    config::watched_config_paths,
     live::{
         AnalysisSession, AnalysisState, LiveError, LiveWatcher, ReportChangedNotification,
         Scheduler,
@@ -74,16 +71,6 @@ pub fn start(
         "file_watch started",
     );
     Ok((watcher, scheduler))
-}
-
-/// Builds the list of config-file paths the watcher must forward as
-/// first-class live updates ([LIVE-CONFIG-LIVE], #139).
-fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
-    let default = root.join(DEFAULT_CONFIG_FILENAME);
-    match override_path {
-        Some(explicit) => vec![default, explicit.to_path_buf()],
-        None => vec![default],
-    }
 }
 
 /// Loops over both broadcast channels and pushes each event as an LSP

--- a/crates/deslop/tests/rerun.rs
+++ b/crates/deslop/tests/rerun.rs
@@ -259,6 +259,92 @@ fn rerun_remove_drops_clone_and_reports_cluster_removed() -> Result<()> {
     Ok(())
 }
 
+// Implements [LIVE-CONFIG-LIVE] (#189): replaying the watched
+// `<root>/.deslop.toml` through the rerun harness must re-evaluate the
+// existing corpus against the reloaded `exclude` patterns. A pattern
+// added between generations drops the now-excluded file — and its
+// clusters — instead of only re-rendering.
+#[test]
+fn issue_189_new_exclude_pattern_drops_existing_corpus_files() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let scan_root = tmp.path().join("src");
+    seed(&fixture("csharp-small"), &scan_root)?;
+    // Stage a config that excludes Beta.cs; `--rerun-add` lands it at
+    // the watched `<root>/.deslop.toml` between generation 0 and 1.
+    let staged = tmp.path().join("staged-deslop.toml");
+    fs::write(&staged, "[defaults]\nexclude = [\"**/Beta.cs\"]\n")?;
+    let config_dst = scan_root.join(".deslop.toml");
+    let spec = format!("{}={}", staged.display(), config_dst.display());
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(&scan_root)
+        .arg("--min-nodes")
+        .arg("8")
+        .arg("--output")
+        .arg(tmp.path().join("report"))
+        .arg("--rerun-add")
+        .arg(&spec)
+        .assert()
+        .success();
+    let delta = load_json(&delta_path(tmp.path()))?;
+    assert_eq!(field(&delta, "from_generation"), 0);
+    assert_eq!(field(&delta, "to_generation"), 1);
+    assert!(
+        array_len(&delta, "clusters_removed") > 0,
+        "excluding Beta.cs must remove the Alpha/Beta clone cluster: {delta:#}"
+    );
+    let report = fs::read_to_string(tmp.path().join("report.json"))?;
+    assert!(
+        !report.contains("Beta.cs"),
+        "generation 1 report must not mention the excluded file"
+    );
+    Ok(())
+}
+
+// Implements [LIVE-CONFIG-LIVE] (#189): the reverse direction — a
+// pattern removed between generations re-discovers the previously
+// excluded file so its clusters appear. Exercises the explicit
+// `--config` override path rather than `<root>/.deslop.toml`.
+#[test]
+fn issue_189_removed_exclude_pattern_rediscovers_files() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let scan_root = tmp.path().join("src");
+    seed(&fixture("csharp-small"), &scan_root)?;
+    // Initial pass excludes Beta.cs via an explicit override config,
+    // so generation 0 sees only Alpha.cs and reports no clusters.
+    let override_config = tmp.path().join("deslop.toml");
+    fs::write(&override_config, "[defaults]\nexclude = [\"**/Beta.cs\"]\n")?;
+    let staged = tmp.path().join("staged-looser.toml");
+    fs::write(&staged, "[defaults]\nexclude = []\n")?;
+    let spec = format!("{}={}", staged.display(), override_config.display());
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(&scan_root)
+        .arg("--min-nodes")
+        .arg("8")
+        .arg("--config")
+        .arg(&override_config)
+        .arg("--output")
+        .arg(tmp.path().join("report"))
+        .arg("--rerun-add")
+        .arg(&spec)
+        .assert()
+        .success();
+    let delta = load_json(&delta_path(tmp.path()))?;
+    assert_eq!(field(&delta, "from_generation"), 0);
+    assert_eq!(field(&delta, "to_generation"), 1);
+    assert!(
+        array_len(&delta, "clusters_added") > 0,
+        "dropping the exclude must re-discover Beta.cs and surface its cluster: {delta:#}"
+    );
+    let report = fs::read_to_string(tmp.path().join("report.json"))?;
+    assert!(
+        report.contains("Beta.cs"),
+        "generation 1 report must include the re-included file"
+    );
+    Ok(())
+}
+
 // Implements [LIVE-STATE] + [EXCLUSION-CONFIG]: a `--rerun-touch` path
 // that is covered by the loaded exclusion config is treated as a
 // deletion so that an edit making it excluded drops it from the corpus.


### PR DESCRIPTION
<!-- agent-pmo:9a71cbf -->
## TLDR

Live `.deslop.toml` `exclude` edits now re-evaluate the whole corpus instead of only re-rendering, so newly-excluded files drop out of the live report and files re-admitted by a removed pattern are re-discovered — without a restart. Closes #189.

## Details

**Root cause.** `AnalysisSession::apply_changes` (`crates/deslop-core/src/live/session.rs`) reloaded the exclusion config when `.deslop.toml` changed, but then filtered the config path out of the changed set, so `PipelineSession::update_files` ran with an empty list and only re-rendered (`mode=rerender-only`). Exclusion was only ever re-checked inside `apply_one_change`, which runs solely for paths in the changed set — already-discovered files matching a new `exclude` pattern were never dropped, and files re-admitted by a removed pattern were never re-discovered.

**Fix — `crates/deslop-core` (`[LIVE-CONFIG-LIVE]`):**

- `PipelineSession::update_files` (`pipeline/session/mod.rs`) now detects watched config paths (`<root>/.deslop.toml` or the explicit `--config` override) in the changed set and calls the new `refresh_exclusion` before the per-file pass.
- `refresh_exclusion` (`pipeline/session/change.rs`) reloads the config, then `drop_newly_excluded` sweeps every live path against the reloaded `exclude` patterns and `drop_path`s the matches, and `apply_newly_included` re-runs `discover_files` and applies every path the new config re-admits that the corpus does not yet contain. A malformed config is logged and the prior exclusion kept, preserving the "a typo never bricks the daemon" guarantee. Structured `tracing` reports the dropped/added counts.
- `AnalysisSession::apply_changes` (`live/session.rs`) no longer pre-filters config paths or reloads the config itself — it forwards the changed set verbatim, so the CLI rerun harness and the live daemon exercise the identical code path. The generation bump and broadcast were already in place, so the reactive loop (watcher → scheduler → session → broadcast → UI) now delivers correct data end-to-end.
- `reload_exclusion` is demoted from `pub` to private — `update_files` is now its only caller.

**Deduplication.** The `watched_config_paths` / `is_config_path` / `canonicalise_or_clone` helpers move from `live/session.rs` into `config.rs` (public), and `deslop-lsp/src/file_watch.rs` deletes its near-duplicate `watched_config_paths` in favour of the shared one. One definition now serves the pipeline session, the live session, and the LSP watcher bypass list.

**Breaking changes:** `PipelineSession::reload_exclusion` is no longer public (it had no external callers besides the live session, which no longer needs it). No CLI flag, report format, or spec ID changes.

Not addressed here (tracked separately per the issue): gitignore-style **directory** patterns (`lib/l10n/`) still match nothing because `is_excluded` matches file paths without a parent-dir walk — consistent between CLI and live, worth its own issue.

## How Do The Automated Tests Prove It Works?

Two new black-box E2E tests in `crates/deslop/tests/rerun.rs` drive the CLI binary against the `csharp-small` fixture (Alpha.cs + Beta.cs form a clone cluster) using the `--rerun-*` harness, which replays watcher-style changes through `PipelineSession::update_files` between generation 0 and 1 — the same entry point the live daemon uses:

- `issue_189_new_exclude_pattern_drops_existing_corpus_files` — `--rerun-add` lands a `.deslop.toml` with `exclude = ["**/Beta.cs"]` at the scan root between generations and replays the config path. Asserts the emitted `report.delta.json` has `from_generation` 0 → `to_generation` 1 with `clusters_removed` non-empty, and that the generation-1 `report.json` no longer mentions `Beta.cs`. Before the fix this produced an empty delta (the config path was a silent no-op).
- `issue_189_removed_exclude_pattern_rediscovers_files` — the reverse direction, via the explicit `--config` override path: generation 0 excludes `Beta.cs` (no clusters), the rerun swaps in a config with `exclude = []`. Asserts `clusters_added` is non-empty and `Beta.cs` appears in the generation-1 report, proving re-discovery of re-admitted files. Also failed with an empty delta before the fix.

Both tests were written first and confirmed failing against the unfixed code (empty `clusters_removed` / `clusters_added`), then confirmed passing after the fix. The existing seven `rerun.rs` tests still pass, covering the no-op, re-parse, unsupported-path, add, remove, and pre-loaded-exclusion branches around the new code.
