### PR TITLE
Derive LSP watched extensions from the parser registry; make .deslop.toml exclude edits reactive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,52 @@
 
 **The point of Deslop is to prevent duplication, not just scrub it afterwards.** Post-hoc deduplication is what every static analyzer already does. Deslop's edge is being **live in the agent's inner loop** so a duplicate never lands in the first place.
 
-**Directive for AI agents (Claude Code, Cursor, Copilot, Codex, Continue):**
+### LAW: call `find-similar` BEFORE you author new code
 
-> **Before writing any new function, class, helper, or test setup, call the `find-similar` MCP tool first.** If the proposed pattern already exists with high similarity, reuse the canonical implementation instead of authoring a new copy.
+Before you write any new function, method, class, helper, fixture, test setup,
+parser branch, error type, route handler, view model, or any other code unit
+larger than a few lines, you MUST call the `find-similar` MCP tool with the
+proposed code (or its byte range, if it already exists in a draft buffer) and
+inspect the response.
 
-This applies during **code authoring**. When fixing existing duplicates, use `top-offenders` and `cluster-by-id`; when writing fresh code, use `find-similar`. Both modes use the same live server — the call you make encodes the intent.
+- If the response shows a cluster with **`signals.fused ≥ 0.85`** *or* the
+  bucket is `identical` / `nearly_identical`, do NOT write the new copy.
+  A `structural_only` match means only the code shape lines up (no token
+  or semantic evidence) — read the match before deciding; it is often
+  sibling boilerplate rather than a reusable implementation.
+  Reuse the canonical occurrence the tool returns. Extract a helper if needed.
+- If the response is empty or the closest match is structurally distant
+  (`signals.fused < 0.6`), proceed with authoring.
+- If the response is borderline (`0.6 ≤ fused < 0.85`), read the canonical
+  occurrence and decide whether the new code is genuinely different. Bias
+  toward reuse.
+
+`find-similar` accepts either:
+- a **byte range** in an existing file (`path`, `start_byte`, `end_byte`), or
+- a **snippet** (`snippet`, `language`) — useful when you have a draft in your
+  scratchpad that has not been written to disk yet.
+
+### When to use the OTHER Deslop tools instead
+
+- **Fixing existing duplicates** (refactor / dedup work) → start with
+  `top-offenders`, then `cluster-by-id` for the cluster you'll merge. Don't
+  use `find-similar` for this — it answers a different question.
+- **Investigating a specific file** → `report-for-file`.
+- **Investigating a specific block before refactor** → `report-for-range`.
+- **Schema reference for the JSON shapes** → call `schema-doc` *once* per
+  session. Don't bundle it into every response.
+
+### Hard rules
+
+- Do NOT skip `find-similar` because "this looks new." Most clones are
+  introduced by people who genuinely thought the code was new. The tool exists
+  to override that intuition with evidence.
+- Do NOT silence Deslop warnings by widening thresholds, marking clusters
+  hidden, or splitting the code into trivially different shapes. If the tool
+  flags something, treat it as a real signal until you've shown otherwise.
+- Do NOT call `find-similar` after writing a duplicate "just to confirm." That
+  is cure, not prevention. Call it BEFORE the keystroke that creates the
+  duplicate.
 
 The MCP tool description leads with prevention ("Call BEFORE writing new code…"). Reports surface `find-similar` as the prevention path in their `action_hints`. This document and the user-facing `AGENTS.md` recipe teach this so agents pick it up without re-reading docstrings.
 

--- a/crates/deslop-core/src/config.rs
+++ b/crates/deslop-core/src/config.rs
@@ -696,6 +696,38 @@ fn matches(matcher: &Gitignore, path: &Path) -> bool {
     matcher.matched(path, false).is_ignore()
 }
 
+/// Builds the canonical set of config paths that should trigger a live
+/// exclusion reload — `<root>/.deslop.toml` plus the explicit override
+/// (if any) ([LIVE-CONFIG-LIVE], #139).
+#[must_use]
+pub fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
+    let default = root.join(DEFAULT_CONFIG_FILENAME);
+    let mut paths = vec![canonicalise_or_clone(&default)];
+    if let Some(explicit) = override_path {
+        paths.push(canonicalise_or_clone(explicit));
+    }
+    paths
+}
+
+/// Returns `true` when `candidate` matches one of the watched config
+/// paths in either canonical or as-given form.
+#[must_use]
+pub fn is_config_path(candidate: &Path, watched: &[PathBuf]) -> bool {
+    if watched.iter().any(|watched_path| watched_path == candidate) {
+        return true;
+    }
+    let canonical = canonicalise_or_clone(candidate);
+    watched
+        .iter()
+        .any(|watched_path| watched_path == &canonical)
+}
+
+/// Canonicalises `path` when possible; otherwise returns a clone so
+/// non-existent override paths still compare predictably.
+fn canonicalise_or_clone(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
 /// Compiles a list of glob patterns into an [`ignore::gitignore::Gitignore`]
 /// matcher. The builder is rooted at the scan root when known so user
 /// patterns are scan-root-relative — `subdir/**` matches

--- a/crates/deslop-core/src/live/session.rs
+++ b/crates/deslop-core/src/live/session.rs
@@ -343,13 +343,12 @@ impl AnalysisSession {
     /// empty delta — the queued paths are replayed inside
     /// [`Self::install_pipeline`].
     ///
-    /// When any entry in `changed` is a watched config file
-    /// (`<root>/.deslop.toml` or the explicit override), the live
-    /// exclusion config is reloaded before re-rendering so a
-    /// `report_hide` edit hides the matching cluster on the next
-    /// generation ([LIVE-CONFIG-LIVE], #139). Source-file entries are
-    /// re-fingerprinted as before; config-file entries are dropped
-    /// from the per-file pass because they are not source.
+    /// Watched config files (`<root>/.deslop.toml` or the explicit
+    /// override) in `changed` are detected inside
+    /// [`crate::PipelineSession::update_files`], which reloads the
+    /// exclusion config and re-evaluates the existing corpus against
+    /// it — dropping newly-excluded files and re-discovering newly
+    /// re-included ones ([LIVE-CONFIG-LIVE], #139, #189).
     ///
     /// # Errors
     ///
@@ -365,28 +364,9 @@ impl AnalysisSession {
                 &self.latest_report,
             ));
         }
-        let watched = watched_config_paths(&self.root, self.config_path.as_deref());
-        let config_changed = changed.iter().any(|path| is_config_path(path, &watched));
-        if config_changed {
-            if let Some(pipeline) = self.pipeline.as_mut() {
-                if let Err(err) = pipeline.reload_exclusion() {
-                    tracing::warn!(
-                        error = %err,
-                        "deslop_toml_reload_failed; keeping prior exclusion config",
-                    );
-                } else {
-                    tracing::info!("deslop_toml_reloaded mode=rerender-only");
-                }
-            }
-        }
-        let source_changed: Vec<PathBuf> = changed
-            .iter()
-            .filter(|path| !is_config_path(path, &watched))
-            .cloned()
-            .collect();
         let previous = Arc::clone(&self.latest_report);
         let prev_generation = self.generation;
-        let next = self.run_pipeline(&source_changed)?;
+        let next = self.run_pipeline(changed)?;
         self.generation = self.generation.saturating_add(1);
         let next_arc = Arc::new(next);
         self.latest_report = Arc::clone(&next_arc);
@@ -772,34 +752,4 @@ fn extension_to_language(path: &Path) -> Option<&'static str> {
         "py" => Some("python"),
         _ => None,
     }
-}
-
-/// Builds the canonical set of config paths that should trigger a live
-/// exclusion reload — `<root>/.deslop.toml` plus the explicit override
-/// (if any) ([LIVE-CONFIG-LIVE], #139).
-fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
-    let default = root.join(crate::config::DEFAULT_CONFIG_FILENAME);
-    let mut paths = vec![canonicalise_or_clone(&default)];
-    if let Some(explicit) = override_path {
-        paths.push(canonicalise_or_clone(explicit));
-    }
-    paths
-}
-
-/// Returns `true` when `candidate` matches one of the watched config
-/// paths in either canonical or as-given form.
-fn is_config_path(candidate: &Path, watched: &[PathBuf]) -> bool {
-    if watched.iter().any(|watched_path| watched_path == candidate) {
-        return true;
-    }
-    let canonical = canonicalise_or_clone(candidate);
-    watched
-        .iter()
-        .any(|watched_path| watched_path == &canonical)
-}
-
-/// Canonicalises `path` when possible; otherwise returns a clone so
-/// non-existent override paths still compare predictably.
-fn canonicalise_or_clone(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/deslop-core/src/pipeline/corpus.rs
+++ b/crates/deslop-core/src/pipeline/corpus.rs
@@ -291,6 +291,18 @@ pub fn language_ids() -> Vec<&'static str> {
     default_parsers().iter().map(|parser| parser.id()).collect()
 }
 
+/// Source-file extensions of every registered parser, in registry order.
+/// Single source of truth for any surface that filters filesystem events
+/// by extension — e.g. the LSP live watcher — so the watched set can
+/// never drift from [`default_parsers`] ([PIPELINE-LANG-TRAIT]).
+#[must_use]
+pub fn watched_source_extensions() -> Vec<&'static str> {
+    default_parsers()
+        .iter()
+        .flat_map(|parser| parser.file_extensions().iter().copied())
+        .collect()
+}
+
 /// Builds a lowercase-extension → language-id lookup from the parser
 /// registry. Returning the language id (not a parser index) lets
 /// [`crate::discover::discover_files`] check [`crate::config::ExclusionConfig`]

--- a/crates/deslop-core/src/pipeline/mod.rs
+++ b/crates/deslop-core/src/pipeline/mod.rs
@@ -20,6 +20,6 @@ mod session;
 mod signatures;
 
 pub use config::{EmbeddingSettings, PipelineConfig};
-pub use corpus::language_ids;
+pub use corpus::{language_ids, watched_source_extensions};
 pub use run::{debug_ast_dump, run};
 pub use session::PipelineSession;

--- a/crates/deslop-core/src/pipeline/session/change.rs
+++ b/crates/deslop-core/src/pipeline/session/change.rs
@@ -4,11 +4,14 @@
 //! resolution, path canonicalisation, and pipeline config construction.
 //! All methods are `pub(super)` — they are called only from `session/mod.rs`.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use crate::{
-    boilerplate::collect_import_boilerplate_ranges, error::CoreError, report::CacheStats,
-    state::FileId,
+    boilerplate::collect_import_boilerplate_ranges, discover::discover_files, error::CoreError,
+    report::CacheStats, state::FileId,
 };
 
 use super::{
@@ -68,6 +71,70 @@ impl PipelineSession {
         let _prev_lang = self.file_languages.insert(file_id, language);
         self.files_analysed = self.live_paths.len();
         Ok(())
+    }
+
+    /// Reloads `.deslop.toml` and re-evaluates the existing corpus
+    /// against it: drops files the new `exclude` patterns now match
+    /// and re-discovers files a removed pattern re-admits
+    /// ([LIVE-CONFIG-LIVE], #189). A malformed config is logged and
+    /// the prior exclusion is kept — a typo never bricks the daemon.
+    pub(super) fn refresh_exclusion(
+        &mut self,
+        stats: &mut CacheStats,
+        embedding: &EmbeddingSettings<'_>,
+    ) -> Result<(), CoreError> {
+        if let Err(error) = self.reload_exclusion() {
+            tracing::warn!(
+                %error,
+                "deslop_toml_reload_failed; keeping prior exclusion config",
+            );
+            return Ok(());
+        }
+        let dropped = self.drop_newly_excluded();
+        let added = self.apply_newly_included(stats, embedding)?;
+        tracing::info!(dropped, added, "deslop_toml_reloaded corpus re-evaluated");
+        Ok(())
+    }
+
+    /// Drops every live file the reloaded exclusion config now
+    /// matches. Returns the number of dropped paths.
+    fn drop_newly_excluded(&mut self) -> usize {
+        let doomed: Vec<PathBuf> = self
+            .live_paths
+            .iter()
+            .filter_map(|(file_id, path)| {
+                let language = self.file_languages.get(file_id).copied();
+                self.exclusion
+                    .is_excluded(path, language)
+                    .then(|| path.clone())
+            })
+            .collect();
+        for path in &doomed {
+            self.drop_path(path);
+        }
+        doomed.len()
+    }
+
+    /// Re-runs discovery and applies every path the reloaded exclusion
+    /// config re-admits but the corpus does not yet contain. Returns
+    /// the number of newly-applied paths.
+    fn apply_newly_included(
+        &mut self,
+        stats: &mut CacheStats,
+        embedding: &EmbeddingSettings<'_>,
+    ) -> Result<usize, CoreError> {
+        let discovery = discover_files(&self.root, &self.extension_to_language, &self.exclusion);
+        let known: HashSet<PathBuf> = self.live_paths.values().cloned().collect();
+        let fresh: Vec<PathBuf> = discovery
+            .files
+            .into_iter()
+            .map(|file| file.path)
+            .filter(|path| !known.contains(path))
+            .collect();
+        for path in &fresh {
+            self.apply_one_change(path, stats, embedding)?;
+        }
+        Ok(fresh.len())
     }
 
     /// Removes a path from every in-memory map if present.

--- a/crates/deslop-core/src/pipeline/session/mod.rs
+++ b/crates/deslop-core/src/pipeline/session/mod.rs
@@ -18,7 +18,7 @@ use std::{
 
 use crate::{
     boilerplate::BoilerplateRange,
-    config::ExclusionConfig,
+    config::{is_config_path, watched_config_paths, ExclusionConfig},
     discover::{discover_files, DiscoveryResult},
     error::CoreError,
     fpcache::CachedFile,
@@ -174,6 +174,12 @@ impl PipelineSession {
     /// root or with unsupported extensions are silently skipped — a
     /// watcher can fire on any file, not only interesting ones.
     ///
+    /// A `changed` entry naming a watched config file
+    /// (`<root>/.deslop.toml` or the explicit override) reloads the
+    /// exclusion config and re-evaluates the whole corpus against it:
+    /// newly-excluded files are dropped, newly re-included files are
+    /// re-discovered ([LIVE-CONFIG-LIVE], #189).
+    ///
     /// # Errors
     ///
     /// Same error surface as [`Self::initialise`].
@@ -183,7 +189,14 @@ impl PipelineSession {
         embedding: EmbeddingSettings<'_>,
     ) -> Result<Report, CoreError> {
         let mut stats = CacheStats::default();
-        for path in changed {
+        let watched = watched_config_paths(&self.root, self.config_path.as_deref());
+        if changed.iter().any(|path| is_config_path(path, &watched)) {
+            self.refresh_exclusion(&mut stats, &embedding)?;
+        }
+        for path in changed
+            .iter()
+            .filter(|path| !is_config_path(path, &watched))
+        {
             self.apply_one_change(path, &mut stats, &embedding)?;
         }
         self.cumulative_stats.hits = self.cumulative_stats.hits.saturating_add(stats.hits);
@@ -280,15 +293,16 @@ impl PipelineSession {
         self.files_analysed
     }
 
-    /// Reloads the exclusion config from disk. Called by the daemon
-    /// when `.deslop.toml` itself changes.
+    /// Reloads the exclusion config from disk. Called from
+    /// [`Self::update_files`] when a watched config path is in the
+    /// changed set ([LIVE-CONFIG-LIVE], #189).
     ///
     /// # Errors
     ///
     /// Returns [`CoreError::ConfigParse`] or [`CoreError::ConfigPattern`]
     /// when the new config is malformed. The session keeps the old
     /// config on failure so a bad edit does not brick the daemon.
-    pub fn reload_exclusion(&mut self) -> Result<(), CoreError> {
+    fn reload_exclusion(&mut self) -> Result<(), CoreError> {
         self.exclusion = load_exclusion(&self.root, self.config_path.as_deref())?;
         Ok(())
     }

--- a/crates/deslop-lsp/src/file_watch.rs
+++ b/crates/deslop-lsp/src/file_watch.rs
@@ -18,26 +18,21 @@
 //! decorations, bubble, status bar) refreshes immediately without any
 //! editor action ([LSP-PUSH-NOTIFICATIONS], [VSIX-REACTIVITY-INVARIANT]).
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{path::Path, sync::Arc};
 
 use deslop_core::{
-    config::DEFAULT_CONFIG_FILENAME,
+    config::watched_config_paths,
     live::{
         AnalysisSession, AnalysisState, LiveError, LiveWatcher, ReportChangedNotification,
         Scheduler,
     },
+    pipeline::watched_source_extensions,
     ExclusionConfig,
 };
 use tokio::sync::{broadcast::Receiver, Mutex};
 use tower_lsp::Client;
 
 use crate::notifications::{AnalysisStateLspNotification, ReportChangedLspNotification};
-
-/// File extensions the watcher monitors — one entry per supported language.
-const WATCHED_EXTENSIONS: &[&str] = &["cs", "rs", "py"];
 
 /// Starts the filesystem watcher + scheduler for `root` and spawns
 /// the background task that forwards change broadcasts to `client`.
@@ -55,7 +50,10 @@ pub fn start(
     session: Arc<Mutex<AnalysisSession>>,
     client: Client,
 ) -> Result<(LiveWatcher, Scheduler), LiveError> {
-    let extensions: Vec<String> = WATCHED_EXTENSIONS.iter().map(|e| (*e).to_owned()).collect();
+    let extensions: Vec<String> = watched_source_extensions()
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
     let exclusion = Arc::new(ExclusionConfig::empty());
     let config_paths = watched_config_paths(root, config_path);
     let (watcher, watcher_rx) =
@@ -74,16 +72,6 @@ pub fn start(
         "file_watch started",
     );
     Ok((watcher, scheduler))
-}
-
-/// Builds the list of config-file paths the watcher must forward as
-/// first-class live updates ([LIVE-CONFIG-LIVE], #139).
-fn watched_config_paths(root: &Path, override_path: Option<&Path>) -> Vec<PathBuf> {
-    let default = root.join(DEFAULT_CONFIG_FILENAME);
-    match override_path {
-        Some(explicit) => vec![default, explicit.to_path_buf()],
-        None => vec![default],
-    }
 }
 
 /// Loops over both broadcast channels and pushes each event as an LSP

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -139,6 +139,50 @@ fn report_changed_fires_for_each_external_save_of_the_same_path() -> Result<()> 
     Ok(())
 }
 
+/// [LIVE-WATCHER] A pure-fs edit to a Dart file must drive the live
+/// loop exactly like C#/Rust/Python. The watcher's extension filter
+/// must cover every registered `LanguageParser`; a `.dart` save with
+/// no LSP notification must still push `deslop/reportChanged`.
+#[test]
+fn report_changed_fires_for_external_save_of_dart_file() -> Result<()> {
+    let workspace = copy_fixture("dart-small")?;
+    let beta = workspace.path().join("beta.dart");
+    let mut child = spawn_lsp(workspace.path())?;
+    let (mut stdin, stdout, _stderr) = take_io(&mut child)?;
+    let _guard = KillOnDrop(&mut child);
+    let frames = spawn_frame_reader(stdout);
+
+    let (init_id, init) = initialize_request()?;
+    let _init = send_and_recv_frame(&mut stdin, &frames, init_id, &init)?;
+    let initial = request_response(
+        &mut stdin,
+        &frames,
+        "deslop/reportGet",
+        &serde_json::json!({}),
+    )?;
+    ensure!(
+        cluster_count(&initial) > 0,
+        "dart fixture must start with duplicate clusters"
+    );
+
+    // Pure external save: rewrite beta.dart on disk to break the clone
+    // pair. No didChangeWatchedFiles is sent — only the filesystem
+    // watcher can deliver this event to the scheduler.
+    fs::write(&beta, unrelated_dart())?;
+    let changed = recv_method(&frames, "deslop/reportChanged", Duration::from_secs(10))?;
+    let removed = json_u64(&changed, "/params/summary/clusters_removed")?;
+    ensure!(
+        removed > 0,
+        "external .dart save must remove the broken clone cluster"
+    );
+    Ok(())
+}
+
+/// Replacement Dart body with no duplicated logic.
+fn unrelated_dart() -> &'static str {
+    "String describe(String name) {\n  return 'value: ' + name;\n}\n"
+}
+
 /// Second replacement body for the back-to-back saves test above.
 fn second_unrelated_csharp() -> &'static str {
     "public class Beta {\n    public string Description() {\n        return \"distinct\";\n    }\n}\n"

--- a/crates/deslop/tests/rerun.rs
+++ b/crates/deslop/tests/rerun.rs
@@ -259,6 +259,92 @@ fn rerun_remove_drops_clone_and_reports_cluster_removed() -> Result<()> {
     Ok(())
 }
 
+// Implements [LIVE-CONFIG-LIVE] (#189): replaying the watched
+// `<root>/.deslop.toml` through the rerun harness must re-evaluate the
+// existing corpus against the reloaded `exclude` patterns. A pattern
+// added between generations drops the now-excluded file — and its
+// clusters — instead of only re-rendering.
+#[test]
+fn issue_189_new_exclude_pattern_drops_existing_corpus_files() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let scan_root = tmp.path().join("src");
+    seed(&fixture("csharp-small"), &scan_root)?;
+    // Stage a config that excludes Beta.cs; `--rerun-add` lands it at
+    // the watched `<root>/.deslop.toml` between generation 0 and 1.
+    let staged = tmp.path().join("staged-deslop.toml");
+    fs::write(&staged, "[defaults]\nexclude = [\"**/Beta.cs\"]\n")?;
+    let config_dst = scan_root.join(".deslop.toml");
+    let spec = format!("{}={}", staged.display(), config_dst.display());
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(&scan_root)
+        .arg("--min-nodes")
+        .arg("8")
+        .arg("--output")
+        .arg(tmp.path().join("report"))
+        .arg("--rerun-add")
+        .arg(&spec)
+        .assert()
+        .success();
+    let delta = load_json(&delta_path(tmp.path()))?;
+    assert_eq!(field(&delta, "from_generation"), 0);
+    assert_eq!(field(&delta, "to_generation"), 1);
+    assert!(
+        array_len(&delta, "clusters_removed") > 0,
+        "excluding Beta.cs must remove the Alpha/Beta clone cluster: {delta:#}"
+    );
+    let report = fs::read_to_string(tmp.path().join("report.json"))?;
+    assert!(
+        !report.contains("Beta.cs"),
+        "generation 1 report must not mention the excluded file"
+    );
+    Ok(())
+}
+
+// Implements [LIVE-CONFIG-LIVE] (#189): the reverse direction — a
+// pattern removed between generations re-discovers the previously
+// excluded file so its clusters appear. Exercises the explicit
+// `--config` override path rather than `<root>/.deslop.toml`.
+#[test]
+fn issue_189_removed_exclude_pattern_rediscovers_files() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let scan_root = tmp.path().join("src");
+    seed(&fixture("csharp-small"), &scan_root)?;
+    // Initial pass excludes Beta.cs via an explicit override config,
+    // so generation 0 sees only Alpha.cs and reports no clusters.
+    let override_config = tmp.path().join("deslop.toml");
+    fs::write(&override_config, "[defaults]\nexclude = [\"**/Beta.cs\"]\n")?;
+    let staged = tmp.path().join("staged-looser.toml");
+    fs::write(&staged, "[defaults]\nexclude = []\n")?;
+    let spec = format!("{}={}", staged.display(), override_config.display());
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _assertion = cmd
+        .arg(&scan_root)
+        .arg("--min-nodes")
+        .arg("8")
+        .arg("--config")
+        .arg(&override_config)
+        .arg("--output")
+        .arg(tmp.path().join("report"))
+        .arg("--rerun-add")
+        .arg(&spec)
+        .assert()
+        .success();
+    let delta = load_json(&delta_path(tmp.path()))?;
+    assert_eq!(field(&delta, "from_generation"), 0);
+    assert_eq!(field(&delta, "to_generation"), 1);
+    assert!(
+        array_len(&delta, "clusters_added") > 0,
+        "dropping the exclude must re-discover Beta.cs and surface its cluster: {delta:#}"
+    );
+    let report = fs::read_to_string(tmp.path().join("report.json"))?;
+    assert!(
+        report.contains("Beta.cs"),
+        "generation 1 report must include the re-included file"
+    );
+    Ok(())
+}
+
 // Implements [LIVE-STATE] + [EXCLUSION-CONFIG]: a `--rerun-touch` path
 // that is covered by the loaded exclusion config is treated as a
 // deletion so that an edit making it excluded drops it from the corpus.

--- a/scripts/test-release-version-stamping.mjs
+++ b/scripts/test-release-version-stamping.mjs
@@ -3,9 +3,10 @@
 import { spawnSync } from "node:child_process";
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const stamper = join(repoRoot, "scripts/stamp-release-version.mjs");
 const version = "9.8.7-test.1";
 

--- a/scripts/test-release-workflow-contract.mjs
+++ b/scripts/test-release-workflow-contract.mjs
@@ -6,8 +6,9 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const workflowPath = resolve(repoRoot, ".github/workflows/release.yml");
 const workflow = readFileSync(workflowPath, "utf8");
 

--- a/scripts/test-verifiers.mjs
+++ b/scripts/test-verifiers.mjs
@@ -4,9 +4,10 @@
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, copyFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(new URL("..", import.meta.url).pathname);
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const verifyManifest = join(repoRoot, "scripts/verify-deployment-manifest.mjs");
 const verifyBinaries = join(repoRoot, "scripts/verify-deployment-binaries.mjs");
 const verifyJetBrains = join(repoRoot, "scripts/verify-jetbrains-package.mjs");


### PR DESCRIPTION
<!-- agent-pmo:9a71cbf -->
## TLDR

Fixes two live-loop reactivity bugs: the LSP filesystem watcher now derives its extension filter from the `LanguageParser` registry so pure-disk `.dart` edits drive the reactive loop (Closes #204), and live `.deslop.toml` `exclude` edits now re-evaluate the whole corpus instead of only re-rendering (Closes #189).

## Details

**Watcher extension drift — Closes #204 ([LIVE-WATCHER], [PIPELINE-LANG-TRAIT])**

- `crates/deslop-lsp/src/file_watch.rs` hardcoded `WATCHED_EXTENSIONS = &["cs", "rs", "py"]` — a parallel copy of the language set that drifted when Dart landed. Pure filesystem writes to `.dart` files (the primary path for agent-driven edits) never reached the scheduler, so the reactive loop (watcher → scheduler → session → broadcast → UI) was dead for Dart until restart.
- New `watched_source_extensions()` in `crates/deslop-core/src/pipeline/corpus.rs` (exported from `deslop_core::pipeline` beside `language_ids()`) flat-maps `LanguageParser::file_extensions()` over `default_parsers()`. The watcher now consumes it; the hardcoded constant is deleted. The parser registry is the single source of truth, so future languages (TypeScript, Go) cannot reintroduce the drift.

**Live `.deslop.toml` exclude edits — Closes #189 ([LIVE-CONFIG-LIVE])**

- Previously a config-file change only reloaded the exclusion config and re-rendered, so the UI kept stale offenders. `PipelineSession::update_files` (`crates/deslop-core/src/pipeline/session/mod.rs`) now detects watched config paths in the changed set and calls the new `refresh_exclusion` (`crates/deslop-core/src/pipeline/session/change.rs`), which reloads the config, drops corpus files the new `exclude` patterns match (`drop_newly_excluded`), and re-discovers files a removed pattern re-admits (`apply_newly_included`). A malformed config is logged and the prior exclusion kept, so a typo never bricks the daemon.
- `watched_config_paths` / `is_config_path` / path canonicalisation moved from `crates/deslop-core/src/live/session.rs` into `crates/deslop-core/src/config.rs` as public helpers; `AnalysisSession::apply_changed_paths` no longer does its own config-path filtering, and `reload_exclusion` is no longer public (it is now an internal step of `refresh_exclusion`). `crates/deslop-lsp/src/file_watch.rs` consumes `config::watched_config_paths` instead of a private duplicate.

**Shipwright verifier scripts — path-with-spaces fix**

- `scripts/test-release-workflow-contract.mjs`, `scripts/test-release-version-stamping.mjs`, and `scripts/test-verifiers.mjs` derived the repo root via `new URL("..", import.meta.url).pathname`, which leaves percent-encoding in place (`Coding%20Tools`) and aborts `make ci` with `ENOENT` on any checkout whose path contains a space. They now use `fileURLToPath` from `node:url`; unused `resolve` imports removed.

**Docs**

- `CLAUDE.md`: the agent directive for `find-similar` is expanded into the "LAW: call `find-similar` BEFORE you author new code" section with fused-score thresholds, tool-selection guidance, and hard rules.

**Breaking change note:** `deslop_core::PipelineSession::reload_exclusion` is no longer `pub`; config reload is now driven through `update_files`. No CLI flag, report format, or spec ID changed.

## How Do The Automated Tests Prove It Works?

- `report_changed_fires_for_external_save_of_dart_file` (`crates/deslop-lsp/tests/notifications.rs`, [LIVE-WATCHER]) — black-box E2E against the real `deslop-lsp` binary on the `dart-small` fixture. Asserts the Dart clone cluster exists at startup, then writes `beta.dart` on disk **without any LSP notification** and requires a `deslop/reportChanged` push whose `summary.clusters_removed > 0`. Timed out before the fix (watcher dropped the `.dart` event); passes after.
- `issue_189_new_exclude_pattern_drops_existing_corpus_files` (`crates/deslop/tests/rerun.rs`, [LIVE-CONFIG-LIVE]) — replays a `.deslop.toml` landing at the watched path via `--rerun-add`; asserts the generation-1 delta removes the Alpha/Beta clone cluster and the rendered report no longer mentions the excluded `Beta.cs`.
- `issue_189_removed_exclude_pattern_rediscovers_files` (`crates/deslop/tests/rerun.rs`, [LIVE-CONFIG-LIVE]) — the reverse direction through the explicit `--config` override: loosening the exclude re-discovers `Beta.cs`, the delta reports `clusters_added > 0`, and the report includes the re-included file.
- The Shipwright proof suites themselves (`3 release workflow contract tests passed`, `3 release version stamping tests passed`, `31 verifier proof tests passed`) now run to completion from a space-containing checkout, where they previously aborted before executing a single test.
- Full `make ci` (lint + fail-fast test suite + build + deployment-verify) passes locally with coverage above every threshold in `coverage-thresholds.json` (workspace 94.8%; thresholds unchanged).
