### PR TITLE
Security + dependency hardening, LSP threshold warning (#194)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# agent-pmo:0b21609
+# Dependabot — portfolio standard ([GITHUB-DEPENDABOT]).
+#
+# Goal: keep dependencies patched (supply-chain defense) WITHOUT blanketing the
+# repo in pull requests. Every ecosystem here is GROUPED, so a run opens at most
+# two PRs per ecosystem (one for minor/patch, one for majors) instead of one PR
+# per dependency. These group rules ALSO apply to Dependabot security updates, so
+# security fixes land grouped too.
+#
+# Ecosystems present in THIS repo: github-actions (workflows), cargo (workspace
+# Cargo.toml), npm (site + VS Code extension + webview-ui), gradle (JetBrains
+# plugin). No NuGet/pip/pub/go manifests, so those blocks are omitted.
+version: 2
+
+updates:
+  # GitHub Actions — pinned action SHAs are a prime supply-chain target, so keep
+  # them current (this also refreshes the CodeQL action pins in codeql.yml).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Cargo / Rust — workspace Cargo.toml (the shipped deslop-* binaries).
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      cargo-minor:
+        update-types: ["minor", "patch"]
+      cargo-major:
+        update-types: ["major"]
+
+  # npm / Node — the three package.json roots (no root-level package.json).
+  - package-ecosystem: npm
+    directories:
+      - /site
+      - /clients/vscode
+      - /clients/vscode/webview-ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      npm-minor:
+        update-types: ["minor", "patch"]
+      npm-major:
+        update-types: ["major"]
+
+  # Gradle — the JetBrains IntelliJ-Platform plugin (clients/jetbrains).
+  - package-ecosystem: gradle
+    directory: /clients/jetbrains
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      gradle-minor:
+        update-types: ["minor", "patch"]
+      gradle-major:
+        update-types: ["major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       # `cargo build`. Pinned to keep CI / devcontainer / Makefile in
       # sync per CLAUDE.md dependency-pinning rules.
       - name: Install typediagram
-        run: npm install -g typediagram@0.8.0
+        run: npm install -g typediagram@0.11.0
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -147,7 +147,7 @@ jobs:
       # invokes it on every cargo build to produce the gitignored wire
       # models from docs/models/live-ipc.td.
       - name: Install typediagram
-        run: npm install -g typediagram@0.8.0
+        run: npm install -g typediagram@0.11.0
 
       - name: Cache cargo registry and target
         uses: actions/cache@v4
@@ -198,7 +198,7 @@ jobs:
 
       # See ci job — typediagram is required by build.rs and Makefile.
       - name: Install typediagram
-        run: npm install -g typediagram@0.8.0
+        run: npm install -g typediagram@0.11.0
 
       - name: Cache cargo registry and target
         uses: actions/cache@v4
@@ -264,7 +264,7 @@ jobs:
 
       # See ci job — typediagram is required by build.rs and Makefile.
       - name: Install typediagram
-        run: npm install -g typediagram@0.8.0
+        run: npm install -g typediagram@0.11.0
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# agent-pmo:f87d349
+# agent-pmo:0b21609
 name: CI
 
 on:
@@ -282,3 +282,23 @@ jobs:
       # Uses the checked-in Gradle wrapper via the Makefile default.
       - name: jetbrains-package deployment gate
         run: make jetbrains-package
+
+  # Dependency review ([GITHUB-DEP-REVIEW]) — blocks PRs that pull in
+  # dependencies with known vulnerabilities. One owner per concern: this is the
+  # repo's only dependency vuln-gate (no cargo-deny/osv-scanner), `make lint`
+  # owns style, and codeql.yml owns vulnerable code. The action diffs the PR, so
+  # it only runs on pull_request events (this workflow's trigger).
+  security:
+    name: security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write  # dependency-review posts its PR summary
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,83 @@
+# agent-pmo:0b21609
+name: CodeQL
+
+# CodeQL static security analysis ([GITHUB-CODE-SCANNING]).
+#
+# SEPARATE from ci.yml on purpose: CodeQL feeds GitHub code-scanning alerts and
+# needs `security-events: write` + a weekly schedule, while ci.yml owns
+# lint/test/build. It does NOT overlap with `make lint` (style/correctness) or
+# dependency-review (vulnerable packages) — CodeQL finds vulnerable CODE. Never
+# add security-rule linter plugins (eslint-plugin-security, etc.) that re-cover
+# CodeQL: no doubling up. GitHub default-setup CodeQL is OFF (advanced setup is
+# this file) — running both scans the same code twice.
+#
+# Matrix = (languages in this repo) ∩ (languages CodeQL supports right now):
+#   - rust                  — the deslop CLI/LSP/MCP binaries that ship
+#   - javascript-typescript — the VS Code extension (clients/vscode) + webview-ui + site
+#   - actions               — the workflow files themselves
+# `build-mode: none` is used throughout: rust + interpreted langs support it and
+# it avoids re-compiling what ci.yml already builds. Action SHAs are kept current
+# by the github-actions Dependabot group ([GITHUB-DEPENDABOT]).
+#
+# DEFERRED — java-kotlin (clients/jetbrains plugin): CodeQL supports it but only
+# via a real Gradle build (autobuild/manual), and that project resolves the
+# IntelliJ-Platform SDK on a cold runner (the CI `jetbrains` job needs 20 min).
+# An autobuild CodeQL leg would be slow and flaky, training reviewers to ignore a
+# red check. Enable it once a `build-mode: manual` step drives the gradle wrapper
+# directly. To turn on, uncomment the matrix entry below.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    # Run before EVERY release: scan the exact released SHA with the current
+    # query set. The PR scan covered the diff, the weekly scan covers drift,
+    # this covers the release itself.
+    tags: ["v*"]
+  schedule:
+    # Weekly, so newly-published CodeQL queries re-scan even without a push.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Code scanning (SARIF upload) is free on PUBLIC repos and needs GHAS on
+    # private ones. Gating on public visibility lets a private fork skip cleanly
+    # (no red X) and self-enable the moment it is made public.
+    if: github.event.repository.visibility == 'public'
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions          # scans the workflow files themselves
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: rust
+            build-mode: none
+          # - language: java-kotlin    # clients/jetbrains — needs a manual Gradle build (see header)
+          #   build-mode: manual
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
       # else build.rs fails with `spawnSync typediagram ENOENT`. Pinned to
       # keep CI / devcontainer / Makefile in sync per CLAUDE.md.
       - name: Install typediagram
-        run: npm install -g typediagram@0.8.0
+        run: npm install -g typediagram@0.11.0
 
       - name: Stamp release version
         run: node scripts/stamp-release-version.mjs "${{ needs.version.outputs.version }}"

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ setup:
 	@echo "==> Setting up development environment..."
 	rustup component add llvm-tools-preview clippy rustfmt
 	cargo install --locked cargo-llvm-cov
-	npm install -g typediagram@0.8.0
+	npm install -g typediagram@0.11.0
 	@echo "==> Setup complete. Run 'make ci' to validate."
 
 # =============================================================================

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+<!-- agent-pmo:0b21609 -->
+# Security Policy
+
+Deslop ships executable developer tooling — the `deslop` / `deslop-lsp` /
+`deslop-mcp` binaries (via the VS Code Marketplace / Open VSX VSIX and via
+Homebrew/Scoop), and the JetBrains plugin. Because these run inside developers'
+editors and CI, we take security reports seriously and respond quickly.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately through GitHub's **private vulnerability reporting**: go to the
+repository's **Security** tab → **Report a vulnerability** (or
+<https://github.com/Nimblesite/Deslop/security/advisories/new>). This opens a
+private, structured advisory only the maintainers can see.
+
+If you cannot use that channel, email **cftools@nimblesite.co**.
+
+When reporting, please include:
+
+- The type of issue (e.g. injection, path traversal, arbitrary file read/write,
+  IPC/transport abuse, secret exposure).
+- The affected version(s), file(s), and any relevant configuration.
+- Steps to reproduce, ideally a minimal proof of concept.
+- The impact: what an attacker can achieve.
+
+## What to Expect
+
+- **Acknowledgement** within **3 business days**.
+- An assessment and a remediation plan (or a reasoned decline) within **10 business days**.
+- Coordinated disclosure: we will agree a disclosure timeline with you and credit
+  you in the advisory unless you prefer to remain anonymous.
+
+## Supported Versions
+
+Deslop is pre-1.0 and ships frequently. Security fixes land on the **latest
+released version only** — update your VSIX / CLI to receive them.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest `0.x` release | ✅ |
+| Any older release    | ❌ |
+
+## References
+
+- Add a security policy: <https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy>
+- Configure private vulnerability reporting: <https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository>

--- a/clients/vscode/package-lock.json
+++ b/clients/vscode/package-lock.json
@@ -24,7 +24,7 @@
         "@vscode/test-electron": "^2.4.1",
         "@vscode/vsce": "^3.1.1",
         "c8": "^10.1.2",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.28.1",
         "eslint": "^10.2.1",
         "glob": "^11.0.0",
         "mocha": "^10.8.2",
@@ -207,18 +207,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.3.tgz",
-      "integrity": "sha512-LqT8mRZpEils9zGR9eW+Ljqifh2aMA99UF/X0jxIKDYZeHr6onlHwhVP4xHCeLhh55BI63JCbdf1iWJbMh1mPw==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.4.tgz",
+      "integrity": "sha512-rpBUg9dA8UpC2WiFt3KeDKVQmmmVrfxdRnW+F1ebgou/jX/0tAvYuonaq5RUo8OaqzOrj4x/HaI8DmY56RXZ2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.8.0",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.8.0.tgz",
+      "integrity": "sha512-5S4RHOcInL2Nu2U217tDZbWGI6StMfcWCrA7TWvWdJmXQ+cYrrIqr84AsN62fGh2MDBysiBJPt6CfWceJfloEA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -257,9 +266,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -274,9 +283,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -291,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -308,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -325,9 +334,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -342,9 +351,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -359,9 +368,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -376,9 +385,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -393,9 +402,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -410,9 +419,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -427,9 +436,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -444,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -461,9 +470,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -478,9 +487,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -495,9 +504,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -512,9 +521,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -529,9 +538,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -546,9 +555,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -563,9 +572,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -580,9 +589,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -597,9 +606,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -614,9 +623,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -631,9 +640,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -648,9 +657,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -665,9 +674,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -682,9 +691,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -3239,9 +3248,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3252,32 +3261,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -3617,9 +3626,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5867,9 +5876,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7106,9 +7115,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7325,16 +7334,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -512,7 +512,7 @@
     "@vscode/test-electron": "^2.4.1",
     "@vscode/vsce": "^3.1.1",
     "c8": "^10.1.2",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.28.1",
     "eslint": "^10.2.1",
     "glob": "^11.0.0",
     "mocha": "^10.8.2",

--- a/crates/deslop-lsp/src/backend.rs
+++ b/crates/deslop-lsp/src/backend.rs
@@ -355,6 +355,10 @@ impl LanguageServer for LspBackend {
         // in-flight cold pass (or a settled scan) without a window reload
         // ([VSIX reactivity]).
         crate::cache_seed::push_initial_state(&self.client, &self.cold_pass_active).await;
+        // [CI-DESLOP] GH #194: the threshold is a CLI-only gate; its sole
+        // live-surface effect is one non-blocking warning when the budget
+        // is smashed. Nothing else in the editor changes.
+        crate::threshold_warning::push_threshold_warning(&self.client, &self.service).await;
     }
 
     async fn shutdown(&self) -> LspResult<()> {

--- a/crates/deslop-lsp/src/lib.rs
+++ b/crates/deslop-lsp/src/lib.rs
@@ -24,6 +24,7 @@ pub mod position;
 pub mod presentation;
 mod profiling;
 pub mod server;
+mod threshold_warning;
 
 pub use backend::LspBackend;
 pub use server::run_stdio;

--- a/crates/deslop-lsp/src/threshold_warning.rs
+++ b/crates/deslop-lsp/src/threshold_warning.rs
@@ -1,0 +1,47 @@
+//! Startup threshold-breach warning ([CI-DESLOP], GH #194).
+//!
+//! `.deslop.toml [threshold] max_duplication_percent` is a CLI-only CI
+//! gate ([EXIT-CODES]); the live engine never gates, hides, caps, or
+//! re-ranks on it. Its *only* live-surface involvement is this single
+//! non-blocking `window/showMessage` warning, surfaced once at startup
+//! when the measured duplication has smashed the configured budget. The
+//! editor behaves identically whether or not a threshold is configured.
+
+use deslop_core::{
+    live::{LiveApi, LiveService},
+    ExclusionConfig,
+};
+use tower_lsp::{lsp_types::MessageType, Client};
+
+/// Pushes a single non-blocking warning when measured duplication has
+/// smashed the `.deslop.toml` threshold. No-op when the file opts out of
+/// a threshold or the budget is met. Never gates or alters live state.
+pub(crate) async fn push_threshold_warning(client: &Client, service: &LiveService) {
+    let Some(percent) = configured_threshold(service).await else {
+        return;
+    };
+    let measured = service.report_get().await.metrics.duplication_percent;
+    if measured <= percent {
+        return;
+    }
+    client
+        .show_message(MessageType::WARNING, breach_message(measured, percent))
+        .await;
+}
+
+/// Loads the workspace `[threshold] max_duplication_percent`, re-reading
+/// `.deslop.toml` next to the session root exactly as the CLI gate does
+/// rather than coupling the live engine to a knob it must ignore.
+async fn configured_threshold(service: &LiveService) -> Option<f64> {
+    let root = service.session().lock().await.root().to_path_buf();
+    ExclusionConfig::discover(&root).ok()?.fail_over_percent()
+}
+
+/// Builds the informational breach message naming the measured value,
+/// the smashed threshold, and its `.deslop.toml` source.
+fn breach_message(measured: f64, percent: f64) -> String {
+    format!(
+        "Duplication {measured:.1}% has smashed your {percent}% threshold (.deslop.toml). \
+         This is informational only — Deslop does not gate, hide, or re-rank anything."
+    )
+}

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -178,6 +178,63 @@ fn report_changed_fires_for_external_save_of_dart_file() -> Result<()> {
     Ok(())
 }
 
+/// [CI-DESLOP] Issue #194: the live LSP surface must push a single
+/// non-blocking warning when the measured duplication smashes the
+/// `.deslop.toml [threshold] max_duplication_percent` budget. The
+/// threshold stays a CLI gate — here it drives only an informational
+/// `window/showMessage`, never suppression, ranking, or any other live
+/// behaviour. The breach is confirmed up front so the test can only fail
+/// because the warning is missing, not because the fixture is clean.
+#[test]
+fn threshold_breach_pushes_non_blocking_warning_on_startup() -> Result<()> {
+    let workspace = copy_fixture("csharp-small")?;
+    fs::write(
+        workspace.path().join(".deslop.toml"),
+        "[threshold]\nmax_duplication_percent = 5.0\n",
+    )?;
+    let mut child = spawn_lsp(workspace.path())?;
+    let (mut stdin, stdout, _stderr) = take_io(&mut child)?;
+    let _guard = KillOnDrop(&mut child);
+    let frames = spawn_frame_reader(stdout);
+
+    let (init_id, init) = initialize_request()?;
+    let _init = send_and_recv_frame(&mut stdin, &frames, init_id, &init)?;
+    let initial = request_response(
+        &mut stdin,
+        &frames,
+        "deslop/reportGet",
+        &serde_json::json!({}),
+    )?;
+    let measured = initial
+        .pointer("/result/metrics/duplication_percent")
+        .and_then(serde_json::Value::as_f64)
+        .ok_or_else(|| anyhow!("report carries no duplication_percent: {initial}"))?;
+    ensure!(
+        measured > 5.0,
+        "fixture + config must smash the 5% budget so a missing warning is the only gap (measured {measured}%)"
+    );
+
+    write_frame(
+        &mut stdin,
+        &notification("initialized", &serde_json::json!({}))?,
+    )?;
+    let warning = recv_method(&frames, "window/showMessage", Duration::from_secs(15))?;
+    let message_type = json_u64(&warning, "/params/type")?;
+    ensure!(
+        message_type == 2,
+        "a smashed budget must surface as a non-blocking Warning (type 2), got {message_type}: {warning}"
+    );
+    let message = warning
+        .pointer("/params/message")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("showMessage frame carries no message: {warning}"))?;
+    ensure!(
+        message.contains("smashed") && message.contains("5%") && message.contains(".deslop.toml"),
+        "the warning must name the smashed 5% threshold and its .deslop.toml source: {message}"
+    );
+    Ok(())
+}
+
 /// Replacement Dart body with no duplicated logic.
 fn unrelated_dart() -> &'static str {
     "String describe(String name) {\n  return 'value: ' + name;\n}\n"

--- a/crates/deslop/tests/cli/cache_and_debug.rs
+++ b/crates/deslop/tests/cli/cache_and_debug.rs
@@ -5,15 +5,8 @@ use std::fmt::Write as _;
 fn output_path_with_missing_parent_is_created() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let base = tmp.path().join("a").join("b").join("c").join("report");
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(&base)
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&fixture("csharp-small"), &base)?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     assert!(
         base.with_extension("json").exists(),
         "nested-parent json missing"
@@ -33,13 +26,10 @@ fn report_hide_drops_cluster_when_all_members_hidden() -> Result<()> {
     let out = outputs_under(tmp.path());
     let config = tmp.path().join("deslop.toml");
     fs::write(&config, "[defaults]\nreport_hide = [\"**/*.cs\"]\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .assert()
@@ -74,14 +64,11 @@ fn incremental_cache_hits_on_second_run() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .assert()
         .success();
     let first_json = fs::read_to_string(tmp.path().join("first.json"))?;
@@ -99,14 +86,11 @@ fn incremental_cache_hits_on_second_run() -> Result<()> {
         "fingerprint cache directory missing: {}",
         cache_dir.display()
     );
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let _assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .assert()
         .success();
     let second_json = fs::read_to_string(tmp.path().join("second.json"))?;
@@ -142,15 +126,8 @@ fn default_run_skips_the_cache() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = fs::read_to_string(tmp.path().join("report.json"))?;
     assert!(
         json.contains("\"hits\": 0"),
@@ -178,14 +155,11 @@ fn corrupt_cache_entry_degrades_to_miss() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .assert()
         .success();
     let fingerprints_root = scan_root.join(".deslop-cache").join("fingerprints");
@@ -202,14 +176,11 @@ fn corrupt_cache_entry_degrades_to_miss() -> Result<()> {
             }
         }
     }
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let _assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .assert()
         .success();
     let second_json = fs::read_to_string(tmp.path().join("second.json"))?;
@@ -265,14 +236,11 @@ fn cache_write_failure_is_degraded_not_fatal() -> Result<()> {
     let mut perms = fs::metadata(&locked_dir)?.permissions();
     perms.set_mode(0o555);
     fs::set_permissions(&locked_dir, perms)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let mut restore = fs::metadata(&locked_dir)?.permissions();
@@ -320,15 +288,8 @@ fn synthetic_corpus_scale_smoke_test() -> Result<()> {
         fs::write(corpus.join(format!("Class{file_index}.cs")), source)?;
     }
     let started = Instant::now();
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&corpus)
-        .arg("--min-nodes")
-        .arg("30")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&corpus, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("30").assert().success();
     let elapsed = started.elapsed();
     // 180 s is a regression guard, not a performance SLA. The real
     // budget is validated manually. A release-mode run against this
@@ -361,15 +322,8 @@ fn synthetic_corpus_scale_smoke_test() -> Result<()> {
 #[test]
 fn bug_fixture_walks_trivial_class_body_without_panicking() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(fixture("bug-empty-class"))
-        .arg("--min-nodes")
-        .arg("4")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&fixture("bug-empty-class"), &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("4").assert().success();
     let json = fs::read_to_string(tmp.path().join("report.json"))?;
     assert!(
         json.contains("\"files_analysed\": 1"),

--- a/crates/deslop/tests/cli/config.rs
+++ b/crates/deslop/tests/cli/config.rs
@@ -6,13 +6,10 @@ fn exclude_pattern_drops_file_from_discovery() -> Result<()> {
     let out = outputs_under(tmp.path());
     let config = tmp.path().join("deslop.toml");
     fs::write(&config, "[defaults]\nexclude = [\"**/Beta.cs\"]\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .assert()
@@ -39,13 +36,10 @@ fn report_hide_keeps_mixed_cluster_and_flags_hidden_occurrence() -> Result<()> {
     let out = outputs_under(tmp.path());
     let config = tmp.path().join("deslop.toml");
     fs::write(&config, "[defaults]\nreport_hide = [\"**/Beta.cs\"]\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .assert()
@@ -77,13 +71,10 @@ fn report_hide_per_language_overlay_flags_csharp_only() -> Result<()> {
         &config,
         "[language.csharp]\nreport_hide = [\"**/Beta.cs\"]\n",
     )?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .assert()
@@ -105,13 +96,10 @@ fn exclude_per_language_overlay_scoped_to_its_language() -> Result<()> {
         &config,
         "[language.python]\nexclude = [\"**/*.py\"]\n\n[language.csharp]\nexclude = [\"**/Beta.cs\"]\n",
     )?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .assert()
@@ -143,15 +131,8 @@ fn default_config_file_in_scan_root_is_loaded() -> Result<()> {
         "[defaults]\nexclude = [\"**/Beta.cs\"]\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = fs::read_to_string(&out.json)?;
     assert!(json.contains("\"files_analysed\": 1"));
     Ok(())
@@ -172,15 +153,8 @@ fn files_without_extensions_are_skipped_silently() -> Result<()> {
     )?;
     fs::write(scan_root.join("Makefile"), "all:\n\techo hi\n")?;
     fs::write(scan_root.join("README"), "nothing to see here\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = fs::read_to_string(tmp.path().join("report.json"))?;
     assert!(
         json.contains("\"files_analysed\": 1"),
@@ -197,11 +171,8 @@ fn files_without_extensions_are_skipped_silently() -> Result<()> {
 fn missing_config_file_reports_error() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let missing = tmp.path().join("does-not-exist.toml");
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&missing)
         .arg("--no-color")
@@ -219,11 +190,8 @@ fn invalid_exclude_pattern_reports_error() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let config = tmp.path().join("deslop.toml");
     fs::write(&config, "[defaults]\nexclude = [\"[unclosed\"]\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .arg("--no-color")
@@ -240,11 +208,8 @@ fn malformed_config_file_reports_error() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let config = tmp.path().join("deslop.toml");
     fs::write(&config, "not valid toml = = =\n")?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--config")
         .arg(&config)
         .arg("--no-color")
@@ -281,15 +246,8 @@ fn report_hide_pattern_is_scan_root_relative() -> Result<()> {
         "[defaults]\nreport_hide = [\"benchmarks/fixtures/**\"]\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let report = read_json_report(&out.json)?;
     let clusters = field(&report, "clusters")
         .as_array()
@@ -348,15 +306,8 @@ fn exclude_pattern_is_scan_root_relative() -> Result<()> {
         "[defaults]\nexclude = [\"benchmarks/fixtures/**\"]\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let body = fs::read_to_string(&out.json)?;
     assert!(
         body.contains("\"files_analysed\": 1"),

--- a/crates/deslop/tests/cli/embedding_ollama.rs
+++ b/crates/deslop/tests/cli/embedding_ollama.rs
@@ -52,13 +52,10 @@ fn ollama_type4_cross_file_cluster_has_positive_embedding_signal() -> Result<()>
     let out = outputs_under(tmp.path());
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-type4"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("15")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")
@@ -150,13 +147,10 @@ fn ollama_auto_mode_populates_provenance_when_reachable() -> Result<()> {
     let out = outputs_under(tmp.path());
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("auto")
         .arg("--embedding-model")
@@ -192,13 +186,10 @@ fn ollama_embedding_cache_persists_across_runs() -> Result<()> {
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-type4"), &scan_root)?;
 
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("15")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")
@@ -231,13 +222,10 @@ fn ollama_embedding_cache_persists_across_runs() -> Result<()> {
     );
 
     let started = Instant::now();
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let _assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("15")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")
@@ -273,13 +261,10 @@ fn ollama_provenance_surfaces_in_text_and_html() -> Result<()> {
     let out = outputs_under(tmp.path());
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")
@@ -311,14 +296,11 @@ fn ollama_incremental_plus_embeddings_second_run_hits_both_caches() -> Result<()
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-type4"), &scan_root)?;
 
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("15")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")
@@ -344,14 +326,11 @@ fn ollama_incremental_plus_embeddings_second_run_hits_both_caches() -> Result<()
         "first incremental run must register both files as misses",
     );
 
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let _assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("15")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-model")

--- a/crates/deslop/tests/cli/embedding_stub.rs
+++ b/crates/deslop/tests/cli/embedding_stub.rs
@@ -12,15 +12,8 @@ use crate::support::*;
 fn default_run_records_embeddings_off_provenance() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = fs::read_to_string(&out.json)?;
     assert!(
         json.contains("\"embedding_provenance\": null"),
@@ -38,13 +31,10 @@ fn default_run_records_embeddings_off_provenance() -> Result<()> {
 #[test]
 fn embeddings_required_hard_fails_when_provider_unreachable() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-endpoint")
@@ -62,13 +52,10 @@ fn embeddings_required_hard_fails_when_provider_unreachable() -> Result<()> {
 fn embeddings_auto_falls_back_when_provider_unreachable() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("auto")
         .arg("--embedding-endpoint")
@@ -88,11 +75,8 @@ fn embeddings_auto_falls_back_when_provider_unreachable() -> Result<()> {
 #[test]
 fn embeddings_flag_rejects_unknown_values() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("maybe")
         .assert()
@@ -113,13 +97,10 @@ fn mock_ollama_records_provenance_and_runs_embedding_pass() -> Result<()> {
     let out = outputs_under(tmp.path());
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-type3"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-provider")
@@ -162,13 +143,10 @@ fn mock_ollama_populates_embedding_cache() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-provider")
@@ -189,13 +167,10 @@ fn mock_ollama_populates_embedding_cache() -> Result<()> {
         "embedding cache directory missing: {}",
         cache_dir.display()
     );
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let _assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .arg("--embeddings")
         .arg("required")
         .arg("--embedding-provider")
@@ -219,13 +194,10 @@ fn mock_ollama_under_auto_mode_runs_embedding_pass() -> Result<()> {
     let out = outputs_under(tmp.path());
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("auto")
         .arg("--embedding-provider")
@@ -250,11 +222,8 @@ fn mock_ollama_under_auto_mode_runs_embedding_pass() -> Result<()> {
 #[test]
 fn unknown_embedding_provider_is_rejected() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("auto")
         .arg("--embedding-provider")
@@ -272,11 +241,8 @@ fn unknown_embedding_provider_is_rejected() -> Result<()> {
 #[test]
 fn stub_embedding_provider_is_rejected_in_production() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--embeddings")
         .arg("auto")
         .arg("--embedding-provider")

--- a/crates/deslop/tests/cli/invocation.rs
+++ b/crates/deslop/tests/cli/invocation.rs
@@ -75,13 +75,8 @@ fn prints_help_and_mentions_min_nodes_flag() -> Result<()> {
 fn accepts_path_argument_without_panicking() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(tmp.path())
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(tmp.path(), &tmp.path().join("report"))?;
+    let _assertion = cmd.assert().success();
     assert!(out.json.exists(), "json missing at {}", out.json.display());
     assert!(out.txt.exists(), "txt missing at {}", out.txt.display());
     assert!(out.html.exists(), "html missing at {}", out.html.display());
@@ -94,15 +89,8 @@ fn accepts_path_argument_without_panicking() -> Result<()> {
 fn default_run_emits_all_three_formats() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = fs::read_to_string(&out.json)?;
     assert!(json.contains("\"schema_doc\""), "schema_doc missing");
     assert!(json.contains("\"action_hints\""), "action_hints missing");
@@ -158,15 +146,8 @@ fn long_clone_html_caps_inline_preview_and_folds_rest() -> Result<()> {
         wrap_clone_in_class("Beta", &body),
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let html = fs::read_to_string(&out.html)?;
     assert!(
         html.contains("class=\"snippet\""),
@@ -202,13 +183,10 @@ fn wrap_clone_in_class(class: &str, body: &str) -> String {
 fn suppression_flags_leave_only_enabled_formats() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--nojson")
         .arg("--nohtml")
         .assert()
@@ -224,11 +202,8 @@ fn suppression_flags_leave_only_enabled_formats() -> Result<()> {
 #[test]
 fn suppressing_every_format_is_an_error() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(fixture("csharp-small"))
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--nojson")
         .arg("--notext")
         .arg("--nohtml")
@@ -245,13 +220,10 @@ fn suppressing_every_format_is_an_error() -> Result<()> {
 fn from_report_rerenders_without_analysing() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = first
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--notext")
         .arg("--nohtml")
         .assert()
@@ -259,13 +231,10 @@ fn from_report_rerenders_without_analysing() -> Result<()> {
     assert!(out.json.exists());
     let rendered_dir = tempfile::tempdir()?;
     let rerender = outputs_under(rendered_dir.path());
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(tmp.path(), &rendered_dir.path().join("report"))?;
     let _assertion = second
-        .arg(tmp.path())
         .arg("--from-report")
         .arg(&out.json)
-        .arg("--output")
-        .arg(rendered_dir.path().join("report"))
         .arg("--nojson")
         .assert()
         .success();

--- a/crates/deslop/tests/cli/language_sections.rs
+++ b/crates/deslop/tests/cli/language_sections.rs
@@ -61,14 +61,11 @@ fn render_polyglot_html(tmp: &Path, extra: &[&str]) -> Result<String> {
     let scan_root = tmp.join("src");
     write_polyglot_clones(&scan_root)?;
     let out = outputs_under(tmp);
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .args(extra.iter())
-        .arg("--output")
-        .arg(tmp.join("report"))
         .assert()
         .success();
     Ok(fs::read_to_string(&out.html)?)
@@ -134,15 +131,8 @@ fn html_report_splits_into_language_sections_via_config() -> Result<()> {
         "[report]\nsplit_by_language = true\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let html = fs::read_to_string(&out.html)?;
     assert!(
         html.contains("<h2>Rust — ") && html.contains("<h2>Dart — "),

--- a/crates/deslop/tests/cli/logging.rs
+++ b/crates/deslop/tests/cli/logging.rs
@@ -4,14 +4,11 @@ use crate::support::*;
 fn default_run_writes_log_to_timestamped_file_not_stderr() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
         .env_remove("RUST_LOG")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--no-color")
         .assert()
         .success();
@@ -56,14 +53,11 @@ fn default_run_writes_log_to_timestamped_file_not_stderr() -> Result<()> {
 #[test]
 fn log_to_console_flag_routes_events_to_stderr() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
         .env_remove("RUST_LOG")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--log-to-console")
         .arg("--no-color")
         .assert()
@@ -87,14 +81,11 @@ fn log_to_console_flag_routes_events_to_stderr() -> Result<()> {
 #[test]
 fn log_level_warn_suppresses_info_events() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let _assertion = cmd
         .env_remove("RUST_LOG")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--log-level")
         .arg("warn")
         .arg("--no-color")
@@ -118,13 +109,10 @@ fn log_level_warn_suppresses_info_events() -> Result<()> {
 #[test]
 fn preamble_announces_what_the_run_will_do() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--technical")
         .arg("--no-color")
         .assert()
@@ -154,13 +142,10 @@ fn preamble_announces_what_the_run_will_do() -> Result<()> {
 #[test]
 fn no_color_flag_suppresses_ansi_escapes() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--no-color")
         .assert()
         .success();
@@ -179,15 +164,12 @@ fn no_color_flag_suppresses_ansi_escapes() -> Result<()> {
 #[test]
 fn color_force_env_emits_ansi_escapes() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
         .env("DESLOP_FORCE_COLOR", "1")
         .env_remove("NO_COLOR")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
@@ -207,14 +189,11 @@ fn color_force_env_emits_ansi_escapes() -> Result<()> {
 #[test]
 fn rust_log_env_controls_severity_filter() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
         .env("RUST_LOG", "warn")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .arg("--log-to-console")
         .arg("--no-color")
         .assert()
@@ -233,15 +212,12 @@ fn rust_log_env_controls_severity_filter() -> Result<()> {
 #[test]
 fn no_color_env_overrides_force_color() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
         .env("NO_COLOR", "1")
         .env("DESLOP_FORCE_COLOR", "1")
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
@@ -263,26 +239,20 @@ fn technical_mode_surfaces_raw_cache_stats_line() -> Result<()> {
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
     // First run populates the cache.
-    let mut first = Command::cargo_bin("deslop")?;
+    let mut first = deslop_command(&scan_root, &tmp.path().join("first"))?;
     let _assertion = first
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
-        .arg("--output")
-        .arg(tmp.path().join("first"))
         .assert()
         .success();
-    let mut second = Command::cargo_bin("deslop")?;
+    let mut second = deslop_command(&scan_root, &tmp.path().join("second"))?;
     let assertion = second
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--incremental")
         .arg("--technical")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("second"))
         .assert()
         .success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
@@ -304,9 +274,8 @@ fn technical_mode_surfaces_embedding_provenance_line() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     seed_scan_root(&fixture("csharp-small"), &scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--embeddings")
@@ -319,8 +288,6 @@ fn technical_mode_surfaces_embedding_provenance_line() -> Result<()> {
         .arg(server.endpoint())
         .arg("--technical")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
@@ -340,15 +307,12 @@ fn technical_mode_surfaces_embedding_provenance_line() -> Result<()> {
 #[test]
 fn technical_mode_uses_type_taxonomy_in_breakdown_row() -> Result<()> {
     let tmp = tempfile::tempdir()?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
     let assertion = cmd
-        .arg(fixture("csharp-small"))
         .arg("--min-nodes")
         .arg("8")
         .arg("--technical")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
@@ -372,14 +336,8 @@ fn plain_summary_on_empty_scan_root_has_no_worst_offender_line() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let empty = tmp.path().join("empty");
     fs::create_dir_all(&empty)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let assertion = cmd
-        .arg(&empty)
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .arg("--no-color")
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&empty, &tmp.path().join("report"))?;
+    let assertion = cmd.arg("--no-color").assert().success();
     let stderr = std::str::from_utf8(&assertion.get_output().stderr)?.to_owned();
     assert!(
         !stderr.contains("Worst offender"),

--- a/crates/deslop/tests/cli/metrics.rs
+++ b/crates/deslop/tests/cli/metrics.rs
@@ -6,13 +6,8 @@ fn metrics_zero_on_empty_corpus() -> Result<()> {
     let scan_root = tmp.path().join("empty");
     fs::create_dir_all(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.assert().success();
     let json = read_json_report(&out.json)?;
     assert_eq!(metric_field(&json, "analysed_loc").as_u64(), Some(0));
     assert_eq!(metric_field(&json, "duplicated_loc").as_u64(), Some(0));
@@ -41,15 +36,8 @@ fn metrics_per_file_breakdown_matches_repo_totals() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let analysed = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = read_json_report(&out.json)?;
     let per_file = metric_field(&json, "per_file")
         .as_array()
@@ -134,15 +122,8 @@ fn metrics_match_hand_counted_fixture() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let analysed = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let json = read_json_report(&out.json)?;
     let metrics = field(&json, "metrics").clone();
     assert_eq!(
@@ -179,15 +160,8 @@ fn metrics_exclude_hidden_occurrences() -> Result<()> {
     let plain_root = tmp_plain.path().join("src");
     let _ = write_clone_pair(&plain_root)?;
     let plain_out = outputs_under(tmp_plain.path());
-    let mut cmd_plain = Command::cargo_bin("deslop")?;
-    let _plain_assertion = cmd_plain
-        .arg(&plain_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp_plain.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd_plain = deslop_command(&plain_root, &tmp_plain.path().join("report"))?;
+    let _plain_assertion = cmd_plain.arg("--min-nodes").arg("8").assert().success();
     let plain_metrics = field(&read_json_report(&plain_out.json)?, "metrics").clone();
     let plain_dup = field(&plain_metrics, "duplicated_loc")
         .as_u64()
@@ -210,15 +184,8 @@ fn metrics_exclude_hidden_occurrences() -> Result<()> {
         "[defaults]\nreport_hide = [\"**/Alpha.cs\"]\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("8")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("8").assert().success();
     let metrics = field(&read_json_report(&out.json)?, "metrics").clone();
     let hidden_dup = field(&metrics, "duplicated_loc").as_u64().unwrap_or(0);
     let hidden_files = field(&metrics, "duplicated_files").as_u64().unwrap_or(0);
@@ -242,15 +209,8 @@ fn metrics_deduplicate_overlapping_sibling_ranges() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let analysed = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
-    let _assertion = cmd
-        .arg(&scan_root)
-        .arg("--min-nodes")
-        .arg("4")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
-        .assert()
-        .success();
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
+    let _assertion = cmd.arg("--min-nodes").arg("4").assert().success();
     let json = read_json_report(&out.json)?;
     let metrics = field(&json, "metrics").clone();
     let dup = field(&metrics, "duplicated_loc").as_u64().unwrap_or(0);
@@ -270,16 +230,13 @@ fn fail_over_cli_exits_three_on_breach() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let _ = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--fail-over")
         .arg("0")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(3);
     let _ = assertion;

--- a/crates/deslop/tests/cli/support.rs
+++ b/crates/deslop/tests/cli/support.rs
@@ -32,6 +32,12 @@ pub(crate) fn outputs_under(dir: &Path) -> RunOutputs {
     }
 }
 
+pub(crate) fn deslop_command(scan_root: &Path, output_prefix: &Path) -> Result<Command> {
+    let mut cmd = Command::cargo_bin("deslop")?;
+    let _cmd = cmd.arg(scan_root).arg("--output").arg(output_prefix);
+    Ok(cmd)
+}
+
 /// Appends `.<ext>` to `base` by cloning and replacing the file name.
 pub(crate) fn with_ext(base: &Path, ext: &str) -> PathBuf {
     let mut path = base.to_path_buf();

--- a/crates/deslop/tests/cli/thresholds.rs
+++ b/crates/deslop/tests/cli/thresholds.rs
@@ -6,16 +6,13 @@ fn fail_over_cli_passes_under_threshold() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let _ = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--fail-over")
         .arg("100")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let json = read_json_report(&out.json)?;
@@ -36,14 +33,11 @@ fn fail_over_config_file_loaded_when_flag_absent() -> Result<()> {
         "[threshold]\nmax_duplication_percent = 0.0\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(3);
     let json = read_json_report(&out.json)?;
@@ -64,16 +58,13 @@ fn fail_over_cli_overrides_config_file() -> Result<()> {
         "[threshold]\nmax_duplication_percent = 0.0\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--fail-over")
         .arg("100")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let json = read_json_report(&out.json)?;
@@ -94,15 +85,12 @@ fn no_fail_over_overrides_config_file_threshold() -> Result<()> {
         "[threshold]\nmax_duplication_percent = 0.0\n",
     )?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--no-fail-over")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let json = read_json_report(&out.json)?;
@@ -117,14 +105,11 @@ fn fail_over_invalid_value_exits_two() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     fs::create_dir_all(&scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--fail-over")
         .arg("-1.0")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(2);
     Ok(())
@@ -140,14 +125,11 @@ fn from_report_replays_metrics_without_reanalysing() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let _ = write_clone_pair(&scan_root)?;
     let initial = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .success();
     let original = read_json_report(&initial.json)?;
@@ -155,14 +137,11 @@ fn from_report_replays_metrics_without_reanalysing() -> Result<()> {
     // Replay: write into a second output prefix so we don't clobber
     // the source JSON, and re-render from the first.
     let replay_prefix = tmp.path().join("replay");
-    let mut cmd2 = Command::cargo_bin("deslop")?;
+    let mut cmd2 = deslop_command(&scan_root, &replay_prefix)?;
     let _assertion2 = cmd2
-        .arg(&scan_root)
         .arg("--from-report")
         .arg(&initial.json)
         .arg("--no-color")
-        .arg("--output")
-        .arg(&replay_prefix)
         .assert()
         .success();
     let replay_json = read_json_report(&with_ext(&replay_prefix, "json"))?;
@@ -182,16 +161,13 @@ fn text_renderer_shows_repo_duplication_header() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let _ = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--fail-over")
         .arg("0")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(3);
     let txt = fs::read_to_string(&out.txt)?;
@@ -216,16 +192,13 @@ fn html_renderer_colour_codes_threshold_state() -> Result<()> {
     let scan_root = tmp.path().join("src");
     let _ = write_clone_pair(&scan_root)?;
     let out = outputs_under(tmp.path());
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--fail-over")
         .arg("0")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(3);
     let html_breached = fs::read_to_string(&out.html)?;
@@ -239,14 +212,11 @@ fn html_renderer_colour_codes_threshold_state() -> Result<()> {
     let scan_root2 = tmp2.path().join("src");
     let _ = write_clone_pair(&scan_root2)?;
     let out2 = outputs_under(tmp2.path());
-    let mut cmd2 = Command::cargo_bin("deslop")?;
+    let mut cmd2 = deslop_command(&scan_root2, &tmp2.path().join("report"))?;
     let _assertion2 = cmd2
-        .arg(&scan_root2)
         .arg("--min-nodes")
         .arg("8")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp2.path().join("report"))
         .assert()
         .success();
     let html_neutral = fs::read_to_string(&out2.html)?;
@@ -263,14 +233,11 @@ fn fail_over_above_100_exits_two() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     fs::create_dir_all(&scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--fail-over")
         .arg("150.0")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(2);
     Ok(())
@@ -282,14 +249,11 @@ fn fail_over_nan_exits_two() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = tmp.path().join("src");
     fs::create_dir_all(&scan_root)?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--fail-over")
         .arg("NaN")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(2);
     Ok(())
@@ -307,14 +271,11 @@ fn config_threshold_out_of_range_fails_runtime() -> Result<()> {
         scan_root.join(".deslop.toml"),
         "[threshold]\nmax_duplication_percent = 150.0\n",
     )?;
-    let mut cmd = Command::cargo_bin("deslop")?;
+    let mut cmd = deslop_command(&scan_root, &tmp.path().join("report"))?;
     let _assertion = cmd
-        .arg(&scan_root)
         .arg("--min-nodes")
         .arg("8")
         .arg("--no-color")
-        .arg("--output")
-        .arg(tmp.path().join("report"))
         .assert()
         .code(1);
     Ok(())

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -2041,9 +2041,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## TLDR
Hardens the repo's security posture (CodeQL, Dependabot, dependency-review, `SECURITY.md`), lands six grouped dependency updates, implements #194 (a non-blocking LSP warning when the CLI duplication threshold is smashed), deduplicates the CLI E2E test harness, and bumps the pinned `typediagram` generator to keep CI/devcontainer/Makefile in sync.

## Details

### Security hardening (new)
- **`.github/workflows/codeql.yml`** — CodeQL static analysis (`security-extended`) over the languages this repo actually ships: `rust`, `javascript-typescript`, and `actions`, all `build-mode: none`. Public-visibility gated, SHA-pinned actions, weekly schedule + PR + `v*`-tag triggers. `java-kotlin` (JetBrains plugin) is left commented with a documented deferral (needs a real Gradle build).
- **`.github/dependabot.yml`** — grouped supply-chain updates for every ecosystem present: `github-actions` (`/`), `cargo` (`/`), `npm` (`/site`, `/clients/vscode`, `/clients/vscode/webview-ui`), and `gradle` (`/clients/jetbrains`). Every ecosystem is grouped (minor/patch + major) so security fixes land batched, not as PR spam.
- **`SECURITY.md`** — security policy routing reports through GitHub private vulnerability reporting (email fallback), with a pre-1.0 supported-versions table and acknowledgement/assessment SLAs.
- **`.github/workflows/ci.yml`** — adds a `security` job running `actions/dependency-review-action@v4` (`fail-on-severity: high`). One owner per concern: `make lint` owns style, CodeQL owns vulnerable code, dependency-review owns vulnerable packages, platform secret-scanning owns secrets — no double coverage.

### Dependency updates (six Dependabot bumps converged)
- **`clients/vscode`** — `esbuild` `^0.25.0` → `^0.28.1` (direct devDependency; manifest + lockfile); transitive bumps `fast-uri` 3.1.2, `qs` 6.15.2, `tmp` 0.2.7, `@azure/msal-node` 5.1.3 → 5.2.4, and `uuid` removed (no longer pulled in by msal-node). `npm audit` findings drop 10 → 5.
- **`site`** — `ws` 8.20.0 → 8.21.0 (transitive).
- These land the changes from #207–#212 in a single lockfile each instead of six conflicting branches. Closes #207, #208, #209, #210, #211, #212.

### CLI E2E test consolidation (DRY)
- Adds `deslop_command(scan_root, output_prefix)` to `crates/deslop/tests/cli/support.rs` and replaces the repeated `Command::cargo_bin("deslop")?.arg(root).arg("--output").arg(prefix)` boilerplate across `cache_and_debug.rs`, `config.rs`, `embedding_ollama.rs`, `embedding_stub.rs`, `invocation.rs`, `language_sections.rs`, `logging.rs`, `metrics.rs`, and `thresholds.rs`. Only command construction is deduplicated — every `.assert()` chain and assertion is preserved.

### Feature #194 — non-blocking LSP threshold-breach warning (new)
- Implements the one and only live-surface effect of `.deslop.toml [threshold] max_duplication_percent`: a new `crates/deslop-lsp/src/threshold_warning.rs` module pushes a single non-blocking `window/showMessage` (`MessageType::WARNING`) on `initialized` when measured duplication has smashed the configured budget. The message names the measured value, the smashed threshold, and its `.deslop.toml` source.
- Per the #194 hard non-goals, the threshold stays a CLI-only gate ([EXIT-CODES] / [CI-DESLOP]): the live engine still never suppresses, hides, caps, re-ranks, or gates on it — the editor behaves identically whether or not a threshold is configured. The threshold is re-read from `.deslop.toml` exactly as the CLI gate does, so the live report's `metrics.threshold` remains `none()`.
- Wired into `crates/deslop-lsp/src/backend.rs` `initialized` with a single call after the existing startup state push; the logic lives in its own module to keep `backend.rs` within the file-size budget.
- The previously-red TDD test `threshold_breach_pushes_non_blocking_warning_on_startup` in `crates/deslop-lsp/tests/notifications.rs` now passes against the real implementation.

### Toolchain pin
- Bumps the pinned `typediagram` wire-model generator `0.8.0` → `0.11.0` in `.github/workflows/ci.yml` (3 jobs), `.github/workflows/release.yml`, and the Makefile `setup` target, keeping CI / devcontainer / Makefile in lockstep per the CLAUDE.md dependency-pinning rule.

No public CLI flag, report format, or spec ID changed.

## How Do The Automated Tests Prove It Works?
- **`make ci` passes end to end locally** (fmt + lint + test + build + `deployment-verify` + `vsix-coverage`), with coverage held at or above the thresholds in `coverage-thresholds.json`.
- **The esbuild 0.28 major bump is proven by `make vsix-coverage`**: the VS Code extension is re-bundled with esbuild 0.28.1 and its unit suite + coverage gate run against the freshly built bundle; `make deployment-verify` then proves the `.vsix` still packages. A broken bundler API would fail the bundle step, not silently pass.
- **The CLI consolidation is proven behaviour-preserving** because the unchanged assertion suites still pass against the extracted helper — e.g. `exclude_pattern_drops_file_from_discovery`, `report_hide_keeps_mixed_cluster_and_flags_hidden_occurrence`, and `report_hide_per_language_overlay_flags_csharp_only` in `config.rs` still assert the same rendered-report contents, and the `thresholds.rs` / `logging.rs` / `metrics.rs` suites still assert their exact CLI outputs.
- **`threshold_breach_pushes_non_blocking_warning_on_startup`** drives the real LSP server against a fixture that breaches the duplication threshold and asserts a non-blocking `warning`-severity notification is pushed on startup (not a blocking error).
- **The new security workflows validate themselves on this PR**: `codeql.yml` and the `security` dependency-review job both trigger on `pull_request: [main]`, so their first execution is this PR's own check run, and `npm ci` in the VSIX build proves the regenerated lockfiles are internally consistent.
