### PR TITLE
Fix duplication metric to count only the clusters the report renders

### DIFF
--- a/crates/deslop-core/src/report.rs
+++ b/crates/deslop-core/src/report.rs
@@ -149,6 +149,17 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
         .map(|cluster| materialise_cluster(cluster, &inputs, &parse_cache, policy))
         .collect();
     let clusters_hidden = materialised.iter().filter(|(_, hidden)| *hidden).count();
+    // The metric must count the same clusters the report renders, so it
+    // sees only the survivors of `materialise_cluster` — never a cluster
+    // dropped as report-hidden, noise, or structural-only sibling
+    // boilerplate. Aligned positionally with `inputs.clusters` because
+    // `materialised` was mapped over it in order ([METRICS-REPO]).
+    let visible_internal: Vec<&Cluster> = inputs
+        .clusters
+        .iter()
+        .zip(&materialised)
+        .filter_map(|(cluster, (_, hidden))| (!hidden).then_some(cluster))
+        .collect();
     let mut visible_clusters: Vec<ReportCluster> = materialised
         .into_iter()
         .filter_map(|(cluster, hidden)| if hidden { None } else { Some(cluster) })
@@ -156,7 +167,7 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
     reweigh_by_visible_occurrences(&mut visible_clusters, policy);
     log_bucket_distribution(&visible_clusters, clusters_hidden);
     let mut metrics = compute_repo_metrics(&MetricsInputs {
-        clusters: inputs.clusters,
+        clusters: &visible_internal,
         sources: inputs.sources,
         file_languages: inputs.file_languages,
         registry: inputs.registry,

--- a/crates/deslop-core/src/report_metrics.rs
+++ b/crates/deslop-core/src/report_metrics.rs
@@ -89,9 +89,13 @@ pub type AnalysedLines = HashMap<FileId, u64>;
 /// point past the 7-argument budget.
 #[derive(Debug)]
 pub struct MetricsInputs<'a, S: BuildHasher> {
-    /// Ranked cluster list produced by
-    /// [`crate::cluster::build_ranked_fused_clusters`].
-    pub clusters: &'a [Cluster],
+    /// The clusters that survive into the rendered report — the visible
+    /// set after [`crate::report::render_report`] drops report-hidden and
+    /// noise / structural-only clusters. The metric counts the same
+    /// clusters the report carries, never one the report dropped, so
+    /// per-file and repo percentages stay consistent with the cluster list
+    /// every surface renders ([METRICS-REPO]).
+    pub clusters: &'a [&'a Cluster],
     /// Per-file source bytes keyed by [`FileId`]. Used to convert
     /// `byte_range` to line numbers; only read, never mutated.
     pub sources: &'a HashMap<FileId, Vec<u8>>,
@@ -117,7 +121,7 @@ pub fn compute_repo_metrics<S: BuildHasher>(inputs: &MetricsInputs<'_, S>) -> Re
     let analysed_loc: u64 = inputs.analysed_lines.values().copied().sum();
     let mut per_file_lines: HashMap<FileId, BTreeSet<u64>> = HashMap::new();
     let mut contributing_clusters: usize = 0;
-    for cluster in inputs.clusters {
+    for &cluster in inputs.clusters {
         if fold_cluster_lines(cluster, inputs, &mut per_file_lines) {
             contributing_clusters = contributing_clusters.saturating_add(1);
         }

--- a/crates/deslop/tests/common/mod.rs
+++ b/crates/deslop/tests/common/mod.rs
@@ -11,7 +11,11 @@
 
 #![allow(dead_code)]
 
-use std::{fs, path::Path, path::PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::anyhow;
 pub(crate) use anyhow::Result;
@@ -148,4 +152,75 @@ pub(crate) fn summaries_where(
         }
     }
     Ok(summaries)
+}
+
+/// Reads a scalar field off the report's `metrics` block ([METRICS-REPO]).
+pub(crate) fn metric_field<'a>(report: &'a Value, name: &str) -> &'a Value {
+    field(field(report, "metrics"), name)
+}
+
+/// `metrics.per_file` rows, or an empty slice when absent.
+pub(crate) fn per_file_metrics(report: &Value) -> &[Value] {
+    metric_field(report, "per_file")
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+}
+
+/// Count of a cluster's non-hidden (live) occurrences.
+pub(crate) fn live_occurrences(cluster: &Value) -> usize {
+    occurrences(cluster)
+        .iter()
+        .filter(|occurrence| !field(occurrence, "hidden").as_bool().unwrap_or(false))
+        .count()
+}
+
+/// Line-set cardinality as the `u64` the wire metric uses.
+pub(crate) fn line_count(lines: &BTreeSet<u64>) -> u64 {
+    u64::try_from(lines.len()).unwrap_or(u64::MAX)
+}
+
+/// Per-file set of line numbers covered by the non-hidden occurrences of the
+/// report's *visible* clusters — the exact line set [METRICS-REPO] requires
+/// the duplication metric to count. Keyed by the relative occurrence path so
+/// callers match it against the absolute metric path with `ends_with`.
+pub(crate) fn visible_duplicated_lines(report: &Value) -> BTreeMap<String, BTreeSet<u64>> {
+    let mut per_file: BTreeMap<String, BTreeSet<u64>> = BTreeMap::new();
+    for cluster in clusters(report) {
+        for occurrence in occurrences(cluster) {
+            if field(occurrence, "hidden").as_bool().unwrap_or(false) {
+                continue;
+            }
+            let Some(path) = field(occurrence, "path").as_str() else {
+                continue;
+            };
+            let start = field(occurrence, "start_line").as_u64().unwrap_or(0);
+            let end = field(occurrence, "end_line").as_u64().unwrap_or(0);
+            let entry = per_file.entry(path.to_owned()).or_default();
+            for line in start..=end {
+                let _inserted = entry.insert(line);
+            }
+        }
+    }
+    per_file
+}
+
+/// Total lines the report's visible clusters cover across every file — the
+/// repo-level `duplicated_loc` the metric must report ([METRICS-REPO]).
+pub(crate) fn visible_duplicated_loc(report: &Value) -> u64 {
+    visible_duplicated_lines(report)
+        .values()
+        .map(line_count)
+        .sum()
+}
+
+/// Writes two byte-identical source files (`a.<extension>`, `b.<extension>`)
+/// into a freshly created `dir`: the minimal corpus for a fully-duplicated
+/// repo, used to prove the duplication metric is language-agnostic.
+pub(crate) fn write_identical_pair(dir: &Path, extension: &str, source: &str) -> Result<()> {
+    fs::create_dir_all(dir)?;
+    for stem in ["a", "b"] {
+        fs::write(dir.join(format!("{stem}.{extension}")), source)?;
+    }
+    Ok(())
 }

--- a/crates/deslop/tests/dart_issue_197_single_file_structural_only.rs
+++ b/crates/deslop/tests/dart_issue_197_single_file_structural_only.rs
@@ -56,14 +56,37 @@ fn single_file_structural_only_method_families_do_not_top_the_report() -> Result
     let scan_root = fixture("dart-issue-197-settings-getters");
     let report = run_report(&scan_root)?;
 
-    let total_clusters = report
+    // [METRICS-REPO] The duplication metric counts only the clusters the
+    // report renders. Every family in this fixture is a hidden
+    // structural-only sibling-method family, so the metric must report zero
+    // duplication even though the families were detected (asserted via
+    // `clusters_hidden` below) — proving a structural-only shape match
+    // cannot inflate the percentage.
+    let visible_contributing = report
         .pointer("/metrics/clusters_total")
         .and_then(Value::as_u64)
         .unwrap_or_default();
+    assert_eq!(
+        visible_contributing, 0,
+        "every family here is hidden structural-only, so none may count as a \
+         visible contributing cluster: {report:#}"
+    );
+    let duplicated_loc = report
+        .pointer("/metrics/duplicated_loc")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        duplicated_loc, 0,
+        "structural-only sibling families must add zero duplicated lines: {report:#}"
+    );
+    let duplication_percent = report
+        .pointer("/metrics/duplication_percent")
+        .and_then(Value::as_f64)
+        .unwrap_or(-1.0);
     assert!(
-        total_clusters >= 1,
-        "fixture must produce at least one cluster (visible or hidden) so the \
-         single-file structural_only demotion is actually exercised: {report:#}"
+        (0.0..=0.0001).contains(&duplication_percent),
+        "duplication_percent must be 0 when every cluster is hidden — the metric \
+         is not influenced by structural-only shape matches: got {duplication_percent}"
     );
 
     let clusters = report

--- a/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
+++ b/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
@@ -58,15 +58,37 @@ fn issue_134_structural_only_clusters_are_not_nearly_identical() -> Result<()> {
     let tmp = tempfile::tempdir()?;
     let scan_root = fixture("csharp-issue-134-structural-only");
     let report = run_report(tmp.path(), &scan_root)?;
-    let total_clusters = report
-        .get("metrics")
-        .and_then(|metrics| metrics.get("clusters_total"))
+    // [METRICS-REPO] `clusters_total` counts only the clusters the report
+    // renders. This fixture's sole family is a hidden structural-only
+    // cluster, so it contributes zero to the metric while still being
+    // detected (`clusters_hidden`) — a structural-only shape match cannot
+    // inflate the percentage.
+    let visible_contributing = report
+        .pointer("/metrics/clusters_total")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        visible_contributing, 0,
+        "hidden structural-only cluster must not count as a visible \
+         contributing cluster: {report}"
+    );
+    let clusters_hidden = report
+        .get("clusters_hidden")
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(0);
     assert!(
-        total_clusters >= 1,
-        "fixture must produce at least one cluster (visible or hidden) so \
+        clusters_hidden >= 1,
+        "fixture must produce at least one hidden structural-only cluster so \
          the bucketing rule is actually exercised: {report}"
+    );
+    let duplication_percent = report
+        .pointer("/metrics/duplication_percent")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(-1.0);
+    assert!(
+        (0.0..=0.0001).contains(&duplication_percent),
+        "structural-only shape matches must not influence duplication_percent: \
+         got {duplication_percent}"
     );
     let clusters = report
         .get("clusters")

--- a/crates/deslop/tests/metric_excludes_hidden_clusters.rs
+++ b/crates/deslop/tests/metric_excludes_hidden_clusters.rs
@@ -1,0 +1,70 @@
+//! E2E regression for [METRICS-REPO]: the duplication metric counts only
+//! the clusters the *visible* report carries.
+//!
+//! A cluster dropped as noise / structural-only sibling boilerplate — here
+//! the kwargs-constructor family in `python-issue-100-kwargs-ctor`, hidden
+//! via [CLONE-NOISE-PY-KWARGS-CTOR] — must not inflate per-file or repo
+//! `duplicated_loc`. Before the fix `compute_repo_metrics` ran over the raw
+//! pre-filter cluster set, so a file whose only match was a hidden cluster
+//! reported phantom duplication (the kwargs fixture showed 56%, the repo's
+//! own test files showed 100%) even though `report-for-file` carried no
+//! cluster for it at all.
+
+mod common;
+
+use crate::common::*;
+
+#[test]
+fn duplication_metric_excludes_hidden_clusters() -> Result<()> {
+    let scan_root = fixture("python-issue-100-kwargs-ctor");
+    let report = run_report(&scan_root, 4)?;
+
+    let visible = visible_duplicated_lines(&report);
+
+    // Per file: `duplicated_loc` must equal the lines the *visible* clusters
+    // cover — never a line that exists only inside a hidden cluster.
+    for metric in per_file_metrics(&report) {
+        let path = field(metric, "path").as_str().unwrap_or_default();
+        let expected = visible
+            .iter()
+            .find(|(occurrence_path, _)| path.ends_with(occurrence_path.as_str()))
+            .map_or(0, |(_, lines)| line_count(lines));
+        let reported = field(metric, "duplicated_loc").as_u64().unwrap_or(u64::MAX);
+        assert_eq!(
+            reported, expected,
+            "{path}: metric reports {reported} duplicated lines but the visible \
+             clusters cover {expected} — hidden clusters must not be counted"
+        );
+    }
+
+    // Repo headline: `duplicated_loc` is the union size across visible clusters.
+    let expected_total = visible_duplicated_loc(&report);
+    let reported_total = metric_field(&report, "duplicated_loc")
+        .as_u64()
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        reported_total, expected_total,
+        "repo duplicated_loc {reported_total} must equal the {expected_total} lines \
+         covered by visible clusters"
+    );
+
+    // `clusters_total` counts only visible clusters with at least two live
+    // (non-hidden) occurrences.
+    let expected_clusters = u64::try_from(
+        clusters(&report)
+            .iter()
+            .filter(|cluster| live_occurrences(cluster) >= 2)
+            .count(),
+    )
+    .unwrap_or(u64::MAX);
+    let reported_clusters = metric_field(&report, "clusters_total")
+        .as_u64()
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        reported_clusters, expected_clusters,
+        "clusters_total {reported_clusters} must match the {expected_clusters} visible \
+         contributing clusters"
+    );
+
+    Ok(())
+}

--- a/crates/deslop/tests/metric_language_agnostic.rs
+++ b/crates/deslop/tests/metric_language_agnostic.rs
@@ -1,0 +1,113 @@
+//! E2E proof for [METRICS-REPO] that the duplication metric is computed by
+//! one language-agnostic code path. `compute_repo_metrics` projects clone
+//! occurrences onto physical-line sets with no per-language branch, so the
+//! same logical input must yield the same percentage in every language.
+//!
+//! Two byte-identical source files are a fully-duplicated repo. For C#,
+//! Rust, Python, and Dart this asserts the metric reports exactly 100% — the
+//! same reasonable value across all four — and that the repo `duplicated_loc`
+//! equals the lines the visible clusters cover, so a hidden / structural-only
+//! match could never inflate it.
+
+mod common;
+
+use serde_json::Value;
+
+use crate::common::*;
+
+/// One language's minimal fully-duplicated corpus: a file extension and a
+/// source body written byte-identically into `a.<ext>` and `b.<ext>`.
+struct LangCase {
+    language: &'static str,
+    extension: &'static str,
+    source: &'static str,
+}
+
+const CASES: &[LangCase] = &[
+    LangCase {
+        language: "csharp",
+        extension: "cs",
+        source: "class Calc {\n    int Combine(int a, int b) {\n        int x = a + b;\n        int y = x * a;\n        return y - b + x;\n    }\n}\n",
+    },
+    LangCase {
+        language: "rust",
+        extension: "rs",
+        source: "fn combine(a: i32, b: i32) -> i32 {\n    let x = a + b;\n    let y = x * a;\n    y - b + x\n}\n",
+    },
+    LangCase {
+        language: "python",
+        extension: "py",
+        source: "def combine(a, b):\n    x = a + b\n    y = x * a\n    return y - b + x\n",
+    },
+    LangCase {
+        language: "dart",
+        extension: "dart",
+        source: "int combine(int a, int b) {\n  var x = a + b;\n  var y = x * a;\n  return y - b + x;\n}\n",
+    },
+];
+
+#[test]
+fn duplication_metric_is_language_agnostic() -> Result<()> {
+    let mut percentages = Vec::new();
+    for case in CASES {
+        let tmp = tempfile::tempdir()?;
+        let scan_root = tmp.path().join(case.language);
+        write_identical_pair(&scan_root, case.extension, case.source)?;
+        let report = run_report(&scan_root, 8)?;
+        assert_fully_duplicated(&report, case.language);
+        percentages.push(
+            metric_field(&report, "duplication_percent")
+                .as_f64()
+                .unwrap_or(-1.0),
+        );
+    }
+
+    // The same logical input yields the same percentage in every language —
+    // there is one calc, not four.
+    let baseline = percentages.first().copied().unwrap_or(-1.0);
+    for (case, percent) in CASES.iter().zip(&percentages) {
+        assert!(
+            (percent - baseline).abs() < 0.0001,
+            "{}: every language must derive the same percentage from identical \
+             input (baseline {baseline}), got {percent}",
+            case.language
+        );
+    }
+    Ok(())
+}
+
+/// Asserts a two-identical-file repo reports a fully-duplicated metric: every
+/// analysed line is duplicated, the percentage is exactly 100, the clone is
+/// real (not hidden noise), and the repo `duplicated_loc` equals the lines
+/// the visible clusters cover.
+fn assert_fully_duplicated(report: &Value, language: &str) {
+    let analysed = metric_field(report, "analysed_loc").as_u64().unwrap_or(0);
+    let duplicated = metric_field(report, "duplicated_loc").as_u64().unwrap_or(0);
+    let percent = metric_field(report, "duplication_percent")
+        .as_f64()
+        .unwrap_or(-1.0);
+    let hidden = field(report, "clusters_hidden")
+        .as_u64()
+        .unwrap_or(u64::MAX);
+    assert!(
+        analysed > 0,
+        "{language}: fixture must analyse at least one line: {report:#}"
+    );
+    assert_eq!(
+        duplicated, analysed,
+        "{language}: every line of an identical pair is duplicated: {report:#}"
+    );
+    assert!(
+        (percent - 100.0).abs() < 0.0001,
+        "{language}: identical files must report 100% duplication, got {percent}: {report:#}"
+    );
+    assert_eq!(
+        hidden, 0,
+        "{language}: an exact identical clone is real duplication, not hidden noise: {report:#}"
+    );
+    assert_eq!(
+        duplicated,
+        visible_duplicated_loc(report),
+        "{language}: metric must equal the visible-cluster line union: {report:#}"
+    );
+}

--- a/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
+++ b/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
@@ -84,6 +84,19 @@ fn structural_only_signature_clusters_are_dropped_from_the_report() -> Result<()
          have no real evidence and must not appear in the ranked report. \
          Offending clusters: {offenders:#?}"
     );
+    // [METRICS-REPO] This fixture mixes visible near-miss clones with hidden
+    // structural_only families. The metric must count only the lines the
+    // visible clusters cover, so the suppressed families add nothing.
+    let reported = report
+        .pointer("/metrics/duplicated_loc")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::MAX);
+    assert_eq!(
+        reported,
+        visible_duplicated_loc(&report),
+        "duplicated_loc must equal the visible-cluster line union — hidden \
+         structural_only families must not inflate the metric: {report:#}"
+    );
     let hidden = report
         .get("clusters_hidden")
         .and_then(Value::as_u64)


### PR DESCRIPTION
<!-- agent-pmo:b636503 -->
## TLDR
The repo-wide duplication metric ([METRICS-REPO]) now counts only the clusters the rendered report actually carries, so a file matched solely by a hidden noise / structural-only cluster no longer shows phantom duplication — the self-scan headline drops from an inflated 20.0% to an honest 11.94%.

## Details
**The bug.** `render_report` (`crates/deslop-core/src/report.rs`) builds the visible cluster set by running `materialise_cluster` over `inputs.clusters` and dropping every cluster that is report-hidden, noise, or a structural-only sibling-boilerplate family. But it then called `compute_repo_metrics` with the **raw, pre-filter** `inputs.clusters`. So the metric counted duplicated lines from clusters the report itself drops. The result: a file whose only match was a hidden "Same shape, different content" cluster reported 100% duplication in the Duplication tree even though `report-for-file` returned no cluster for it, and the repo headline read 20.0%. This directly violated the `report_metrics` module contract: *"computed deterministically from the same cluster set the rendered Report carries."*

**The fix.**
- `crates/deslop-core/src/report.rs` — `render_report` now derives `visible_internal: Vec<&Cluster>` by zipping `inputs.clusters` with the `materialised` hidden flags (positionally aligned, since `materialised` was mapped over `inputs.clusters` in order) and keeping only the survivors. `compute_repo_metrics` is fed that visible set.
- `crates/deslop-core/src/report_metrics.rs` — `MetricsInputs.clusters` becomes `&'a [&'a Cluster]` so the metric and the report share one cluster set without cloning; the fold loop binds `for &cluster in inputs.clusters`. Per-occurrence `report_hide` exclusion is unchanged.

**Behaviour change (not a wire/API break).** The `RepoMetrics` wire shape is unchanged. Values change: `duplication_percent`, `duplicated_loc`, `duplicated_files`, and `clusters_total` now describe only visible duplication. In particular `clusters_total` counts visible contributing clusters (hidden ones are reported separately via the existing `clusters_hidden`). Self-scan: 20.0% → 11.94% (6343 / 53122 LOC). The CLI duplication gate (`.deslop.toml` `max_duplication_percent = 20`) still passes with more headroom.

**Language-agnostic by construction.** `report_metrics.rs` has no per-language branch; it projects clone occurrences onto physical-line sets and counts newlines. The only language touch is the existing `report_hide` / generated-header exclusion, identical for every language.

No new dependencies. No public CLI flag or spec ID changed.

## How Do The Automated Tests Prove It Works?
All black-box E2E against fixture repos, asserting on the rendered JSON report:

- **`metric_excludes_hidden_clusters.rs`** (new) — runs the `python-issue-100-kwargs-ctor` fixture (a kwargs-constructor family that is correctly hidden via `[CLONE-NOISE-PY-KWARGS-CTOR]`). Asserts each file's `duplicated_loc` equals the line union of the report's **visible** clusters (5 lines, not the pre-fix 13), the repo `duplicated_loc` equals that union, and `clusters_total` equals the count of visible clusters with ≥2 live occurrences. This is the exact regression: before the fix it reported 13/56.5% from the dropped cluster.
- **`metric_language_agnostic.rs`** (new) — writes two byte-identical source files for **C#, Rust, Python, and Dart** and asserts each reports exactly 100.0% duplication, `duplicated_loc == analysed_loc`, `clusters_hidden == 0`, and `duplicated_loc == visible-cluster line union`. A final cross-language check asserts every language derives the identical percentage from identical input — proving one calc, not four, and a reasonable value.
- **`issue_134_structural_only_not_nearly_identical.rs`** / **`dart_issue_197_single_file_structural_only.rs`** — strengthened: now assert that a fixture whose only family is a hidden structural-only cluster reports `clusters_total == 0`, `duplicated_loc == 0`, and `duplication_percent == 0` (while `clusters_hidden >= 1`), i.e. a structural-only shape match cannot inflate the percentage. (The pre-fix `clusters_total >= 1` guard, which relied on hidden clusters counting, was replaced by stronger assertions plus the existing `clusters_hidden` check.)
- **`rust_issue_154_structural_only_signatures.rs`** — strengthened to assert `duplicated_loc` equals the visible-cluster line union, proving its two hidden structural-only families do not inflate the metric while its six visible near-miss clones still count.

The shared report-introspection helpers (`visible_duplicated_lines`, `visible_duplicated_loc`, `live_occurrences`, `metric_field`, `per_file_metrics`, `write_identical_pair`) live once in `crates/deslop/tests/common/mod.rs` and are reused by all of the above — no copied assertion logic.

`make test` passes with coverage above threshold for every crate (deslop-core 94.4%, deslop 97.1%, deslop-lsp 95.0%, deslop-mcp 97.1%; workspace 94.8%).
