### PR TITLE
Consolidate duplicate test helpers and JSON-RPC dispatch param extraction

### DIFF
--- a/crates/deslop-lsp/src/ipc/dispatch.rs
+++ b/crates/deslop-lsp/src/ipc/dispatch.rs
@@ -42,10 +42,7 @@ fn dispatch_report_for_file(
     service: &Arc<LiveService>,
     handle: &Handle,
 ) -> Result<Value, Value> {
-    let path = params
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| json!({"code": -32602, "message": "missing path"}))?;
+    let path = required_str_param(params, "path")?;
     let file_report = handle.block_on(service.report_for_file(Path::new(path)));
     serde_json::to_value(&file_report).map_err(|err| rpc_serialise_error(&err))
 }
@@ -56,18 +53,9 @@ fn dispatch_report_for_range(
     service: &Arc<LiveService>,
     handle: &Handle,
 ) -> Result<Value, Value> {
-    let path = params
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| json!({"code": -32602, "message": "missing path"}))?;
-    let start_byte = params
-        .get("start_byte")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| json!({"code": -32602, "message": "missing start_byte"}))?;
-    let end_byte = params
-        .get("end_byte")
-        .and_then(Value::as_u64)
-        .ok_or_else(|| json!({"code": -32602, "message": "missing end_byte"}))?;
+    let path = required_str_param(params, "path")?;
+    let start_byte = required_u64_param(params, "start_byte")?;
+    let end_byte = required_u64_param(params, "end_byte")?;
     let start = usize::try_from(start_byte)
         .map_err(|_| json!({"code": -32602, "message": "start_byte overflow"}))?;
     let end = usize::try_from(end_byte)
@@ -82,10 +70,7 @@ fn dispatch_cluster_by_id(
     service: &Arc<LiveService>,
     handle: &Handle,
 ) -> Result<Value, Value> {
-    let id = params
-        .get("id")
-        .and_then(Value::as_str)
-        .ok_or_else(|| json!({"code": -32602, "message": "missing id"}))?;
+    let id = required_str_param(params, "id")?;
     let cluster = handle
         .block_on(service.cluster_by_id(id))
         .map_err(|err| json!({"code": -32603, "message": err.to_string()}))?;
@@ -143,6 +128,27 @@ fn dispatch_refresh_report(service: &Arc<LiveService>, handle: &Handle) -> Resul
             "clustersUpdated": delta.clusters_updated.len(),
         }))
     })
+}
+
+/// Builds the JSON-RPC `-32602` (invalid params) error for a missing field.
+fn missing_param_error(key: &str) -> Value {
+    json!({"code": -32602, "message": format!("missing {key}")})
+}
+
+/// Reads a required string parameter `key`, or the standard `-32602` error.
+fn required_str_param<'a>(params: &'a Value, key: &str) -> Result<&'a str, Value> {
+    params
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| missing_param_error(key))
+}
+
+/// Reads a required `u64` parameter `key`, or the standard `-32602` error.
+fn required_u64_param(params: &Value, key: &str) -> Result<u64, Value> {
+    params
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| missing_param_error(key))
 }
 
 /// Maps a serialisation failure to a JSON-RPC internal-error envelope.

--- a/crates/deslop-mcp/tests/cli.rs
+++ b/crates/deslop-mcp/tests/cli.rs
@@ -24,7 +24,7 @@ use serde_json::{json, Value};
 use tempfile::TempDir;
 
 mod common;
-use common::{fixture_root, value_get};
+use common::{fixture_root, value_array, value_get};
 #[cfg(unix)]
 use common::{pid_exists, read_mcp_pid, terminate_pid, wait_for_pid_exit, KILLABLE_PARENT_SCRIPT};
 
@@ -1246,10 +1246,7 @@ fn report_get_clusters_are_slim_summaries_only() -> Result<()> {
 fn report_get_first_occurrence_belongs_to_full_cluster() -> Result<()> {
     let (mut child, page) =
         init_and_tool_payload("report-get", &json!({ "offset": 0, "limit": 10 }))?;
-    let clusters = value_get(&page, "/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters not array"))?;
+    let clusters = value_array(&page, "/clusters")?;
     assert!(!clusters.is_empty(), "fixture should produce >= 1 cluster");
     for summary in &clusters {
         assert_first_occurrence_matches_full_cluster(&mut child, summary)?;
@@ -1266,10 +1263,7 @@ fn assert_first_occurrence_matches_full_cluster(
     let first = value_get(summary, "/first_occurrence")?;
     let cluster =
         structured_tool_result(&call_tool(child, "cluster-by-id", &json!({ "id": id }))?)?;
-    let occurrences = value_get(&cluster, "/occurrences")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("occurrences not array"))?;
+    let occurrences = value_array(&cluster, "/occurrences")?;
     assert!(
         occurrences.iter().any(|occ| same_occurrence(occ, &first)),
         "first_occurrence must be present in cluster-by-id occurrences: {summary}"
@@ -1402,10 +1396,7 @@ fn report_query_filters_by_path_contains() -> Result<()> {
         "report-query",
         &json!({ "offset": 0, "limit": 50, "path_contains": "Alpha" }),
     )?;
-    let array = value_get(&page, "/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters not array"))?;
+    let array = value_array(&page, "/clusters")?;
     assert!(
         !array.is_empty(),
         "Alpha.cs participates in the planted clone family"
@@ -1561,10 +1552,7 @@ fn report_query_filters_by_matching_bucket_includes_clusters() -> Result<()> {
         "report-query",
         &json!({ "offset": 0, "limit": 50, "bucket": "nearly_identical" }),
     )?;
-    let clusters = value_get(&page, "/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters not array"))?;
+    let clusters = value_array(&page, "/clusters")?;
     assert!(
         !clusters.is_empty(),
         "fixture has at least one nearly-identical cluster"
@@ -1708,10 +1696,7 @@ fn find_similar_range_finds_clone_on_alpha() -> Result<()> {
             }
         }),
     )?;
-    let clusters = value_get(&response, "/result/structuredContent/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters must be an array: {response}"))?;
+    let clusters = value_array(&response, "/result/structuredContent/clusters")?;
     assert!(
         !clusters.is_empty(),
         "find-similar on Alpha.cs must return at least the Beta sibling cluster: {response}",
@@ -1758,10 +1743,7 @@ fn list_embedding_models_excludes_stub_when_ollama_unreachable() -> Result<()> {
     // listing must come back empty — the deterministic stub is test
     // infrastructure and never appears in production payloads.
     let (child, response) = init_and_tool_response("list-embedding-models", &json!({}))?;
-    let models = value_get(&response, "/result/structuredContent/models")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("models must be an array: {response}"))?;
+    let models = value_array(&response, "/result/structuredContent/models")?;
     let has_stub = models
         .iter()
         .any(|model| model.get("provider_id") == Some(&json!("stub")));
@@ -2113,10 +2095,7 @@ fn find_similar_with_top_n_zero_falls_back_to_default() -> Result<()> {
             "arguments": { "path": "Alpha.cs", "start_byte": 0, "end_byte": source.len(), "top_n": 0 }
         }),
     )?;
-    let clusters = value_get(&response, "/result/structuredContent/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters must be an array: {response}"))?;
+    let clusters = value_array(&response, "/result/structuredContent/clusters")?;
     assert!(
         !clusters.is_empty(),
         "find-similar with top_n=0 must fall back to default and return clusters: {response}",
@@ -2144,10 +2123,7 @@ fn find_similar_snippet_with_empty_source_returns_empty_result() -> Result<()> {
         Some(true),
         "empty snippet must report below_min_nodes=true: {response}"
     );
-    let clusters = value_get(&response, "/result/structuredContent/clusters")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("clusters must be array: {response}"))?;
+    let clusters = value_array(&response, "/result/structuredContent/clusters")?;
     assert!(
         clusters.is_empty(),
         "empty snippet must return no clusters: {response}"
@@ -2643,10 +2619,7 @@ fn list_embedding_models_response_omits_legacy_keys_and_stub() -> Result<()> {
         "tools/call",
         &json!({ "name": "list-embedding-models", "arguments": {} }),
     )?;
-    let models = value_get(&response, "/result/structuredContent/models")?
-        .as_array()
-        .cloned()
-        .ok_or_else(|| anyhow!("models must be an array: {response}"))?;
+    let models = value_array(&response, "/result/structuredContent/models")?;
     let has_stub = models
         .iter()
         .any(|model| model.get("provider_id") == Some(&json!("stub")));

--- a/crates/deslop-mcp/tests/common/mod.rs
+++ b/crates/deslop-mcp/tests/common/mod.rs
@@ -256,6 +256,18 @@ impl Drop for ChildKillOnDrop {
     }
 }
 
+/// Workspace-relative path of the live-report state file the LSP publishes.
+pub const LIVE_REPORT_STATE_FILE: &str = ".deslop-cache/live-report.json";
+
+/// Waits for the LSP to publish its live-report state file under `workspace`,
+/// then returns an initialized MCP handle — the standard preamble shared by
+/// every MCP-over-live-LSP test.
+pub fn wait_for_state_then_init_mcp(workspace: &Path) -> Result<McpHandle> {
+    let state_file = workspace.join(LIVE_REPORT_STATE_FILE);
+    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
+    initialized_mcp(workspace)
+}
+
 /// Spawns + initializes an MCP child against `root`.
 pub fn initialized_mcp(root: &Path) -> Result<McpHandle> {
     let mut mcp = McpHandle::spawn(root)?;
@@ -331,6 +343,15 @@ pub fn value_get(value: &Value, pointer: &str) -> Result<Value> {
         .pointer(pointer)
         .cloned()
         .ok_or_else(|| anyhow!("pointer {pointer} not found in {value}"))
+}
+
+/// Resolves a JSON pointer in `value` and clones the array it points at,
+/// erroring when the pointer is absent or does not name an array.
+pub fn value_array(value: &Value, pointer: &str) -> Result<Vec<Value>> {
+    value_get(value, pointer)?
+        .as_array()
+        .cloned()
+        .ok_or_else(|| anyhow!("pointer {pointer} is not an array in {value}"))
 }
 
 /// Extracts the `/error` frame and its string `message` from a JSON-RPC

--- a/crates/deslop-mcp/tests/issue_135_rescan_generation.rs
+++ b/crates/deslop-mcp/tests/issue_135_rescan_generation.rs
@@ -8,13 +8,13 @@
 
 #![cfg(unix)]
 
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{anyhow, ensure, Result};
 use serde_json::{json, Value};
 
 mod common;
 use common::{
-    copied_fixture, initialized_mcp, spawn_lsp_and_wait_for_socket, structured_content,
-    wait_for_path, McpHandle, SOCKET_TIMEOUT,
+    copied_fixture, spawn_lsp_and_wait_for_socket, structured_content,
+    wait_for_state_then_init_mcp, McpHandle,
 };
 
 /// Issue #135: `rescan`, `session-config`, and `report-get` must all
@@ -25,10 +25,7 @@ fn issue_135_rescan_generation_matches_report_get_and_session_config() -> Result
     let beta = workspace.path().join("Beta.cs");
     let _lsp_guard = spawn_lsp_and_wait_for_socket(workspace.path())?;
 
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
 
     // Edit Beta.cs so the LSP must do at least one re-analysis when
     // rescan asks it to refresh. This bumps the LSP-internal generation

--- a/crates/deslop-mcp/tests/issue_153_rescan_freshness.rs
+++ b/crates/deslop-mcp/tests/issue_153_rescan_freshness.rs
@@ -16,9 +16,7 @@ use anyhow::{anyhow, ensure, Context, Result};
 use serde_json::Value;
 
 mod common;
-use common::{
-    initialized_mcp, lsp_workspace_with_socket, rescan_call, wait_for_path, SOCKET_TIMEOUT,
-};
+use common::{lsp_workspace_with_socket, rescan_call, wait_for_state_then_init_mcp};
 
 /// One unique C# file body that shares no normalised subtrees with
 /// the rest of the corpus, so writing it eliminates any cluster the
@@ -36,10 +34,7 @@ fn unique_body(seed: u32) -> String {
 #[test]
 fn issue_153_single_rescan_reflects_post_edit_state() -> Result<()> {
     let (workspace, _lsp_guard, _socket) = lsp_workspace_with_socket()?;
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
 
     // Baseline must have at least one cluster — otherwise the test
     // cannot prove the rescan is doing real work.
@@ -90,10 +85,7 @@ fn issue_153_single_rescan_reflects_post_edit_state() -> Result<()> {
 #[test]
 fn issue_153_rescan_occurrence_offsets_reflect_post_edit_file() -> Result<()> {
     let (workspace, _lsp_guard, _socket) = lsp_workspace_with_socket()?;
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
 
     // Insert a long leading comment block into Alpha.cs so the
     // surviving Alpha occurrence shifts down by many bytes. The

--- a/crates/deslop-mcp/tests/issue_156_cluster_id_stale_offsets.rs
+++ b/crates/deslop-mcp/tests/issue_156_cluster_id_stale_offsets.rs
@@ -17,10 +17,7 @@ use anyhow::{anyhow, ensure, Context, Result};
 use serde_json::{json, Value};
 
 mod common;
-use common::{
-    call_tool, initialized_mcp, lsp_workspace_with_socket, rescan_call, wait_for_path,
-    SOCKET_TIMEOUT,
-};
+use common::{call_tool, lsp_workspace_with_socket, rescan_call, wait_for_state_then_init_mcp};
 
 /// Issue #156: after rescanning, the cluster payload returned by
 /// `cluster-by-id` must contain occurrence byte ranges that map onto
@@ -29,10 +26,7 @@ use common::{
 #[test]
 fn issue_156_cluster_by_id_returns_post_edit_offsets() -> Result<()> {
     let (workspace, _lsp_guard, _socket) = lsp_workspace_with_socket()?;
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
 
     // Force a refresh first so the baseline is deterministic.
     let baseline = rescan_call(&mut mcp, &[])?;

--- a/crates/deslop-mcp/tests/lsp_integration.rs
+++ b/crates/deslop-mcp/tests/lsp_integration.rs
@@ -15,13 +15,13 @@
 
 use std::fs;
 
-use anyhow::{anyhow, ensure, Context, Result};
+use anyhow::{anyhow, ensure, Result};
 use serde_json::{json, Value};
 
 mod common;
 use common::{
     copied_fixture, initialized_mcp, lsp_workspace_with_socket, spawn_lsp_and_wait_for_socket,
-    structured_content, wait_for_path, McpHandle, SOCKET_TIMEOUT,
+    structured_content, wait_for_state_then_init_mcp, McpHandle,
 };
 
 /// [MCP-IPC-CLIENT] When the LSP is running, MCP must delegate
@@ -31,10 +31,7 @@ use common::{
 #[test]
 fn find_similar_via_mcp_delegates_to_running_lsp() -> Result<()> {
     let (workspace, _lsp_guard, _socket) = lsp_workspace_with_socket()?;
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
 
     let response = mcp.request(
         "tools/call",
@@ -200,10 +197,7 @@ fn issue_135_rescan_generation_matches_report_get_and_session_config() -> Result
     let beta = workspace.path().join("Beta.cs");
     let _lsp_guard = spawn_lsp_and_wait_for_socket(workspace.path())?;
 
-    let state_file = workspace.path().join(".deslop-cache/live-report.json");
-    wait_for_path(&state_file, SOCKET_TIMEOUT).context("wait for state file")?;
-
-    let mut mcp = initialized_mcp(workspace.path())?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
     fs::write(
         &beta,
         b"namespace Solo { class Only { public int Go() => 1; } }\n",

--- a/crates/deslop/tests/cli/embedding_ollama.rs
+++ b/crates/deslop/tests/cli/embedding_ollama.rs
@@ -92,10 +92,11 @@ fn ollama_type4_cross_file_cluster_has_positive_embedding_signal() -> Result<()>
         ],
     )?;
     let json = load_report_json(&out.json)?;
-    let provenance = json
-        .get("embedding_provenance")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| anyhow::anyhow!("embedding_provenance missing or not an object"))?;
+    let provenance = object_field(
+        &json,
+        "embedding_provenance",
+        "embedding_provenance missing or not an object",
+    )?;
     assert_eq!(
         provenance.get("provider_id").and_then(|v| v.as_str()),
         Some("ollama"),
@@ -125,10 +126,7 @@ fn ollama_type4_cross_file_cluster_has_positive_embedding_signal() -> Result<()>
         find_cross_file_cluster(&json, &["Recursive.cs", "Iterative.cs"]).ok_or_else(|| {
             anyhow::anyhow!("no cross-file cluster spanning Recursive.cs + Iterative.cs")
         })?;
-    let signals = cluster
-        .get("signals")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| anyhow::anyhow!("cluster missing signals object"))?;
+    let signals = object_field(&cluster, "signals", "cluster missing signals object")?;
     let embedding_cos = signals
         .get("embedding_cos")
         .and_then(serde_json::Value::as_f64)
@@ -187,12 +185,11 @@ fn ollama_auto_mode_populates_provenance_when_reachable() -> Result<()> {
         ],
     )?;
     let json = load_report_json(&out.json)?;
-    let provenance = json
-        .get("embedding_provenance")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| {
-            anyhow::anyhow!("auto mode with reachable Ollama must populate provenance")
-        })?;
+    let provenance = object_field(
+        &json,
+        "embedding_provenance",
+        "auto mode with reachable Ollama must populate provenance",
+    )?;
     assert_eq!(
         provenance.get("provider_id").and_then(|v| v.as_str()),
         Some("ollama"),
@@ -270,10 +267,7 @@ fn ollama_embedding_cache_persists_across_runs() -> Result<()> {
     );
 
     let json = load_report_json(&tmp.path().join("second.json"))?;
-    let provenance = json
-        .get("embedding_provenance")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| anyhow::anyhow!("second run lost provenance"))?;
+    let provenance = object_field(&json, "embedding_provenance", "second run lost provenance")?;
     assert_eq!(
         provenance.get("model_id").and_then(|v| v.as_str()),
         Some("nomic-embed-text"),
@@ -340,10 +334,7 @@ fn ollama_incremental_plus_embeddings_second_run_hits_both_caches() -> Result<()
     )?;
 
     let first_json = load_report_json(&tmp.path().join("first.json"))?;
-    let first_stats = first_json
-        .get("cache_stats")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| anyhow::anyhow!("first run missing cache_stats"))?;
+    let first_stats = object_field(&first_json, "cache_stats", "first run missing cache_stats")?;
     assert_eq!(
         first_stats.get("hits").and_then(serde_json::Value::as_u64),
         Some(0),
@@ -371,10 +362,11 @@ fn ollama_incremental_plus_embeddings_second_run_hits_both_caches() -> Result<()
         ],
     )?;
     let second_json = load_report_json(&tmp.path().join("second.json"))?;
-    let second_stats = second_json
-        .get("cache_stats")
-        .and_then(|v| v.as_object())
-        .ok_or_else(|| anyhow::anyhow!("second run missing cache_stats"))?;
+    let second_stats = object_field(
+        &second_json,
+        "cache_stats",
+        "second run missing cache_stats",
+    )?;
     assert_eq!(
         second_stats.get("hits").and_then(serde_json::Value::as_u64),
         Some(2),

--- a/crates/deslop/tests/cli/support.rs
+++ b/crates/deslop/tests/cli/support.rs
@@ -127,6 +127,21 @@ pub(crate) fn read_json_report(path: &Path) -> Result<serde_json::Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
+/// The JSON object at `key` in `value`, erroring with `context` when the key
+/// is absent or its value is not an object. Centralises the
+/// `get(key).and_then(as_object).ok_or_else(...)` idiom while preserving each
+/// call site's bespoke error message.
+pub(crate) fn object_field<'a>(
+    value: &'a Value,
+    key: &str,
+    context: &str,
+) -> Result<&'a serde_json::Map<String, Value>> {
+    value
+        .get(key)
+        .and_then(Value::as_object)
+        .ok_or_else(|| anyhow::anyhow!("{context}"))
+}
+
 /// Looks up a named field on `value`; returns `Value::Null` when the
 /// field is absent so callers get a deterministic `!=` instead of a
 /// panic ([TESTS-NO-INDEXING]).

--- a/crates/deslop/tests/common/mod.rs
+++ b/crates/deslop/tests/common/mod.rs
@@ -108,13 +108,81 @@ pub(crate) fn occurrences(cluster: &Value) -> &[Value] {
         .unwrap_or_default()
 }
 
+/// A cluster's `bucket` label (e.g. `identical`), or `"?"` when absent.
+pub(crate) fn cluster_bucket(cluster: &Value) -> &str {
+    field(cluster, "bucket").as_str().unwrap_or("?")
+}
+
+/// A cluster's stable `id`, or `"?"` when absent.
+pub(crate) fn cluster_id(cluster: &Value) -> &str {
+    field(cluster, "id").as_str().unwrap_or("?")
+}
+
+/// A cluster's `size` (its occurrence count), or `0` when absent.
+pub(crate) fn cluster_size(cluster: &Value) -> u64 {
+    field(cluster, "size").as_u64().unwrap_or(0)
+}
+
+/// One component of a cluster's fused `signals` block (e.g. `token_jaccard`),
+/// or `0.0` when the named signal is absent.
+pub(crate) fn signal(cluster: &Value, key: &str) -> f64 {
+    cluster
+        .pointer(&format!("/signals/{key}"))
+        .and_then(Value::as_f64)
+        .unwrap_or_default()
+}
+
+/// Number of clusters the report rendered — the [METRICS-REPO] visible set.
+pub(crate) fn cluster_count(report: &Value) -> usize {
+    array_len(report, "clusters")
+}
+
+/// The report's `clusters_hidden` count (suppressed-cluster telemetry), or
+/// `0` when absent.
+pub(crate) fn clusters_hidden(report: &Value) -> u64 {
+    field(report, "clusters_hidden").as_u64().unwrap_or(0)
+}
+
+/// The relative path of a single occurrence, erroring when absent.
+pub(crate) fn occurrence_path(occurrence: &Value) -> Result<&str> {
+    field(occurrence, "path")
+        .as_str()
+        .ok_or_else(|| anyhow!("reported occurrence is missing path"))
+}
+
+/// The relative paths of every occurrence in `cluster`, in report order.
+pub(crate) fn occurrence_paths(cluster: &Value) -> Vec<String> {
+    occurrences(cluster)
+        .iter()
+        .filter_map(|occurrence| field(occurrence, "path").as_str().map(ToOwned::to_owned))
+        .collect()
+}
+
+/// The bare file names (no directory) of every occurrence in `cluster`.
+pub(crate) fn occurrence_files(cluster: &Value) -> Vec<String> {
+    occurrences(cluster)
+        .iter()
+        .filter_map(|occurrence| {
+            field(occurrence, "path")
+                .as_str()
+                .and_then(|path| Path::new(path).file_name())
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .collect()
+}
+
+/// The source slice each occurrence in `cluster` points at, in report order.
+pub(crate) fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
+    occurrences(cluster)
+        .iter()
+        .map(|occurrence| occurrence_text(scan_root, occurrence))
+        .collect()
+}
+
 /// Reads the source slice an occurrence points at, resolving its `path`
 /// relative to `scan_root` and slicing `[start_byte, end_byte)`.
 pub(crate) fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
-    let path = occurrence
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("reported occurrence is missing path"))?;
+    let path = occurrence_path(occurrence)?;
     let source = fs::read_to_string(scan_root.join(path))?;
     let start = occurrence_byte(occurrence, "start_byte")?;
     let end = occurrence_byte(occurrence, "end_byte")?;

--- a/crates/deslop/tests/cross_cluster_collapse.rs
+++ b/crates/deslop/tests/cross_cluster_collapse.rs
@@ -62,14 +62,6 @@ fn cluster_occurrences(cluster: &serde_json::Value) -> Vec<Occurrence> {
         .unwrap_or_default()
 }
 
-fn cluster_id(cluster: &serde_json::Value) -> String {
-    cluster
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("?")
-        .to_owned()
-}
-
 fn ranges_overlap(left: &Occurrence, right: &Occurrence) -> bool {
     left.path == right.path && left.start < right.end && right.start < left.end
 }
@@ -85,7 +77,7 @@ fn first_subsumed_pair(report: &serde_json::Value) -> Option<String> {
     let clusters = report.get("clusters")?.as_array()?;
     let occurrence_sets: Vec<(String, Vec<Occurrence>)> = clusters
         .iter()
-        .map(|cluster| (cluster_id(cluster), cluster_occurrences(cluster)))
+        .map(|cluster| (cluster_id(cluster).to_owned(), cluster_occurrences(cluster)))
         .collect();
     for (outer_index, (outer_id, outer)) in occurrence_sets.iter().enumerate() {
         for (inner_id, inner) in occurrence_sets.iter().skip(outer_index.saturating_add(1)) {

--- a/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
+++ b/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
@@ -51,22 +51,6 @@ fn cluster_paths(cluster: &serde_json::Value) -> BTreeSet<String> {
         .unwrap_or_default()
 }
 
-fn cluster_id(cluster: &serde_json::Value) -> String {
-    cluster
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("?")
-        .to_owned()
-}
-
-fn cluster_bucket(cluster: &serde_json::Value) -> String {
-    cluster
-        .get("bucket")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("?")
-        .to_owned()
-}
-
 fn occurrence_slices(cluster: &serde_json::Value, scan_root: &Path) -> Result<Vec<Vec<u8>>> {
     let Some(occurrences) = cluster
         .get("occurrences")

--- a/crates/deslop/tests/dart_issue_119_embedding_role_mismatch.rs
+++ b/crates/deslop/tests/dart_issue_119_embedding_role_mismatch.rs
@@ -63,26 +63,6 @@ fn bucket(cluster: &Value) -> &str {
     cluster.get("bucket").and_then(Value::as_str).unwrap_or("")
 }
 
-fn clusters_hidden(report: &Value) -> u64 {
-    report
-        .get("clusters_hidden")
-        .and_then(Value::as_u64)
-        .unwrap_or_default()
-}
-
-/// Collects the raw source text of every occurrence in `cluster`.
-fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
-    let occurrences = cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
-    occurrences
-        .iter()
-        .map(|occurrence| occurrence_text(scan_root, occurrence))
-        .collect()
-}
-
 /// Returns visible clusters that pair the Dart class with the top-level
 /// function. An occurrence covering a class field (`alpha = 0`) plus
 /// another covering the function body (`saved.bind`) is the role-mismatch

--- a/crates/deslop/tests/dart_issue_197_single_file_structural_only.rs
+++ b/crates/deslop/tests/dart_issue_197_single_file_structural_only.rs
@@ -36,21 +36,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn cluster_bucket(cluster: &Value) -> &str {
-    cluster.get("bucket").and_then(Value::as_str).unwrap_or("?")
-}
-
-fn signal(cluster: &Value, key: &str) -> f64 {
-    cluster
-        .pointer(&format!("/signals/{key}"))
-        .and_then(Value::as_f64)
-        .unwrap_or_default()
-}
-
-fn cluster_size(cluster: &Value) -> u64 {
-    cluster.get("size").and_then(Value::as_u64).unwrap_or(0)
-}
-
 #[test]
 fn single_file_structural_only_method_families_do_not_top_the_report() -> Result<()> {
     let scan_root = fixture("dart-issue-197-settings-getters");

--- a/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
+++ b/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
@@ -31,28 +31,6 @@ fn run_report(tmp: &Path, scan_root: &Path) -> Result<serde_json::Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn signal(cluster: &serde_json::Value, key: &str) -> f64 {
-    cluster
-        .get("signals")
-        .and_then(|signals| signals.get(key))
-        .and_then(serde_json::Value::as_f64)
-        .unwrap_or_default()
-}
-
-fn cluster_bucket(cluster: &serde_json::Value) -> &str {
-    cluster
-        .get("bucket")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("?")
-}
-
-fn cluster_id(cluster: &serde_json::Value) -> &str {
-    cluster
-        .get("id")
-        .and_then(serde_json::Value::as_str)
-        .unwrap_or("?")
-}
-
 #[test]
 fn issue_134_structural_only_clusters_are_not_nearly_identical() -> Result<()> {
     let tmp = tempfile::tempdir()?;

--- a/crates/deslop/tests/issue_169_dart_const_registry.rs
+++ b/crates/deslop/tests/issue_169_dart_const_registry.rs
@@ -25,17 +25,6 @@ fn report_path(tmp: &Path) -> PathBuf {
     path
 }
 
-fn occurrence_paths(cluster: &Value) -> Vec<&str> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|occ| occ.get("path").and_then(Value::as_str))
-        .collect()
-}
-
 fn any_cluster_touches(report: &Value, file_name: &str) -> bool {
     clusters(report).iter().any(|cluster| {
         occurrence_paths(cluster)

--- a/crates/deslop/tests/issue_169_dart_filter_precision.rs
+++ b/crates/deslop/tests/issue_169_dart_filter_precision.rs
@@ -92,11 +92,7 @@ fn dart_verbatim_field_block_copy_stays_visible() -> Result<()> {
 
     let report = run(&src, tmp.path(), "5")?;
     let spans_both = clusters(&report).iter().any(|cluster| {
-        let paths: Vec<&str> = cluster
-            .get("occurrences")
-            .and_then(Value::as_array)
-            .map(Vec::as_slice)
-            .unwrap_or_default()
+        let paths: Vec<&str> = occurrences(cluster)
             .iter()
             .filter_map(|occ| occ.get("path").and_then(Value::as_str))
             .collect();

--- a/crates/deslop/tests/issue_190_data_table_demote.rs
+++ b/crates/deslop/tests/issue_190_data_table_demote.rs
@@ -35,17 +35,6 @@ fn report_path(tmp: &Path, stem: &str) -> PathBuf {
     path
 }
 
-fn occurrence_paths(cluster: &Value) -> Vec<&str> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|occ| occ.get("path").and_then(Value::as_str))
-        .collect()
-}
-
 fn cluster_touches(cluster: &Value, file_name: &str) -> bool {
     occurrence_paths(cluster)
         .iter()
@@ -86,13 +75,6 @@ fn weight_of(report: &Value, file_name: &str) -> f64 {
         .and_then(|cluster| cluster.get("weight"))
         .and_then(Value::as_f64)
         .unwrap_or(0.0)
-}
-
-fn clusters_hidden(report: &Value) -> u64 {
-    report
-        .get("clusters_hidden")
-        .and_then(Value::as_u64)
-        .unwrap_or(0)
 }
 
 /// Writes a fixture repo with a data table (≥3 differing constructor rows in

--- a/crates/deslop/tests/jwt_independent_verification_false_positive.rs
+++ b/crates/deslop/tests/jwt_independent_verification_false_positive.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::BTreeSet, fs, path::Path};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde_json::Value;
 
 mod common;
@@ -22,24 +22,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
         .success();
     let body = fs::read_to_string(output.with_extension("json"))?;
     Ok(serde_json::from_str(&body)?)
-}
-
-fn occurrence_path(occurrence: &Value) -> Result<&str> {
-    occurrence
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("reported occurrence is missing path"))
-}
-
-fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
-    let path = occurrence_path(occurrence)?;
-    let source = fs::read_to_string(scan_root.join(path))?;
-    let start = occurrence_byte(occurrence, "start_byte")?;
-    let end = occurrence_byte(occurrence, "end_byte")?;
-    source
-        .get(start..end)
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| anyhow!("reported occurrence range is invalid for {path}"))
 }
 
 fn jwt_verifier_clusters(report: &Value, scan_root: &Path) -> Result<Vec<String>> {

--- a/crates/deslop/tests/python_generated_template_false_positive.rs
+++ b/crates/deslop/tests/python_generated_template_false_positive.rs
@@ -7,7 +7,7 @@ mod common;
 
 use std::{fs, path::Path};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde_json::Value;
 
 use crate::common::*;
@@ -21,24 +21,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
         .success();
     let body = fs::read_to_string(output.with_extension("json"))?;
     Ok(serde_json::from_str(&body)?)
-}
-
-fn occurrence_path(occurrence: &Value) -> Result<&str> {
-    occurrence
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("reported occurrence is missing path"))
-}
-
-fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
-    let path = occurrence_path(occurrence)?;
-    let source = fs::read_to_string(scan_root.join(path))?;
-    let start = occurrence_byte(occurrence, "start_byte")?;
-    let end = occurrence_byte(occurrence, "end_byte")?;
-    source
-        .get(start..end)
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| anyhow!("reported occurrence range is invalid for {path}"))
 }
 
 fn generated_template_clusters(report: &Value, scan_root: &Path) -> Result<Vec<String>> {

--- a/crates/deslop/tests/python_issue_104_module_preamble.rs
+++ b/crates/deslop/tests/python_issue_104_module_preamble.rs
@@ -32,32 +32,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn occurrence_paths(cluster: &Value) -> Vec<String> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|occ| {
-            occ.get("path")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
-        .collect()
-}
-
-fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .map(|occurrence| occurrence_text(scan_root, occurrence))
-        .collect()
-}
-
 /// Collects every visible cluster whose occurrences contain `needle`.
 fn clusters_touching(report: &Value, scan_root: &Path, needle: &str) -> Result<Vec<Vec<String>>> {
     let mut hits = Vec::new();

--- a/crates/deslop/tests/python_issue_119_embedding_role_mismatch.rs
+++ b/crates/deslop/tests/python_issue_119_embedding_role_mismatch.rs
@@ -60,26 +60,6 @@ fn bucket(cluster: &Value) -> &str {
     cluster.get("bucket").and_then(Value::as_str).unwrap_or("")
 }
 
-fn clusters_hidden(report: &Value) -> u64 {
-    report
-        .get("clusters_hidden")
-        .and_then(Value::as_u64)
-        .unwrap_or_default()
-}
-
-/// Collects the raw source text of every occurrence in `cluster`.
-fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
-    let occurrences = cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default();
-    occurrences
-        .iter()
-        .map(|occurrence| occurrence_text(scan_root, occurrence))
-        .collect()
-}
-
 /// Returns visible clusters that pair the helper class with the test
 /// function. Either occurrence covering the class keyword and another
 /// covering the test function body is the role-mismatch signature.

--- a/crates/deslop/tests/python_issue_133_constant_table.rs
+++ b/crates/deslop/tests/python_issue_133_constant_table.rs
@@ -35,32 +35,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn occurrence_texts(scan_root: &Path, cluster: &Value) -> Result<Vec<String>> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .map(|occurrence| occurrence_text(scan_root, occurrence))
-        .collect()
-}
-
-fn occurrence_paths(cluster: &Value) -> Vec<String> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map(Vec::as_slice)
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|occ| {
-            occ.get("path")
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
-        .collect()
-}
-
 /// Resolves the named fixture and runs the constant-table report over it.
 fn fixture_report(fixture_name: &str) -> Result<(std::path::PathBuf, Value)> {
     let scan_root = fixture(fixture_name);

--- a/crates/deslop/tests/python_issue_72_monkeypatch.rs
+++ b/crates/deslop/tests/python_issue_72_monkeypatch.rs
@@ -20,13 +20,6 @@ fn run_report(fixture_name: &str) -> Result<serde_json::Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn cluster_count(report: &serde_json::Value) -> usize {
-    report
-        .get("clusters")
-        .and_then(serde_json::Value::as_array)
-        .map_or(0, Vec::len)
-}
-
 #[test]
 fn monkeypatch_setenv_setup_pattern_is_not_duplicate_code() -> Result<()> {
     let report = run_report("python-issue-72-monkeypatch-setenv")?;

--- a/crates/deslop/tests/rust_issue_150_mod_declarations.rs
+++ b/crates/deslop/tests/rust_issue_150_mod_declarations.rs
@@ -24,13 +24,6 @@ fn run_report(fixture_name: &str) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn cluster_count(report: &Value) -> usize {
-    report
-        .get("clusters")
-        .and_then(Value::as_array)
-        .map_or(0, Vec::len)
-}
-
 #[test]
 fn rust_mod_and_use_declarations_do_not_cluster_as_duplicates() -> Result<()> {
     let report = run_report("rust-issue-150-mod-declarations")?;

--- a/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
+++ b/crates/deslop/tests/rust_issue_154_structural_only_signatures.rs
@@ -33,17 +33,6 @@ fn run_report(scan_root: &Path) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn cluster_bucket(cluster: &Value) -> &str {
-    cluster.get("bucket").and_then(Value::as_str).unwrap_or("?")
-}
-
-fn signal(cluster: &Value, key: &str) -> f64 {
-    cluster
-        .pointer(&format!("/signals/{key}"))
-        .and_then(Value::as_f64)
-        .unwrap_or_default()
-}
-
 #[test]
 fn structural_only_signature_clusters_are_dropped_from_the_report() -> Result<()> {
     let scan_root = fixture("rust-issue-154-structural-only");

--- a/crates/deslop/tests/rust_issue_176_match_dispatch.rs
+++ b/crates/deslop/tests/rust_issue_176_match_dispatch.rs
@@ -26,28 +26,16 @@ fn run_report(fixture_name: &str) -> Result<Value> {
     Ok(serde_json::from_str(&body)?)
 }
 
-fn cluster_count(report: &Value) -> usize {
-    report
-        .get("clusters")
-        .and_then(Value::as_array)
-        .map_or(0, Vec::len)
-}
-
 fn cluster_occurrence_paths(cluster: &Value) -> std::collections::BTreeSet<String> {
-    cluster
-        .get("occurrences")
-        .and_then(Value::as_array)
-        .map_or_else(Default::default, |values| {
-            values
-                .iter()
-                .filter_map(|occurrence| {
-                    occurrence
-                        .get("path")
-                        .and_then(Value::as_str)
-                        .map(str::to_owned)
-                })
-                .collect()
+    occurrences(cluster)
+        .iter()
+        .filter_map(|occurrence| {
+            occurrence
+                .get("path")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
         })
+        .collect()
 }
 
 #[test]

--- a/crates/deslop/tests/rust_trait_boilerplate_false_positive.rs
+++ b/crates/deslop/tests/rust_trait_boilerplate_false_positive.rs
@@ -10,7 +10,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde_json::Value;
 
 mod common;
@@ -42,24 +42,6 @@ fn cluster_paths(cluster: &Value) -> BTreeSet<&str> {
         .iter()
         .filter_map(|occurrence| occurrence.get("path").and_then(Value::as_str))
         .collect()
-}
-
-fn occurrence_text(scan_root: &Path, occurrence: &Value) -> Result<String> {
-    let path = occurrence_path(occurrence)?;
-    let source = fs::read_to_string(scan_root.join(path))?;
-    let start = occurrence_byte(occurrence, "start_byte")?;
-    let end = occurrence_byte(occurrence, "end_byte")?;
-    source
-        .get(start..end)
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| anyhow!("reported occurrence range is invalid for {path}"))
-}
-
-fn occurrence_path(occurrence: &Value) -> Result<&str> {
-    occurrence
-        .get("path")
-        .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("reported occurrence is missing path"))
 }
 
 fn language_parser_adapter_clusters(report: &Value, scan_root: &Path) -> Result<Vec<String>> {

--- a/crates/deslop/tests/showstoppers.rs
+++ b/crates/deslop/tests/showstoppers.rs
@@ -15,22 +15,6 @@ use anyhow::Result;
 mod common;
 use crate::common::*;
 
-fn occurrence_paths(cluster: &serde_json::Value) -> Vec<String> {
-    cluster
-        .get("occurrences")
-        .and_then(serde_json::Value::as_array)
-        .map_or_else(Vec::new, |values| {
-            values
-                .iter()
-                .filter_map(|occ| {
-                    occ.get("path")
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_owned)
-                })
-                .collect()
-        })
-}
-
 fn visible_count(cluster: &serde_json::Value) -> usize {
     cluster
         .get("occurrences")


### PR DESCRIPTION
<!-- agent-pmo:b636503 -->
## TLDR

Eliminate the worst-offender duplicate-code clusters in Deslop's own codebase — the live `find-similar` MCP's top families — by consolidating copy-pasted test helpers into the per-crate `tests/common` modules and extracting two reused idioms in production LSP dispatch, with zero behaviour change.

## Details

Deslop's self-scan flagged its own repository as ~12% duplicated; this PR removes the highest-weighted **actionable** clones (verified against the live `deslop-mcp`), leaving intentional duplication (pedagogical `examples/`, bug-reproduction fixtures) untouched. No public API, CLI flag, report format, or spec ID changes. No new dependencies.

**Production code — `crates/deslop-lsp/src/ipc/dispatch.rs` (cluster `f01118b0`, 5 copies):**
- Extracted three private helpers next to the existing `rpc_serialise_error`: `missing_param_error(key)` (builds the standard JSON-RPC `-32602` invalid-params envelope), `required_str_param(params, key)` and `required_u64_param(params, key)`. The five hand-rolled `params.get(K).and_then(as_T).ok_or_else(|| json!({"code": -32602, ...}))` blocks in `dispatch_report_for_file`, `dispatch_report_for_range`, and `dispatch_cluster_by_id` now call these. Error messages are preserved exactly (`format!("missing {key}")` reproduces `"missing path"` / `"missing start_byte"` / `"missing end_byte"` / `"missing id"`).

**`crates/deslop-mcp` test helpers:**
- `tests/common/mod.rs`: added `value_array(value, pointer)` (resolve a JSON pointer + clone the array, or error). Replaced 9 copies of the `value_get(..).as_array().cloned().ok_or_else(..)` idiom in `tests/cli.rs` (cluster `a2a09c4c`, the #1 offender at weight 240).
- `tests/common/mod.rs`: added `wait_for_state_then_init_mcp(workspace)` + `LIVE_REPORT_STATE_FILE` const, collapsing the 6-copy "wait for `.deslop-cache/live-report.json` then init MCP" preamble (cluster `fec54673`) across `tests/lsp_integration.rs`, `tests/issue_135_rescan_generation.rs`, `tests/issue_156_cluster_id_stale_offsets.rs`, and `tests/issue_153_rescan_freshness.rs`. Removed the now-unused `wait_for_path` / `SOCKET_TIMEOUT` / `initialized_mcp` / `Context` imports those files no longer reference.

**`crates/deslop` test helpers (the largest family):**
- `tests/common/mod.rs`: hoisted the accessor helpers that ~19 integration-test binaries had each re-defined locally — `cluster_bucket`, `cluster_id`, `cluster_size`, `signal`, `cluster_count`, `clusters_hidden`, `occurrence_path`, `occurrence_paths`, `occurrence_files`, `occurrence_texts` — standardising on one canonical form (e.g. `signal` uses the `.pointer("/signals/{key}")` form; `cluster_bucket`/`cluster_id` return `&str`). `occurrence_text` now reuses the new `occurrence_path`. Deleted the per-file copies (clusters `12d191bb`, `7ab8d1c8`'s accessor members, `5b262e4c`, `517ec5c6`, and the `occurrence_*` families) and fixed the handful of `String`-vs-`&str` call sites.
- `tests/cli/support.rs`: added `object_field(value, key, context)` (resolve a required JSON object field, preserving each call site's bespoke error message). Replaced 6 copies of the `get(K).and_then(|v| v.as_object()).ok_or_else(..)` idiom in `tests/cli/embedding_ollama.rs` (cluster `c126deb6`); `tests/cli/from_report.rs`'s lone `as_array` variant is no longer a clone.

**Intentionally left (documented, not silenced):** the `examples/rust/state_machines/` trio (`b9673b10`) is pedagogical; cross-crate test scaffolding (`61df37de`, `b3131b15`, `28017258`) would need a shared `test-support` dev-crate (a separate architectural change, related to the `lspkit` migration note); the `run_report` external-tmp variant (`7ab8d1c8`, `e3d08abc`) carries per-file semantic nuance; and the JSON-navigation idiom clones (`7e372e7e`) extract different types/pointers/messages where a single helper would lose bespoke error context (consistent with the issue-#154 readability philosophy). None were widened, hidden, or threshold-tweaked.

## How Do The Automated Tests Prove It Works?

This is a pure DRY refactor of test scaffolding plus a behaviour-preserving production extraction, so the existing black-box E2E suite is the proof: every assertion is unchanged, and the consolidated helpers must reproduce the exact same report-walking and error behaviour or the assertions fail.

- The full `make test` suite (fail-fast, coverage-gated against `coverage-thresholds.json`) passes green. Because no assertion was removed or weakened, the suite continuing to pass demonstrates the hoisted accessors (`signal`, `cluster_bucket`, `occurrence_paths`, …) and the new `value_array` / `object_field` / `wait_for_state_then_init_mcp` helpers return identical values to the inline code they replaced.
- The production `dispatch.rs` extraction is exercised end-to-end by the deslop-mcp/deslop-lsp IPC E2E tests (`tests/lsp_integration.rs`, `tests/issue_135_rescan_generation.rs`, `tests/issue_156_cluster_id_stale_offsets.rs`, `tests/issue_153_rescan_freshness.rs`) which drive `report/forFile`, `report/forRange`, and `cluster/byId` over the real IPC wire — the exact code paths that now route through `required_str_param`/`required_u64_param`. Their assertions on returned cluster payloads and post-edit offsets confirm the `-32602` extraction behaves identically.
- The structural-only / false-positive regressions whose helpers were hoisted (`rust_issue_154_structural_only_signatures`, `issue_134_structural_only_not_nearly_identical`, `dart_issue_197_single_file_structural_only`, the `*_false_positive` trio) still assert their original positive, human-readable expectations (bucket labels, `duplicated_loc == visible_duplicated_loc`, `clusters_hidden` telemetry), proving the shared accessors preserve meaning.
- Coverage remains at or above the existing threshold (no ratchet change in this PR; the extraction adds no new untested branches — the helper bodies are the same lines, executed by the same tests).
