### PR TITLE
Consolidate cross-crate test scaffolding into a shared deslop-test-support crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "deslop-core",
+ "deslop-test-support",
  "predicates",
  "serde_json",
  "tempfile",
@@ -435,6 +436,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "deslop-core",
+ "deslop-test-support",
  "futures",
  "fxprof-processed-profile",
  "pprof",
@@ -457,6 +459,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "deslop-core",
+ "deslop-test-support",
  "nix 0.29.0",
  "notify",
  "predicates",
@@ -466,6 +469,15 @@ dependencies = [
  "thiserror 1.0.63",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "deslop-test-support"
+version = "0.0.0-dev"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/deslop",
     "crates/deslop-lsp",
     "crates/deslop-mcp",
+    "crates/deslop-test-support",
 ]
 
 [workspace.package]

--- a/crates/deslop-lsp/Cargo.toml
+++ b/crates/deslop-lsp/Cargo.toml
@@ -41,6 +41,7 @@ rustix = { version = "=0.38.44", features = ["process"] }
 anyhow.workspace = true
 assert_cmd.workspace = true
 deslop-core = { path = "../deslop-core", features = ["live", "test-support"] }
+deslop-test-support = { path = "../deslop-test-support" }
 tempfile.workspace = true
 tower-lsp.workspace = true
 

--- a/crates/deslop-lsp/tests/cli.rs
+++ b/crates/deslop-lsp/tests/cli.rs
@@ -195,15 +195,7 @@ fn pointer<'a>(value: &'a Value, path: &str) -> Result<&'a str> {
 }
 
 fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
-    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
-    assert_eq!(value.get("name"), Some(&Value::from(name)));
-    assert_eq!(
-        value.get("version").and_then(Value::as_str),
-        Some(expected_version())
-    );
-    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
-    assert_eq!(value.get("language"), Some(&Value::from("rust")));
-    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
+    deslop_test_support::assert_version_manifest(value, name, kind, expected_version());
 }
 
 fn expected_version() -> &'static str {

--- a/crates/deslop-lsp/tests/common/mod.rs
+++ b/crates/deslop-lsp/tests/common/mod.rs
@@ -10,9 +10,9 @@
 
 use std::{
     fs,
-    io::{BufRead, BufReader, Read, Write},
+    io::BufReader,
     path::{Path, PathBuf},
-    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Stdio},
     sync::atomic::{AtomicI64, Ordering},
 };
 
@@ -47,13 +47,7 @@ pub fn copy_fixture(name: &str) -> Result<tempfile::TempDir> {
 
 /// Spawns the LSP binary against `workspace_root`.
 pub fn spawn_lsp(workspace_root: &Path) -> Result<Child> {
-    let bin = assert_cmd::cargo::cargo_bin("deslop-lsp");
-    Ok(Command::new(bin)
-        .arg(workspace_root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?)
+    deslop_test_support::spawn_deslop_lsp(workspace_root, Stdio::piped())
 }
 
 /// Acquires child stdio handles after a successful spawn.
@@ -95,35 +89,12 @@ pub fn spawn_lsp_on_fixture(
 
 /// Writes one LSP framed payload.
 pub fn write_frame(stdin: &mut ChildStdin, payload: &str) -> Result<()> {
-    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
-    stdin.write_all(header.as_bytes())?;
-    stdin.write_all(payload.as_bytes())?;
-    stdin.flush()?;
-    Ok(())
+    deslop_test_support::write_lsp_frame(stdin, payload)
 }
 
 /// Reads one framed JSON-RPC response.
 pub fn read_frame(reader: &mut BufReader<ChildStdout>) -> Result<serde_json::Value> {
-    let length = read_content_length(reader)?;
-    let mut buf = vec![0_u8; length];
-    reader.read_exact(&mut buf)?;
-    Ok(serde_json::from_slice(&buf)?)
-}
-
-/// Reads the `Content-Length` header block.
-fn read_content_length(reader: &mut BufReader<ChildStdout>) -> Result<usize> {
-    let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        let _read = reader.read_line(&mut line)?;
-        if line == "\r\n" {
-            break;
-        }
-        if let Some(rest) = line.strip_prefix("Content-Length: ") {
-            content_length = Some(rest.trim().parse::<usize>()?);
-        }
-    }
-    content_length.ok_or_else(|| anyhow!("missing Content-Length"))
+    deslop_test_support::read_lsp_frame(reader)
 }
 
 /// Sends a request and waits for the matching response id.

--- a/crates/deslop-lsp/tests/cpu_throttle_knob.rs
+++ b/crates/deslop-lsp/tests/cpu_throttle_knob.rs
@@ -11,7 +11,7 @@
 mod common;
 
 use std::{
-    io::{BufRead, BufReader, Read},
+    io::BufReader,
     process::{ChildStdin, ChildStdout, Command, Stdio},
     sync::atomic::{AtomicI64, Ordering},
     thread,
@@ -171,29 +171,8 @@ fn request_without_params(method: &str) -> Result<(i64, String)> {
     Ok((id, serde_json::to_string(&payload)?))
 }
 
-fn read_content_length(reader: &mut BufReader<ChildStdout>) -> Result<usize> {
-    let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        let read = reader.read_line(&mut line)?;
-        if read == 0 {
-            return Err(anyhow!("stdout closed before Content-Length"));
-        }
-        if line == "\r\n" {
-            break;
-        }
-        if let Some(rest) = line.strip_prefix("Content-Length: ") {
-            content_length = Some(rest.trim().parse::<usize>()?);
-        }
-    }
-    content_length.ok_or_else(|| anyhow!("missing Content-Length"))
-}
-
 fn read_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
-    let length = read_content_length(reader)?;
-    let mut buf = vec![0_u8; length];
-    reader.read_exact(&mut buf)?;
-    Ok(serde_json::from_slice(&buf)?)
+    deslop_test_support::read_lsp_frame(reader)
 }
 
 fn send_and_recv(

--- a/crates/deslop-lsp/tests/notifications.rs
+++ b/crates/deslop-lsp/tests/notifications.rs
@@ -51,10 +51,7 @@ fn vscode_core_notifications_are_implemented_or_explicitly_nooped() -> Result<()
 fn report_changed_fires_for_pure_removal_delta() -> Result<()> {
     let workspace = copy_fixture("csharp-small")?;
     let beta = workspace.path().join("Beta.cs");
-    let (_guard, mut stdin, stdout) = spawn_lsp_guarded(workspace.path())?;
-    let frames = spawn_frame_reader(stdout);
-    frame_handshake(&mut stdin, &frames)?;
-    let initial = frame_report_get(&mut stdin, &frames)?;
+    let (_guard, mut stdin, frames, initial) = spawn_lsp_with_initial_report(workspace.path())?;
     ensure!(
         cluster_count(&initial) > 0,
         "fixture must start with duplicate clusters"
@@ -88,10 +85,7 @@ fn report_changed_fires_for_pure_removal_delta() -> Result<()> {
 fn report_changed_fires_for_each_external_save_of_the_same_path() -> Result<()> {
     let workspace = copy_fixture("csharp-small")?;
     let beta = workspace.path().join("Beta.cs");
-    let (_guard, mut stdin, stdout) = spawn_lsp_guarded(workspace.path())?;
-    let frames = spawn_frame_reader(stdout);
-    frame_handshake(&mut stdin, &frames)?;
-    let initial = frame_report_get(&mut stdin, &frames)?;
+    let (_guard, _stdin, frames, initial) = spawn_lsp_with_initial_report(workspace.path())?;
     ensure!(
         cluster_count(&initial) > 0,
         "fixture must start with duplicate clusters"
@@ -126,10 +120,7 @@ fn report_changed_fires_for_each_external_save_of_the_same_path() -> Result<()> 
 fn report_changed_fires_for_external_save_of_dart_file() -> Result<()> {
     let workspace = copy_fixture("dart-small")?;
     let beta = workspace.path().join("beta.dart");
-    let (_guard, mut stdin, stdout) = spawn_lsp_guarded(workspace.path())?;
-    let frames = spawn_frame_reader(stdout);
-    frame_handshake(&mut stdin, &frames)?;
-    let initial = frame_report_get(&mut stdin, &frames)?;
+    let (_guard, _stdin, frames, initial) = spawn_lsp_with_initial_report(workspace.path())?;
     ensure!(
         cluster_count(&initial) > 0,
         "dart fixture must start with duplicate clusters"
@@ -165,10 +156,7 @@ fn threshold_breach_pushes_non_blocking_warning_on_startup() -> Result<()> {
         workspace.path().join(".deslop.toml"),
         "[threshold]\nmax_duplication_percent = 5.0\n",
     )?;
-    let (_guard, mut stdin, stdout) = spawn_lsp_guarded(workspace.path())?;
-    let frames = spawn_frame_reader(stdout);
-    frame_handshake(&mut stdin, &frames)?;
-    let initial = frame_report_get(&mut stdin, &frames)?;
+    let (_guard, mut stdin, frames, initial) = spawn_lsp_with_initial_report(workspace.path())?;
     let measured = initial
         .pointer("/result/metrics/duplication_percent")
         .and_then(serde_json::Value::as_f64)
@@ -249,6 +237,23 @@ fn frame_report_get(
     frames: &Receiver<FrameResult>,
 ) -> Result<serde_json::Value> {
     request_response(stdin, frames, "deslop/reportGet", &serde_json::json!({}))
+}
+
+/// Spawns a guarded LSP, starts its frame reader, completes the handshake, and
+/// returns the guard, stdin, frame channel, and the initial `deslop/reportGet`.
+fn spawn_lsp_with_initial_report(
+    workspace: &Path,
+) -> Result<(
+    LspGuard,
+    ChildStdin,
+    Receiver<FrameResult>,
+    serde_json::Value,
+)> {
+    let (guard, mut stdin, stdout) = spawn_lsp_guarded(workspace)?;
+    let frames = spawn_frame_reader(stdout);
+    frame_handshake(&mut stdin, &frames)?;
+    let initial = frame_report_get(&mut stdin, &frames)?;
+    Ok((guard, stdin, frames, initial))
 }
 
 /// Reads frames on a background thread so tests can time out waiting

--- a/crates/deslop-mcp/Cargo.toml
+++ b/crates/deslop-mcp/Cargo.toml
@@ -32,6 +32,7 @@ nix = { version = "0.29", default-features = false, features = ["process"] }
 anyhow.workspace = true
 assert_cmd.workspace = true
 deslop-core = { path = "../deslop-core", features = ["live", "test-support"] }
+deslop-test-support = { path = "../deslop-test-support" }
 predicates.workspace = true
 tempfile.workspace = true
 

--- a/crates/deslop-mcp/tests/cli.rs
+++ b/crates/deslop-mcp/tests/cli.rs
@@ -215,13 +215,7 @@ impl McpChild {
 /// `initialize`+`initialized` handshake so the IPC socket is ready
 /// before the MCP child connects.
 fn spawn_companion_lsp(root: &Path) -> Result<Child> {
-    let bin = cargo_bin("deslop-lsp");
-    let mut child = Command::new(bin)
-        .arg(root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
+    let mut child = deslop_test_support::spawn_deslop_lsp(root, Stdio::piped())
         .context("spawn companion deslop-lsp")?;
     let mut stdin = child.stdin.take().context("lsp stdin")?;
     let mut stdout = BufReader::new(child.stdout.take().context("lsp stdout")?);
@@ -247,31 +241,12 @@ fn lsp_handshake(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) ->
 
 /// Writes one LSP-framed JSON-RPC message.
 fn write_lsp_frame(stdin: &mut ChildStdin, payload: &str) -> Result<()> {
-    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
-    stdin.write_all(header.as_bytes())?;
-    stdin.write_all(payload.as_bytes())?;
-    stdin.flush()?;
-    Ok(())
+    deslop_test_support::write_lsp_frame(stdin, payload)
 }
 
 /// Reads one LSP-framed JSON-RPC response and returns it as JSON.
 fn read_lsp_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
-    use std::io::Read as _;
-    let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        let _read = reader.read_line(&mut line)?;
-        if line == "\r\n" {
-            break;
-        }
-        if let Some(rest) = line.strip_prefix("Content-Length: ") {
-            content_length = Some(rest.trim().parse::<usize>()?);
-        }
-    }
-    let length = content_length.ok_or_else(|| anyhow!("missing Content-Length"))?;
-    let mut buf = vec![0_u8; length];
-    reader.read_exact(&mut buf)?;
-    Ok(serde_json::from_slice(&buf)?)
+    deslop_test_support::read_lsp_frame(reader)
 }
 
 /// Polls until `<root>/.deslop-cache/deslop.sock` exists. Failure
@@ -533,15 +508,7 @@ fn prints_json_version_contract() -> Result<()> {
 }
 
 fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
-    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
-    assert_eq!(value.get("name"), Some(&Value::from(name)));
-    assert_eq!(
-        value.get("version").and_then(Value::as_str),
-        Some(expected_version())
-    );
-    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
-    assert_eq!(value.get("language"), Some(&Value::from("rust")));
-    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
+    deslop_test_support::assert_version_manifest(value, name, kind, expected_version());
 }
 
 fn call_tool(child: &mut McpChild, name: &str, arguments: &Value) -> Result<Value> {

--- a/crates/deslop-mcp/tests/common/mod.rs
+++ b/crates/deslop-mcp/tests/common/mod.rs
@@ -13,7 +13,7 @@
 
 use std::{
     fs,
-    io::{BufRead, BufReader, Read, Write},
+    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
     thread,
@@ -111,29 +111,11 @@ fn lsp_handshake(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) ->
 }
 
 fn write_lsp_frame(stdin: &mut ChildStdin, payload: &str) -> Result<()> {
-    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
-    stdin.write_all(header.as_bytes())?;
-    stdin.write_all(payload.as_bytes())?;
-    stdin.flush()?;
-    Ok(())
+    deslop_test_support::write_lsp_frame(stdin, payload)
 }
 
 fn read_lsp_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
-    let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        let _read = reader.read_line(&mut line)?;
-        if line == "\r\n" {
-            break;
-        }
-        if let Some(rest) = line.strip_prefix("Content-Length: ") {
-            content_length = Some(rest.trim().parse::<usize>()?);
-        }
-    }
-    let length = content_length.ok_or_else(|| anyhow!("missing Content-Length"))?;
-    let mut buf = vec![0_u8; length];
-    reader.read_exact(&mut buf)?;
-    Ok(serde_json::from_slice(&buf)?)
+    deslop_test_support::read_lsp_frame(reader)
 }
 
 /// Polls until `path` exists, failing after `timeout`.

--- a/crates/deslop-mcp/tests/wrong_root.rs
+++ b/crates/deslop-mcp/tests/wrong_root.rs
@@ -11,7 +11,7 @@
 
 use std::{
     fs,
-    io::{BufRead, BufReader, Read, Write},
+    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
     thread,
@@ -19,7 +19,6 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use assert_cmd::cargo::cargo_bin;
 use serde_json::{json, Value};
 use tempfile::TempDir;
 
@@ -39,14 +38,8 @@ impl Drop for LspGuard {
 }
 
 fn spawn_lsp(root: &Path) -> Result<LspGuard> {
-    let bin = cargo_bin("deslop-lsp");
-    let mut child = Command::new(bin)
-        .arg(root)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .context("spawn deslop-lsp")?;
+    let mut child =
+        deslop_test_support::spawn_deslop_lsp(root, Stdio::null()).context("spawn deslop-lsp")?;
     let mut stdin = child.stdin.take().context("lsp stdin")?;
     let mut stdout = BufReader::new(child.stdout.take().context("lsp stdout")?);
     lsp_handshake(&mut stdin, &mut stdout).context("lsp handshake")?;
@@ -73,29 +66,11 @@ fn lsp_handshake(stdin: &mut ChildStdin, stdout: &mut BufReader<ChildStdout>) ->
 }
 
 fn write_lsp_frame(stdin: &mut ChildStdin, payload: &str) -> Result<()> {
-    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
-    stdin.write_all(header.as_bytes())?;
-    stdin.write_all(payload.as_bytes())?;
-    stdin.flush()?;
-    Ok(())
+    deslop_test_support::write_lsp_frame(stdin, payload)
 }
 
 fn read_lsp_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
-    let mut content_length: Option<usize> = None;
-    loop {
-        let mut line = String::new();
-        let _bytes = reader.read_line(&mut line)?;
-        if line == "\r\n" {
-            break;
-        }
-        if let Some(rest) = line.strip_prefix("Content-Length: ") {
-            content_length = Some(rest.trim().parse::<usize>()?);
-        }
-    }
-    let length = content_length.ok_or_else(|| anyhow!("missing Content-Length"))?;
-    let mut buf = vec![0_u8; length];
-    reader.read_exact(&mut buf)?;
-    Ok(serde_json::from_slice(&buf)?)
+    deslop_test_support::read_lsp_frame(reader)
 }
 
 fn wait_for_socket(path: &Path) -> Result<()> {

--- a/crates/deslop-test-support/Cargo.toml
+++ b/crates/deslop-test-support/Cargo.toml
@@ -1,0 +1,17 @@
+# agent-pmo:9a71cbf
+[package]
+name = "deslop-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+assert_cmd.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/deslop-test-support/src/lib.rs
+++ b/crates/deslop-test-support/src/lib.rs
@@ -1,0 +1,110 @@
+//! Cross-crate E2E test helpers shared by the `deslop`, `deslop-lsp`, and
+//! `deslop-mcp` integration suites.
+//!
+//! Each binary crate previously carried its own byte-identical copies of the
+//! version-manifest assertion, the LSP `Content-Length` JSON-RPC framing, and
+//! the `deslop-lsp` child-spawn idiom. They live here once so the three test
+//! suites share a single canonical implementation.
+//!
+//! Scope note: the LSP wire framing mirrors the shape that the upstream
+//! `lspkit-server` toolkit owns on the production side. These are test-only
+//! utilities (dev-dependency, never published); they do not duplicate the
+//! production protocol shell, which stays in `deslop-lsp` / `deslop-mcp`.
+
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+};
+
+use anyhow::{anyhow, Result};
+use serde_json::Value;
+
+/// Appends `.<ext>` to the file name of `base`, returning the new path.
+/// E.g. `with_ext("/tmp/report", "json")` is `/tmp/report.json`. Used by the
+/// CLI tests to derive the rendered report path from an `--output` prefix.
+#[must_use]
+pub fn with_ext(base: &Path, ext: &str) -> PathBuf {
+    let mut path = base.to_path_buf();
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    name.push(".");
+    name.push(ext);
+    path.set_file_name(name);
+    path
+}
+
+/// Asserts that a `--version --format json` manifest carries the expected
+/// shape: `manifestVersion = 1`, the given `name` and `kind`, the supplied
+/// `version` string, and the fixed `language = "rust"` / `product = "deslop"`
+/// fields every Deslop binary emits.
+///
+/// # Panics
+///
+/// Panics (failing the test) when any manifest field is absent or does not
+/// match the expected value.
+pub fn assert_version_manifest(value: &Value, name: &str, kind: &str, version: &str) {
+    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
+    assert_eq!(value.get("name"), Some(&Value::from(name)));
+    assert_eq!(value.get("version").and_then(Value::as_str), Some(version));
+    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
+    assert_eq!(value.get("language"), Some(&Value::from("rust")));
+    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
+}
+
+/// Writes one LSP-framed (`Content-Length`) payload to a child's stdin.
+///
+/// # Errors
+///
+/// Returns an error if writing the header, the body, or the flush fails.
+pub fn write_lsp_frame(stdin: &mut ChildStdin, payload: &str) -> Result<()> {
+    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
+    stdin.write_all(header.as_bytes())?;
+    stdin.write_all(payload.as_bytes())?;
+    stdin.flush()?;
+    Ok(())
+}
+
+/// Reads one LSP-framed JSON-RPC response: parses the `Content-Length` header
+/// block, reads exactly that many body bytes, and deserialises them as JSON.
+///
+/// # Errors
+///
+/// Returns an error if the stream ends early, the `Content-Length` header is
+/// missing or unparsable, or the body is not valid JSON.
+pub fn read_lsp_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let _read = reader.read_line(&mut line)?;
+        if line == "\r\n" {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("Content-Length: ") {
+            content_length = Some(rest.trim().parse::<usize>()?);
+        }
+    }
+    let length = content_length.ok_or_else(|| anyhow!("missing Content-Length"))?;
+    let mut buf = vec![0_u8; length];
+    reader.read_exact(&mut buf)?;
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+/// Spawns the `deslop-lsp` binary against `root` with piped stdin/stdout and
+/// the caller-chosen `stderr` disposition (`Stdio::piped()` to capture,
+/// `Stdio::null()` to discard).
+///
+/// # Errors
+///
+/// Returns an error if the child process fails to spawn.
+pub fn spawn_deslop_lsp(root: &Path, stderr: Stdio) -> Result<Child> {
+    let bin = assert_cmd::cargo::cargo_bin("deslop-lsp");
+    Ok(Command::new(bin)
+        .arg(root)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(stderr)
+        .spawn()?)
+}

--- a/crates/deslop/Cargo.toml
+++ b/crates/deslop/Cargo.toml
@@ -22,6 +22,7 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 assert_cmd.workspace = true
 deslop-core = { path = "../deslop-core", features = ["test-support"] }
+deslop-test-support = { path = "../deslop-test-support" }
 predicates.workspace = true
 tempfile.workspace = true
 

--- a/crates/deslop/tests/cli/invocation.rs
+++ b/crates/deslop/tests/cli/invocation.rs
@@ -27,15 +27,7 @@ fn prints_json_version_contract() -> Result<()> {
 }
 
 fn assert_version_manifest(value: &Value, name: &str, kind: &str) {
-    assert_eq!(value.get("manifestVersion"), Some(&Value::from(1)));
-    assert_eq!(value.get("name"), Some(&Value::from(name)));
-    assert_eq!(
-        value.get("version").and_then(Value::as_str),
-        Some(expected_version())
-    );
-    assert_eq!(value.get("kind"), Some(&Value::from(kind)));
-    assert_eq!(value.get("language"), Some(&Value::from("rust")));
-    assert_eq!(value.get("product"), Some(&Value::from("deslop")));
+    deslop_test_support::assert_version_manifest(value, name, kind, expected_version());
 }
 
 fn expected_version() -> &'static str {

--- a/crates/deslop/tests/cli/support.rs
+++ b/crates/deslop/tests/cli/support.rs
@@ -40,15 +40,7 @@ pub(crate) fn deslop_command(scan_root: &Path, output_prefix: &Path) -> Result<C
 
 /// Appends `.<ext>` to `base` by cloning and replacing the file name.
 pub(crate) fn with_ext(base: &Path, ext: &str) -> PathBuf {
-    let mut path = base.to_path_buf();
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".");
-    name.push(ext);
-    path.set_file_name(name);
-    path
+    deslop_test_support::with_ext(base, ext)
 }
 
 /// Copies every top-level entry in `src` into a freshly created `dst`.

--- a/crates/deslop/tests/cross_language.rs
+++ b/crates/deslop/tests/cross_language.rs
@@ -82,13 +82,5 @@ fn extension(path: &str) -> Option<&str> {
 }
 
 fn with_ext(base: &Path, ext: &str) -> PathBuf {
-    let mut path = base.to_path_buf();
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".");
-    name.push(ext);
-    path.set_file_name(name);
-    path
+    deslop_test_support::with_ext(base, ext)
 }

--- a/crates/deslop/tests/csharp_type1_type2_distinct_buckets.rs
+++ b/crates/deslop/tests/csharp_type1_type2_distinct_buckets.rs
@@ -8,24 +8,10 @@
 //! claiming "every copy is the same".
 //! Tests [CLONE-BUCKETS-IDENTICAL]
 
-use std::{fs, path::Path};
-
 use anyhow::Result;
 
 mod common;
 use crate::common::*;
-
-fn run_report(tmp: &Path, scan_root: &Path) -> Result<serde_json::Value> {
-    let mut cmd = deslop_cmd(scan_root, &tmp.join("report"))?;
-    let _assertion = cmd
-        .args(["--min-nodes", "30", "--embeddings", "off"])
-        .assert()
-        .success();
-    let mut json_path = tmp.join("report");
-    let _replaced = json_path.set_extension("json");
-    let body = fs::read_to_string(&json_path)?;
-    Ok(serde_json::from_str(&body)?)
-}
 
 fn cluster_interpretations(report: &serde_json::Value) -> Vec<String> {
     report
@@ -51,11 +37,8 @@ fn cluster_interpretations(report: &serde_json::Value) -> Vec<String> {
 // "every copy is the same". Currently both get the same Identical label.
 #[test]
 fn type2_clusters_render_distinct_action_from_type1() -> Result<()> {
-    let tmp1 = tempfile::tempdir()?;
-    let tmp2 = tempfile::tempdir()?;
-
-    let type2_report = run_report(tmp1.path(), &fixture("csharp-small"))?;
-    let type1_report = run_report(tmp2.path(), &fixture("csharp-type1"))?;
+    let type2_report = run_report(&fixture("csharp-small"), 30)?;
+    let type1_report = run_report(&fixture("csharp-type1"), 30)?;
 
     let type2_interpretations = cluster_interpretations(&type2_report);
     let type1_interpretations = cluster_interpretations(&type1_report);

--- a/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
+++ b/crates/deslop/tests/csharp_unrelated_xunit_classes.rs
@@ -21,18 +21,6 @@ use anyhow::{Context, Result};
 mod common;
 use crate::common::*;
 
-fn run_report(tmp: &Path, scan_root: &Path) -> Result<serde_json::Value> {
-    let mut cmd = deslop_cmd(scan_root, &tmp.join("report"))?;
-    let _assertion = cmd
-        .args(["--min-nodes", "30", "--embeddings", "off"])
-        .assert()
-        .success();
-    let mut json_path = tmp.join("report");
-    let _replaced = json_path.set_extension("json");
-    let body = fs::read_to_string(&json_path)?;
-    Ok(serde_json::from_str(&body)?)
-}
-
 fn cluster_paths(cluster: &serde_json::Value) -> BTreeSet<String> {
     cluster
         .get("occurrences")
@@ -129,9 +117,8 @@ fn identical_clusters_with_different_source(
 // matches.
 #[test]
 fn unrelated_csharp_xunit_classes_are_never_nearly_identical() -> Result<()> {
-    let tmp = tempfile::tempdir()?;
     let scan_root = fixture("csharp-unrelated-xunit-tests");
-    let report = run_report(tmp.path(), &scan_root)?;
+    let report = run_report(&scan_root, 30)?;
     let clusters = report
         .get("clusters")
         .and_then(serde_json::Value::as_array)
@@ -160,9 +147,8 @@ fn unrelated_csharp_xunit_classes_are_never_nearly_identical() -> Result<()> {
 // code`. A user-facing identical bucket must only contain byte-identical slices.
 #[test]
 fn csharp_assertion_blocks_with_different_literals_are_not_identical() -> Result<()> {
-    let tmp = tempfile::tempdir()?;
     let scan_root = fixture("csharp-unrelated-xunit-tests");
-    let report = run_report(tmp.path(), &scan_root)?;
+    let report = run_report(&scan_root, 30)?;
     let offenders = identical_clusters_with_different_source(&report, &scan_root)?;
     assert!(
         offenders.is_empty(),

--- a/crates/deslop/tests/defaults.rs
+++ b/crates/deslop/tests/defaults.rs
@@ -273,15 +273,7 @@ fn occurrence_path_contains(cluster: &Value, needle: &str) -> bool {
 }
 
 fn with_ext(base: &Path, ext: &str) -> PathBuf {
-    let mut path = base.to_path_buf();
-    let mut name = path
-        .file_name()
-        .map(std::ffi::OsStr::to_os_string)
-        .unwrap_or_default();
-    name.push(".");
-    name.push(ext);
-    path.set_file_name(name);
-    path
+    deslop_test_support::with_ext(base, ext)
 }
 
 const GENERATED_ALPHA: &str = r"

--- a/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
+++ b/crates/deslop/tests/issue_134_structural_only_not_nearly_identical.rs
@@ -12,30 +12,15 @@
 //! `bucket=nearly_identical` together with `structural >= 0.99`,
 //! `token_jaccard < 0.05`, and `embedding_cos < 0.05`.
 
-use std::{fs, path::Path};
-
 use anyhow::Result;
 
 mod common;
 use crate::common::*;
 
-fn run_report(tmp: &Path, scan_root: &Path) -> Result<serde_json::Value> {
-    let mut cmd = deslop_cmd(scan_root, &tmp.join("report"))?;
-    let _assertion = cmd
-        .args(["--min-nodes", "30", "--embeddings", "off"])
-        .assert()
-        .success();
-    let mut json_path = tmp.join("report");
-    let _replaced = json_path.set_extension("json");
-    let body = fs::read_to_string(&json_path)?;
-    Ok(serde_json::from_str(&body)?)
-}
-
 #[test]
 fn issue_134_structural_only_clusters_are_not_nearly_identical() -> Result<()> {
-    let tmp = tempfile::tempdir()?;
     let scan_root = fixture("csharp-issue-134-structural-only");
-    let report = run_report(tmp.path(), &scan_root)?;
+    let report = run_report(&scan_root, 30)?;
     // [METRICS-REPO] `clusters_total` counts only the clusters the report
     // renders. This fixture's sole family is a hidden structural-only
     // cluster, so it contributes zero to the metric while still being


### PR DESCRIPTION
<!-- agent-pmo:b636503 -->
## TLDR

Eliminate the worst cross-crate and within-crate duplicate-code clusters in Deslop's own test suites by introducing a shared `deslop-test-support` dev-crate and consolidating onto it (plus the existing `tests/common`), with zero behaviour change.

## Details

Follow-up to the previous dedup pass. Verified against the live `deslop-mcp`, this removes the highest-weighted *actionable* clones that span crate boundaries (which the per-crate `tests/common` modules could not reach). No public API, CLI flag, report format, or spec ID changes. No new external dependencies.

**Intentional duplication left untouched (by design):** `examples/` is Deslop's clone-*demonstration* corpus — `examples/README.md` documents the identical `run`/`ticks_until` traffic-light shells (`b9673b1`) and the `strip_punctuation`/`deduplicate_words` bodies as *expected* Type-1/2 detections shown in the VS Code walkthrough. Those stay duplicated on purpose.

**New crate — `crates/deslop-test-support` (dev-only, `publish = false`, `version.workspace = true`):**
A single home for E2E test helpers that all three binary crates' suites had each copied verbatim. Added as a `[dev-dependencies]` path dep to `deslop`, `deslop-lsp`, and `deslop-mcp`; added to workspace `members`. Helpers:
- `assert_version_manifest(value, name, kind, version)` — the `--version --format json` manifest assertion (cluster `61df37d`, a 110-node block identical across `deslop/tests/cli/invocation.rs`, `deslop-mcp/tests/cli.rs`, `deslop-lsp/tests/cli.rs`). Takes `version` as a parameter so each crate keeps its own `expected_version() = env!("CARGO_PKG_VERSION")`.
- `write_lsp_frame` / `read_lsp_frame` — the LSP `Content-Length` JSON-RPC framing (cluster `b3131b1`, 5 copies across `deslop-lsp/tests/common`, `deslop-lsp/tests/cpu_throttle_knob`, `deslop-mcp/tests/common`, `deslop-mcp/tests/cli`, `deslop-mcp/tests/wrong_root`).
- `spawn_deslop_lsp(root, stderr)` — the `deslop-lsp` child-spawn idiom (cluster `2801725`), parameterised on the `stderr` disposition (`piped` vs `null`).
- `with_ext(base, ext)` — report-path-from-output-prefix helper (cluster `e3d08ab`, identical across `deslop/tests/cli/support.rs`, `deslop/tests/defaults.rs`, `deslop/tests/cross_language.rs`; the `cli` test binary can't reach `tests/common`, so the shared crate is the only common home).

Each existing local helper was rewritten to *delegate* to the shared crate (its name/signature kept identical), so no call site changed; dead private helpers (`read_content_length`) and now-unused imports were removed.

**Within-`deslop` consolidation (onto existing `tests/common`):**
- `7ab8d1c` (98-node): the 3 files defining a local 2-arg `run_report(tmp, scan_root)` now call the existing `common::run_report(scan_root, 30)` (which makes its own temp dir); the redundant local fns and `tempfile::tempdir()` bindings were deleted.

**Within-`deslop-lsp` consolidation:**
- `9e70870` (43-node, 4 copies in `tests/notifications.rs`): the spawn-guarded-LSP + frame-reader + handshake + initial-reportGet preamble is now one local `spawn_lsp_with_initial_report` helper.

**lspkit note:** the LSP framing/spawn helpers mirror the wire shape the upstream `lspkit-server` toolkit owns on the *production* side (see CLAUDE.md migration table). These are test-only utilities and do not duplicate the production protocol shell; if/when the toolkit grows test fixtures, this crate is the migration candidate.

## How Do The Automated Tests Prove It Works?

A pure DRY refactor of test scaffolding: every assertion is byte-for-byte unchanged, and the delegating helpers must reproduce identical behaviour or the suite fails.

- The full `make test` suite (fail-fast, coverage-gated against `coverage-thresholds.json`) passes green. Since no `#[test]`, `assert*!`, or `ensure!` was removed or weakened, the suite continuing to pass proves `deslop_test_support::{assert_version_manifest, write_lsp_frame, read_lsp_frame, spawn_deslop_lsp, with_ext}` behave identically to the inline code they replaced.
- The migrated framing/spawn helpers are exercised end-to-end by the real-binary IPC suites — `deslop-lsp/tests/{cli, notifications, cpu_throttle_knob, state_file_and_ipc}.rs` and `deslop-mcp/tests/{cli, wrong_root, lsp_integration, issue_135/153/156}.rs` — which spawn the actual `deslop-lsp`/`deslop-mcp` binaries and drive `initialize`/`report`/`rescan`/`cluster-by-id` over the JSON-RPC wire. Their assertions on framed responses confirm the shared `read_lsp_frame`/`write_lsp_frame`/`spawn_deslop_lsp` are wire-correct.
- The version-manifest assertion is exercised by each binary's `--version --format json` CLI test in all three crates; passing confirms the parameterised `assert_version_manifest` plus per-crate `expected_version()` still pin `manifestVersion`, `name`, `kind`, `version`, `language=rust`, `product=deslop`.
- Coverage holds at or above the existing per-crate thresholds (no ratchet change). The new `deslop-test-support` crate is dev-only test scaffolding (not in the product coverage set) and every helper is exercised by the suites above.
