### PR TITLE
Fix serde struct-field false positives (#224), CLI schema_doc bloat, and Dart MCP language label (#164)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           path: |
             lcov.info
             target/llvm-cov/
-          retention-days: 7
+          retention-days: 1
 
       - name: Build
         run: make build
@@ -171,7 +171,7 @@ jobs:
           path: |
             target/release/deslop
             target/release/deslop.exe
-          retention-days: 7
+          retention-days: 1
 
   # Windows compile + transport gate ([LIVE-IPC-TCP]). Until now,
   # cfg(windows) code paths were only compiled by the release matrix —
@@ -295,7 +295,7 @@ jobs:
           name: vsix-coverage
           path: |
             clients/vscode/coverage/
-          retention-days: 7
+          retention-days: 1
 
   jetbrains:
     name: JetBrains package gate
@@ -331,6 +331,11 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+          # Cache the Gradle user home (IntelliJ-Platform SDK + LSP4IJ + deps).
+          # The cold resolve dominates this gate (~378 job-min/month). Caching
+          # keeps _jetbrains-real-binary-test running on every PR — it just stops
+          # re-downloading the SDK each run.
+          cache: gradle
 
       # The Gradle wrapper at clients/jetbrains/gradlew is the source of truth.
       # No external setup-gradle step needed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+          # Key on Cargo.lock only: the release version-stamp rewrites Cargo.toml
+          # on every tag, which would bust an exact key each release — forcing a
+          # fresh ~GB cache save and thrashing the 10 GB cache LRU into cold
+          # rebuilds on the 10x macOS legs. Cargo.lock is the true dependency
+          # fingerprint; cargo's own fingerprinting recompiles changed crates.
+          key: ${{ runner.os }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-release-
 
@@ -251,6 +256,10 @@ jobs:
             dist/deslop-*.zip
             dist/deslop-*.zip.sha256
           if-no-files-found: error
+          # Intermediate build output: consumed by the release/publish jobs in
+          # this same run, then attached to the GitHub Release. Nothing needs it
+          # afterward, so expire it next day instead of the 90-day default.
+          retention-days: 1
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
@@ -258,6 +267,8 @@ jobs:
           name: vsix-${{ matrix.vsix_target }}
           path: clients/vscode/deslop-live-*.vsix
           if-no-files-found: error
+          # See "Upload CLI artifact": transient, published to the Release.
+          retention-days: 1
 
   jetbrains:
     name: Build JetBrains plugin
@@ -278,6 +289,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
+          # Cache the Gradle user home (IntelliJ-Platform SDK + LSP4IJ + deps).
+          # The cold dependency resolve dominates this job; caching keeps every
+          # gate running while skipping the multi-hundred-MB SDK re-download.
+          cache: gradle
 
       # Lock-step version: stamps shipwright.json (the staged manifest the plugin
       # verifies its bundled binary against) to the tag version. The Gradle plugin
@@ -330,6 +345,8 @@ jobs:
           path: |
             clients/jetbrains/deslop-lsp4ij/build/distributions/*.zip
           if-no-files-found: error
+          # See "Upload CLI artifact": transient, published to the Release.
+          retention-days: 1
 
   release:
     name: Create GitHub release

--- a/crates/deslop-core/src/cluster_filters/mod.rs
+++ b/crates/deslop-core/src/cluster_filters/mod.rs
@@ -234,12 +234,13 @@ fn python_noise(snippets: &[Snippet<'_>]) -> bool {
         || python_constants::is_module_constant_table_cluster(snippets)
 }
 
-/// All Rust idiom noise filters (issues #75/#147/#150/#176).
+/// All Rust idiom noise filters (issues #75/#147/#150/#176/#224).
 fn rust_noise(snippets: &[Snippet<'_>]) -> bool {
     rust::is_rust_language_parser_adapter_cluster(snippets)
         || rust::is_rust_top_level_decl_cluster(snippets)
         || rust::is_rust_iter_collect_idiom_cluster(snippets)
         || rust::is_rust_match_dispatch_cluster(snippets)
+        || rust::is_rust_struct_field_declaration_cluster(snippets)
 }
 
 /// Decides whether an embedding-dominant `same_behavior` cluster pairs

--- a/crates/deslop-core/src/cluster_filters/rust.rs
+++ b/crates/deslop-core/src/cluster_filters/rust.rs
@@ -497,3 +497,118 @@ fn field_expression_projects_closure_arg(
     node.child_by_field_name("field")
         .is_some_and(|field| field.kind() == "field_identifier")
 }
+
+/// Detects **issue #224** [CLONE-NOISE-RUST-STRUCT-FIELDS]: clusters whose
+/// every member covers only Rust struct field declarations. A field list
+/// encodes a data model's *shape*, not extractable duplicate logic — after
+/// identifier, type, and literal normalisation `pub a: Option<String>`
+/// collapses to the same subtree as `pub b: Option<String>`, so unrelated
+/// field runs (and whole structs that are nothing but such fields) cluster as
+/// `structural_only`. No refactor removes them, yet they dominate the
+/// duplication metric on serde-heavy repos. This is the Rust counterpart of
+/// the Dart class-field filter (#169).
+///
+/// Guarded by `raw_snippet_texts_differ` exactly like the Dart filter: a
+/// byte-identical copy-pasted struct still surfaces as genuine duplication
+/// rather than being mistaken for a run of distinct fields.
+pub(super) fn is_rust_struct_field_declaration_cluster(snippets: &[Snippet<'_>]) -> bool {
+    is_multi_member_language_cluster(snippets, "rust")
+        && snippets.iter().all(covers_only_struct_field_declarations)
+        && raw_snippet_texts_differ(snippets)
+}
+
+/// Returns true when `snippet.range` covers only Rust struct field
+/// declarations — a run of sibling fields inside one `field_declaration_list`,
+/// or one whole `struct_item` whose body is nothing but field declarations.
+/// Any method, impl, or other item body fails the check and keeps clustering.
+fn covers_only_struct_field_declarations(snippet: &Snippet<'_>) -> bool {
+    let Some(tree) = parse_for(snippet) else {
+        return false;
+    };
+    let range = trimmed_snippet_range(snippet).unwrap_or(snippet.range);
+    let root = tree.root_node();
+    // A run of sibling fields inside one struct's field list.
+    if let Some(list) = enclosing_kind(root, range, &["field_declaration_list"]) {
+        return field_list_range_is_all_fields(list, range);
+    }
+    // Otherwise the range is a whole-struct window: the smallest node spanning
+    // it is the struct itself (range hugs one `struct_item`), its field list,
+    // or a container holding one or more whole structs plus their leading
+    // `#[derive]` / `#[serde]` attribute siblings.
+    let Some(container) = root.descendant_for_byte_range(range.start, range.end) else {
+        return false;
+    };
+    match container.kind() {
+        "field_declaration_list" => field_list_range_is_all_fields(container, range),
+        "struct_item" => struct_body_in_range_is_all_fields(container, range),
+        _ => range_covers_only_field_structs(container, range),
+    }
+}
+
+/// Returns true when one `struct_item`'s body covers only field declarations
+/// within `range`.
+fn struct_body_in_range_is_all_fields(struct_item: Node<'_>, range: ByteRange) -> bool {
+    field_declaration_list_of(struct_item)
+        .is_some_and(|list| field_list_range_is_all_fields(list, range))
+}
+
+/// Returns true when every named child of `container` that `range` covers is a
+/// whole struct whose in-range body is only field declarations, or a leading
+/// attribute sibling — and at least one field is covered. Any function, impl,
+/// or other item keeps the cluster.
+fn range_covers_only_field_structs(container: Node<'_>, range: ByteRange) -> bool {
+    let mut cursor = container.walk();
+    let mut saw_field = false;
+    for child in container.named_children(&mut cursor) {
+        if !node_intersects_range(child, range) {
+            continue;
+        }
+        match child.kind() {
+            "struct_item" => {
+                let Some(list) = field_declaration_list_of(child) else {
+                    return false;
+                };
+                if node_intersects_range(list, range) {
+                    if !field_list_range_is_all_fields(list, range) {
+                        return false;
+                    }
+                    saw_field = true;
+                }
+            }
+            "attribute_item" => {}
+            kind if kind.ends_with("comment") => {}
+            _ => return false,
+        }
+    }
+    saw_field
+}
+
+/// Returns the direct `field_declaration_list` child of a `struct_item`, or
+/// `None` for a tuple/unit struct that has none.
+fn field_declaration_list_of(struct_item: Node<'_>) -> Option<Node<'_>> {
+    let mut cursor = struct_item.walk();
+    let list = struct_item
+        .named_children(&mut cursor)
+        .find(|child| child.kind() == "field_declaration_list");
+    list
+}
+
+/// Returns true when every named child of `list` that intersects `range` is a
+/// `field_declaration` or its `attribute_item`, with at least one field
+/// present.
+fn field_list_range_is_all_fields(list: Node<'_>, range: ByteRange) -> bool {
+    let mut cursor = list.walk();
+    let mut fields = 0_usize;
+    for member in list.named_children(&mut cursor) {
+        if !node_intersects_range(member, range) {
+            continue;
+        }
+        match member.kind() {
+            "field_declaration" => fields = fields.saturating_add(1),
+            "attribute_item" => {}
+            kind if kind.ends_with("comment") => {}
+            _ => return false,
+        }
+    }
+    fields >= 1
+}

--- a/crates/deslop-core/src/pipeline/corpus.rs
+++ b/crates/deslop-core/src/pipeline/corpus.rs
@@ -291,6 +291,27 @@ pub fn language_ids() -> Vec<&'static str> {
     default_parsers().iter().map(|parser| parser.id()).collect()
 }
 
+/// Detected display language id for a source path, derived from the parser
+/// registry's declared extensions, or `"unknown"`. The single labeling map
+/// shared by every human/agent surface (the HTML report highlighter, MCP page
+/// summaries) so the detected language can never drift between them — or from
+/// the registry when a language is added ([PIPELINE-LANG-TRAIT], #164).
+#[must_use]
+pub fn language_for_path(path: &Path) -> &'static str {
+    let Some(extension) = path.extension().and_then(|ext| ext.to_str()) else {
+        return "unknown";
+    };
+    default_parsers()
+        .iter()
+        .find(|parser| {
+            parser
+                .file_extensions()
+                .iter()
+                .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+        })
+        .map_or("unknown", |parser| parser.id())
+}
+
 /// Source-file extensions of every registered parser, in registry order.
 /// Single source of truth for any surface that filters filesystem events
 /// by extension — e.g. the LSP live watcher — so the watched set can

--- a/crates/deslop-core/src/pipeline/mod.rs
+++ b/crates/deslop-core/src/pipeline/mod.rs
@@ -20,6 +20,6 @@ mod session;
 mod signatures;
 
 pub use config::{EmbeddingSettings, PipelineConfig};
-pub use corpus::{language_ids, watched_source_extensions};
+pub use corpus::{language_for_path, language_ids, watched_source_extensions};
 pub use run::{debug_ast_dump, run};
 pub use session::PipelineSession;

--- a/crates/deslop-core/src/render/html.rs
+++ b/crates/deslop-core/src/render/html.rs
@@ -20,6 +20,7 @@ use std::{
 use crate::{
     buckets::{bucket_labels, classify, ClusterKind},
     clone_category::CloneCategory,
+    pipeline::language_for_path,
     render::{
         highlight::highlight_snippet,
         html_css::{REPORT_CSS, SITE_CSS},
@@ -597,22 +598,4 @@ fn digits(value: usize) -> usize {
         n /= 10;
     }
     count
-}
-
-/// Maps a file extension to a language id understood by the
-/// highlighter. Unknown extensions return `"unknown"`, which the
-/// highlighter degrades to plain escaped text.
-fn language_for_path(path: &Path) -> &'static str {
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("cs") => "csharp",
-        Some("rs") => "rust",
-        Some("py") => "python",
-        Some("dart") => "dart",
-        _ => "unknown",
-    }
 }

--- a/crates/deslop-core/src/render/html_footer.rs
+++ b/crates/deslop-core/src/render/html_footer.rs
@@ -105,8 +105,13 @@ fn write_boilerplate_hints(out: &mut String, report: &Report, escape: fn(&str) -
 }
 
 /// Embedded schema-doc markdown so agents can self-document the JSON
-/// schema without a second round-trip.
+/// schema without a second round-trip. Skipped when the report omits the
+/// `schema_doc` (the CLI drops it — it is served on demand, #110/#111), so a
+/// human HTML report never carries an empty schema section.
 fn write_schema(out: &mut String, report: &Report, escape: fn(&str) -> String) {
+    if report.schema_doc.is_empty() {
+        return;
+    }
     let _ = write!(
         out,
         "<h3>Schema reference</h3><pre>{doc}</pre>",

--- a/crates/deslop-mcp/src/page.rs
+++ b/crates/deslop-mcp/src/page.rs
@@ -8,9 +8,8 @@
 //! by id is what keeps a single page survivable on a real workspace
 //! (where the unsliced report has hit 4 MB+ in production).
 
-use std::path::Path;
-
 use deslop_core::{
+    pipeline::language_for_path,
     report::{Report, ReportCluster},
     wire_generated::{
         ClusterSummary, OccurrenceSummary, ReportPage, ReportPageFilters, ReportPageInfo,
@@ -153,22 +152,5 @@ fn cluster_summary_from(cluster: &ReportCluster) -> ClusterSummary {
         occurrence_count,
         language: language.to_owned(),
         first_occurrence,
-    }
-}
-
-/// Maps a file extension to a registered language id. Mirrors the
-/// renderer's `language_for_path` so MCP summaries stay consistent
-/// with the HTML report.
-fn language_for_path(path: &Path) -> &'static str {
-    match path
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(str::to_ascii_lowercase)
-        .as_deref()
-    {
-        Some("cs") => "csharp",
-        Some("rs") => "rust",
-        Some("py") => "python",
-        _ => "unknown",
     }
 }

--- a/crates/deslop-mcp/tests/dart_language_label_over_mcp.rs
+++ b/crates/deslop-mcp/tests/dart_language_label_over_mcp.rs
@@ -1,0 +1,72 @@
+//! Real-binary MCP regression for GH #164.
+//!
+//! Drives the actual `deslop-lsp` + `deslop-mcp` binaries (never a fake
+//! server) against the `dart-mcp` fixture and asserts that a hand-written
+//! Dart cluster reports `language: "dart"` over the `report-query` wire.
+//!
+//! The MCP page summary derived each cluster's language from a hand-maintained
+//! extension → id map in `deslop-mcp` that omitted `.dart` (a drifted copy of
+//! the renderer's mapping). Every Dart cluster therefore surfaced as
+//! `language: "unknown"`, breaking the language label and the `report-query`
+//! language filter on Dart repos even after the enum gained `dart` (#170/#198).
+
+#![cfg(unix)]
+
+use anyhow::{ensure, Result};
+use serde_json::{json, Value};
+
+mod common;
+use common::{call_tool, copied_fixture_named, initialized_mcp, spawn_lsp_and_wait_for_socket};
+
+/// The `language` label of every returned cluster whose representative
+/// occurrence is a `.dart` file.
+fn dart_cluster_languages(page: &Value) -> Vec<String> {
+    page.get("clusters")
+        .and_then(Value::as_array)
+        .map(|clusters| {
+            clusters
+                .iter()
+                .filter(|cluster| first_occurrence_is_dart(cluster))
+                .filter_map(|cluster| cluster.get("language").and_then(Value::as_str))
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// True when a cluster's `first_occurrence.path` is a `.dart` file.
+fn first_occurrence_is_dart(cluster: &Value) -> bool {
+    cluster
+        .pointer("/first_occurrence/path")
+        .and_then(Value::as_str)
+        .and_then(|path| std::path::Path::new(path).extension()?.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("dart"))
+}
+
+#[test]
+fn dart_clusters_report_dart_language_over_mcp() -> Result<()> {
+    let workspace = copied_fixture_named("dart-mcp")?;
+    let _lsp_guard = spawn_lsp_and_wait_for_socket(workspace.path())?;
+
+    let mut mcp = initialized_mcp(workspace.path())?;
+    let page = call_tool(
+        &mut mcp,
+        "report-query",
+        &json!({ "offset": 0, "limit": 50 }),
+    )?;
+    let languages = dart_cluster_languages(&page);
+
+    ensure!(
+        !languages.is_empty(),
+        "fixture must surface at least one hand-written Dart cluster so the \
+         language label is exercised: {page}"
+    );
+    for language in &languages {
+        ensure!(
+            language == "dart",
+            "issue #164: a cluster whose representative occurrence is a `.dart` \
+             file must report language=\"dart\", not {language:?}; full page: {page}"
+        );
+    }
+    Ok(())
+}

--- a/crates/deslop/src/main.rs
+++ b/crates/deslop/src/main.rs
@@ -271,6 +271,11 @@ fn run_cli() -> Result<()> {
     };
     let mut report = outcome.report;
     apply_threshold(&args, &mut report)?;
+    // The static schema_doc is served on demand (schema-doc / deslop://schema,
+    // #110/#111); inlining ~13 KB of it into every rendered report drowns the
+    // actual content and bloats the file. Drop it from the CLI output — the
+    // wire field stays present-but-empty.
+    report.schema_doc.clear();
     let split_by_language = resolve_split_by_language(&args)?;
     let mut written = emit_all(&report, &formats, &output, &args.path, split_by_language)?;
     if let Some(delta) = outcome.delta.as_ref() {

--- a/crates/deslop/tests/cli/invocation.rs
+++ b/crates/deslop/tests/cli/invocation.rs
@@ -136,7 +136,9 @@ fn cli_json_report_omits_inline_schema_doc() -> Result<()> {
     let schema_doc = value
         .get("schema_doc")
         .and_then(Value::as_str)
-        .ok_or_else(|| anyhow::anyhow!("schema_doc field must remain present in the wire contract"))?;
+        .ok_or_else(|| {
+            anyhow::anyhow!("schema_doc field must remain present in the wire contract")
+        })?;
     assert!(
         schema_doc.is_empty(),
         "the CLI report must not inline the static schema_doc (it drowns the \

--- a/crates/deslop/tests/cli/invocation.rs
+++ b/crates/deslop/tests/cli/invocation.rs
@@ -119,6 +119,38 @@ fn default_run_emits_all_three_formats() -> Result<()> {
     Ok(())
 }
 
+// Regression for the schema_doc output-bloat report: the CLI report must NOT
+// inline the multi-kilobyte static schema_doc. It drowns the actual report
+// content on inspection and duplicates a document #110/#111 already moved
+// behind `schema-doc` / `deslop://schema` (served on demand, never inlined in
+// a report). The `schema_doc` field stays present-but-empty so the wire
+// contract is unchanged.
+#[test]
+fn cli_json_report_omits_inline_schema_doc() -> Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let out = outputs_under(tmp.path());
+    let mut cmd = deslop_command(&fixture("csharp-small"), &tmp.path().join("report"))?;
+    let _assertion = cmd.args(["--min-nodes", "8"]).assert().success();
+    let json = fs::read_to_string(&out.json)?;
+    let value: Value = serde_json::from_str(&json)?;
+    let schema_doc = value
+        .get("schema_doc")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("schema_doc field must remain present in the wire contract"))?;
+    assert!(
+        schema_doc.is_empty(),
+        "the CLI report must not inline the static schema_doc (it drowns the \
+         report and is served on demand via schema-doc / deslop://schema); got \
+         {} chars",
+        schema_doc.len()
+    );
+    assert!(
+        !json.contains("Deslop Report Context"),
+        "the schema_doc markdown must not appear inline in the CLI report body"
+    );
+    Ok(())
+}
+
 // Implements [OUTPUT-HUMAN-HTML] preview cap: snippets longer than the
 // soft cap render the first window inline and fold the remainder into a
 // `<details>` summary so a 300-line clone does not stretch the page.

--- a/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/host.rs
+++ b/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/host.rs
@@ -1,0 +1,26 @@
+//! Distinct serde data-model structs — different fields, not duplication.
+use serde::{Deserialize, Serialize};
+
+/// Host installer channels.
+#[derive(Serialize, Deserialize)]
+pub struct HostInstaller {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub brew: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scoop: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub winget: Option<String>,
+}
+
+/// Source reference.
+#[derive(Serialize, Deserialize)]
+pub struct SourceRef {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}

--- a/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/manifest.rs
+++ b/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/manifest.rs
@@ -1,0 +1,28 @@
+//! Distinct serde data-model structs — different fields, not duplication.
+use serde::{Deserialize, Serialize};
+
+/// Build target descriptor.
+#[derive(Serialize, Deserialize)]
+pub struct ManifestTarget {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub toolchain: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product: Option<String>,
+}
+
+/// Platform binary descriptor.
+#[derive(Serialize, Deserialize)]
+pub struct PlatformBinary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binary_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platforms: Option<String>,
+}

--- a/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/verbatim_a.rs
+++ b/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/verbatim_a.rs
@@ -1,0 +1,9 @@
+/// A design-token palette duplicated verbatim across two modules.
+pub struct ThemePalette {
+    pub primary: String,
+    pub secondary: String,
+    pub tertiary: String,
+    pub quaternary: String,
+    pub quinary: String,
+    pub senary: String,
+}

--- a/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/verbatim_b.rs
+++ b/crates/deslop/tests/fixtures/rust-issue-224-struct-fields/verbatim_b.rs
@@ -1,0 +1,9 @@
+/// A design-token palette duplicated verbatim across two modules.
+pub struct ThemePalette {
+    pub primary: String,
+    pub secondary: String,
+    pub tertiary: String,
+    pub quaternary: String,
+    pub quinary: String,
+    pub senary: String,
+}

--- a/crates/deslop/tests/rust_issue_224_struct_field_runs.rs
+++ b/crates/deslop/tests/rust_issue_224_struct_field_runs.rs
@@ -1,0 +1,71 @@
+//! E2E regression for GH #224.
+//!
+//! Deslop clustered runs of **distinct** Rust struct field declarations —
+//! different field names, different types — as duplicated code, because AST
+//! normalization collapses identifiers, types, and literals. The normalized
+//! Merkle hash of one serde field run
+//! (`#[serde(skip_serializing_if = "Option::is_none")] pub x: Option<String>`,
+//! repeated) is identical to that of an unrelated run with different field
+//! names, so the two cluster as `structural_only` duplication. These are not
+//! duplicated logic — they are different parts of a data model and no refactor
+//! removes them, yet they dominated the duplication metric on serde-heavy
+//! repos.
+//!
+//! Acceptance: distinct struct-field declaration runs must NOT be reported as
+//! duplication (same boilerplate tier as the existing import / `using` /
+//! Dart-class-field filters), while a *byte-identical* copy-pasted struct must
+//! still surface — the raw-bytes-differ escape hatch that keeps genuine
+//! copy-paste visible.
+
+mod common;
+use crate::common::*;
+
+/// `min-nodes` low enough to admit the per-struct and field-run subtrees the
+/// fixture produces, matching the granularity issue #224 reports.
+const MIN_NODES: u32 = 20;
+
+#[test]
+fn distinct_struct_field_runs_are_not_reported_as_duplication() -> Result<()> {
+    let scan_root = fixture("rust-issue-224-struct-fields");
+    let report = run_report(&scan_root, MIN_NODES)?;
+
+    // The two serde-model files hold only distinct field-declaration runs:
+    // after the fix no visible cluster may touch them.
+    let leaked: Vec<String> = clusters(&report)
+        .iter()
+        .filter(|cluster| {
+            occurrence_files(cluster)
+                .iter()
+                .any(|file| file == "host.rs" || file == "manifest.rs")
+        })
+        .map(|cluster| {
+            format!(
+                "cluster {id} bucket={bucket} files={files:?}",
+                id = cluster_id(cluster),
+                bucket = cluster_bucket(cluster),
+                files = occurrence_files(cluster),
+            )
+        })
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "issue #224: distinct Rust struct-field declaration runs are different \
+         parts of a data model, not extractable duplication, and must not be \
+         reported. Offending clusters: {leaked:#?}\nfull report: {report:#}"
+    );
+
+    // The filter must stay targeted: a byte-identical copy-pasted struct is
+    // genuine duplication and must still surface (the raw-bytes-differ escape
+    // hatch). If this regresses, the filter is hiding real struct clones.
+    let verbatim_surfaces = clusters(&report).iter().any(|cluster| {
+        let files = occurrence_files(cluster);
+        files.iter().any(|file| file == "verbatim_a.rs")
+            && files.iter().any(|file| file == "verbatim_b.rs")
+    });
+    assert!(
+        verbatim_surfaces,
+        "a byte-identical copy-pasted struct must still surface as genuine \
+         duplication (raw-bytes-differ escape hatch): {report:#}"
+    );
+    Ok(())
+}

--- a/docs/specs/noise.md
+++ b/docs/specs/noise.md
@@ -246,6 +246,21 @@ when every member is a contiguous run of `match` arms under a single
 bytes. The distinct-pattern and byte-divergence guards keep a verbatim
 copy-pasted run of arms visible as a genuine clone.
 
+### [CLONE-NOISE-RUST-STRUCT-FIELDS] Struct field-declaration runs
+A struct's field list encodes a data model's *shape*, not extractable duplicate
+logic: after identifier, type, and literal normalisation `pub a: Option<String>`
+collapses to the same subtree as `pub b: Option<String>`, so unrelated runs of
+distinct fields — and whole structs that are nothing but such fields — cluster as
+`structural_only` on serde-heavy or polyglot repos and dominate the duplication
+metric with matches no refactor can remove. A cluster is suppressed when every
+member covers only Rust struct field declarations — a run of sibling fields
+inside one `field_declaration_list`, or one or more whole `struct_item`s whose
+in-range body is nothing but `field_declaration` nodes (their `#[derive]` /
+`#[serde]` attributes and doc comments are trivia) — and at least two members
+differ in raw bytes. The byte-divergence guard keeps a verbatim copy-pasted
+struct visible as a genuine clone. This is the Rust counterpart of the Dart
+class-field filter ([CLONE-NOISE-DART-DATA-TABLE-LITERAL]); see GH #224.
+
 ## Performance
 
 ### [CLONE-NOISE-REPARSE-CACHE] Parse-once filter cache


### PR DESCRIPTION
## TLDR
Eliminates three classes of report defect — serde struct-field false positives (#224), the multi-kilobyte `schema_doc` that drowned every CLI report, and Dart clusters mislabeled `language: "unknown"` over MCP (#164) — and folds in pending CI/release cache tuning.

## Details

### #224 — distinct Rust struct field-declaration runs no longer counted as duplication
After identifier/type/literal normalization, `pub a: Option<String>` hashes the same as `pub b: Option<String>`, so unrelated serde field runs (and whole structs that are nothing but such fields) clustered as `structural_only` and dominated the duplication metric on serde-heavy / polyglot repos with matches no refactor can remove.

- New filter `is_rust_struct_field_declaration_cluster` in `crates/deslop-core/src/cluster_filters/rust.rs`, wired into `rust_noise` in `cluster_filters/mod.rs`. It suppresses a cluster only when every member covers **only** Rust struct field declarations — a run of sibling fields inside one `field_declaration_list`, or one or more whole `struct_item`s whose in-range body is nothing but `field_declaration` nodes (their `#[derive]`/`#[serde]` attributes and doc comments treated as trivia). The existing `raw_snippet_texts_differ` guard keeps a **byte-identical** copy-pasted struct visible as genuine duplication.
- Spec: new `[CLONE-NOISE-RUST-STRUCT-FIELDS]` section in `docs/specs/noise.md` (Rust counterpart of the Dart `[CLONE-NOISE-DART-DATA-TABLE-LITERAL]` filter).

### schema_doc — CLI report no longer inlines the ~13 KB static schema document
The CLI's JSON/HTML report embedded the full `schema_doc` markdown (~13.5 KB) on every run, drowning the actual report and duplicating a document #110/#111 already moved behind `schema-doc` / `deslop://schema` (served on demand, never inlined in a report page).

- `crates/deslop/src/main.rs` clears `report.schema_doc` before rendering. The wire field stays **present-but-empty**, so the schema contract is unchanged.
- `crates/deslop-core/src/render/html_footer.rs` skips the "Schema reference" section when `schema_doc` is empty, so a human HTML report never carries an empty schema block.
- Not changed: the LSP/MCP path. `deslop-lsp` still populates `schema_doc`, so the MCP `schema-doc` tool and `deslop://schema` resource keep serving it on demand (`crates/deslop-mcp/tests/cli.rs::issue_110_*` still passes).

### #164 — one canonical `language_for_path`, fixing Dart `"unknown"` over MCP
`deslop-mcp/src/page.rs` carried a hand-maintained extension→language map (a drifted copy of the renderer's) that omitted `.dart`, so every Dart cluster surfaced as `language: "unknown"` over `report-query`/`report-get` even after the enum gained `dart` (#170/#198).

- New canonical `language_for_path` in `crates/deslop-core/src/pipeline/corpus.rs`, **derived from the parser registry** (`default_parsers().file_extensions()`) so it can never drift from the supported-language set ([PIPELINE-LANG-TRAIT]); re-exported via `deslop_core::pipeline`.
- Both drifted copies deleted: `render/html.rs` and `deslop-mcp/src/page.rs` now call the canonical helper (removing a self-duplication this very tool would flag).

### CI / release infrastructure (pending tweaks carried in this branch)
- `.github/workflows/ci.yml`: artifact retention `7 → 1` day; Gradle SDK caching on the JetBrains gate.
- `.github/workflows/release.yml`: release artifact retention `→ 1` day; release cache key keyed on `Cargo.lock` only so the tag-time version stamp of `Cargo.toml` no longer busts the cache.

**No breaking changes.** No public CLI flag, MCP tool, or wire field was removed; `schema_doc` remains a required wire field (now empty in CLI output). One new spec ID added (`[CLONE-NOISE-RUST-STRUCT-FIELDS]`).

Closes #224. Closes #164.

## How Do The Automated Tests Prove It Works?

- **`crates/deslop/tests/rust_issue_224_struct_field_runs.rs::distinct_struct_field_runs_are_not_reported_as_duplication`** — black-box CLI run over a fixture of distinct serde structs (`host.rs`, `manifest.rs`) plus a byte-identical copied struct (`verbatim_a.rs`/`verbatim_b.rs`). Asserts (a) **no** visible cluster touches the distinct-field files (the 5 `structural_only` false positives that surfaced before the fix are gone) and (b) the byte-identical struct **still** surfaces as a cluster spanning both files — proving the suppression is targeted, not a blanket hide.
- **`crates/deslop/tests/cli/invocation.rs::cli_json_report_omits_inline_schema_doc`** — runs the CLI over `csharp-small`, parses the emitted `report.json`, and asserts `schema_doc` is empty and the document body string (`"Deslop Report Context"`) does not appear inline. `default_run_emits_all_three_formats` still asserts the `schema_doc` field is present, pinning the present-but-empty contract.
- **`crates/deslop-mcp/tests/dart_language_label_over_mcp.rs::dart_clusters_report_dart_language_over_mcp`** — drives the **real** `deslop-lsp` + `deslop-mcp` binaries against the `dart-mcp` fixture and asserts every cluster whose representative occurrence is a `.dart` file reports `language: "dart"` (was `"unknown"`). `crates/deslop-mcp/tests/cli.rs::report_query_accepts_dart_language_filter` and `dart_generated_fp_over_mcp.rs` continue to pass.
- **Regression**: the existing Rust noise filters (`rust_issue_147/150/154/176`, `rust_test_boilerplate`, `rust_trait_boilerplate`), metric tests, sibling/collapse tests, the `#110` schema-omission test, and the full HTML render path all pass. `make ci` is green locally — `make fmt CHECK=1`, `make lint` (clippy `-D pedantic`), `make test` (coverage: core 94.3% / deslop 97.1% / lsp 95.0% / mcp 97.5%, all at or above threshold + slack), `make build`, the Deslop self-duplication gate (`deslop . --no-color`, exit 0 under the 20% budget), and `make deployment-verify` (31 verifier tests).
