### PR TITLE
Stamp every workspace crate in Cargo.lock (fix v0.21.0 release --locked failure)

### DIFF
--- a/scripts/stamp-release-version.mjs
+++ b/scripts/stamp-release-version.mjs
@@ -5,7 +5,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 
-const workspacePackages = new Set(["deslop", "deslop-core", "deslop-lsp", "deslop-mcp"]);
 const nodeProjects = [
   "clients/vscode",
   "clients/vscode/webview-ui",
@@ -92,22 +91,21 @@ function replaceWorkspaceVersion(text, versionValue) {
 }
 
 function replaceLockVersions(text, versionValue) {
-  let currentPackage = "";
-  const seen = new Set();
-  const lines = text.split("\n").map((line) => {
-    if (line === "[[package]]") currentPackage = "";
-    const name = line.match(/^name = "([^"]+)"$/)?.[1];
-    if (name) currentPackage = name;
-    if (workspacePackages.has(currentPackage) && /^version = "/.test(line)) {
-      seen.add(currentPackage);
-      return `version = "${versionValue}"`;
-    }
-    return line;
+  // A workspace/path crate is a `[[package]]` block with no `source =` line
+  // (registry/git crates carry one). Deriving the set from the lock — rather
+  // than a hardcoded crate list — means a newly added workspace crate can never
+  // silently desync Cargo.lock from the stamped Cargo.toml and break the
+  // release's `cargo build --locked` (the deslop-test-support regression, #248).
+  const segments = text.split("[[package]]");
+  let stamped = 0;
+  const out = segments.map((segment, index) => {
+    if (index === 0 || /\nsource = /.test(segment)) return segment;
+    const replaced = segment.replace(/(\nversion = ")[^"]+(")/, `$1${versionValue}$2`);
+    if (replaced !== segment) stamped++;
+    return replaced;
   });
-  for (const packageName of workspacePackages) {
-    if (!seen.has(packageName)) throw new Error(`Cargo.lock is missing ${packageName}`);
-  }
-  return lines.join("\n");
+  if (stamped === 0) throw new Error("Cargo.lock has no workspace crates to stamp");
+  return out.join("[[package]]");
 }
 
 function parseArgs(args) {

--- a/scripts/test-release-version-stamping.mjs
+++ b/scripts/test-release-version-stamping.mjs
@@ -13,6 +13,7 @@ const version = "9.8.7-test.1";
 const tests = [
   sourceProjectsUseVersionPlaceholder,
   stamperSetsEveryProjectVersion,
+  stamperStampsEveryWorkspaceCrateInLock,
   stamperRejectsInvalidVersion,
 ];
 
@@ -74,6 +75,32 @@ function stamperSetsEveryProjectVersion(work) {
   assertJsonVersion(work, "clients/vscode/webview-ui/package-lock.json", version);
   assertJsonVersion(work, "site/package.json", version);
   assertJsonVersion(work, "site/package-lock.json", version);
+}
+
+// Every workspace/path crate (a Cargo.lock `[[package]]` with no `source =`
+// line, i.e. not from a registry/git) must be stamped. A hardcoded crate list
+// silently skips any crate it omits, leaving Cargo.lock out of sync with the
+// stamped Cargo.toml so the release's `cargo build --locked` fails — the
+// regression a new workspace crate (deslop-test-support) introduced.
+function stamperStampsEveryWorkspaceCrateInLock(work) {
+  copyStampInputs(work);
+  const result = spawnSync("node", [stamper, version, "--root", work], { encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`stamper failed: ${result.stderr}`);
+
+  const lock = read(work, "Cargo.lock");
+  let workspaceCrates = 0;
+  for (const block of lock.split("[[package]]").slice(1)) {
+    const name = block.match(/\nname = "([^"]+)"/)?.[1];
+    if (!name || /\nsource = /.test(block)) continue;
+    workspaceCrates++;
+    const lockVersion = block.match(/\nversion = "([^"]+)"/)?.[1];
+    if (lockVersion !== version) {
+      throw new Error(
+        `workspace crate ${name} left at ${lockVersion} in Cargo.lock, expected ${version}`,
+      );
+    }
+  }
+  if (workspaceCrates === 0) throw new Error("Cargo.lock had no workspace crates to stamp");
 }
 
 function stamperRejectsInvalidVersion(work) {


### PR DESCRIPTION
## TLDR
Fix the release version-stamper so it stamps every workspace crate in `Cargo.lock` — the hardcoded crate list omitted `deslop-test-support` (added in #247) and broke the v0.21.0 release build with `cargo build --release --locked`.

## Details
The release pipeline stamps `[workspace.package] version` in `Cargo.toml` to the tag version, then runs `cargo build --release --locked`. `scripts/stamp-release-version.mjs` also rewrites the matching `Cargo.lock` entries — but `replaceLockVersions` used a hardcoded set `{deslop, deslop-core, deslop-lsp, deslop-mcp}`. The `deslop-test-support` crate added by #247 (after v0.20.0) was not in that set, so its `Cargo.lock` version stayed `0.0.0-dev` while `Cargo.toml` became `0.21.0`. `--locked` then refused to update the lock and the Build job failed in ~8s on every platform (`error: cannot update the lock file ... because --locked was passed`). v0.21.0 was the first release to include that crate, so it was the first to hit the latent bug.

- `scripts/stamp-release-version.mjs`: rewrote `replaceLockVersions` to derive the workspace set from the lock itself — every `[[package]]` block with no `source =` line is a workspace/path crate and is stamped. Removed the now-dead hardcoded `workspacePackages` set. This is drift-proof: a newly added workspace crate can never again silently desync `Cargo.lock` from the stamped `Cargo.toml`.

No product code changes; release-infra only. No breaking changes.

## How Do The Automated Tests Prove It Works?
- New `scripts/test-release-version-stamping.mjs::stamperStampsEveryWorkspaceCrateInLock` copies the stamp inputs to a temp dir, runs the stamper, then parses the stamped `Cargo.lock` and asserts **every** source-less `[[package]]` (workspace/path crate) carries the stamped version. Before the fix it failed with `workspace crate deslop-test-support left at 0.0.0-dev`; after the fix all four stamper tests pass. Because the assertion enumerates source-less crates from the lock rather than a fixed list, it will also catch the *next* crate addition.
- This test runs in CI via `make deployment-verify` (`Makefile:217`), which `make ci` invokes.
- Verified locally end-to-end: after `node scripts/stamp-release-version.mjs 0.21.0`, `deslop-test-support` is stamped to `0.21.0` in `Cargo.lock` and `cargo metadata --locked` resolves cleanly (the exact lock-resolution step that failed in the release), then the working tree was restored.
