### PR TITLE
Fix #267: register bundled deslop-mcp with VS Code's MCP API (replace dead contributes.mcpServers)

### DIFF
--- a/clients/vscode/package-lock.json
+++ b/clients/vscode/package-lock.json
@@ -34,7 +34,7 @@
         "v8-to-istanbul": "^9.3.0"
       },
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -12,7 +12,7 @@
     "directory": "clients/vscode"
   },
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Linters",
@@ -548,14 +548,10 @@
         }
       }
     },
-    "mcpServers": [
+    "mcpServerDefinitionProviders": [
       {
         "id": "deslop",
-        "name": "Deslop",
-        "description": "Live duplicate-code analysis for the current workspace.",
-        "command": "${extensionPath}/bin/${platform}/deslop-mcp",
-        "args": [],
-        "env": {}
+        "label": "Deslop"
       }
     ]
   },

--- a/clients/vscode/src/extension.ts
+++ b/clients/vscode/src/extension.ts
@@ -22,6 +22,7 @@ import {
   BinarySettings,
 } from "./binary";
 import { log, logError, initOutputChannel } from "./logging";
+import { wireMcpRegistration } from "./mcpRegistration";
 import { ReportStore } from "./reportStore";
 import { registerCommands } from "./commands/register";
 import {
@@ -53,6 +54,7 @@ import {
 let client: LanguageClient | undefined;
 let resolvedLsp: ResolvedBinary | undefined;
 let resolvedMcp: ResolvedBinary | undefined;
+let mcpDefinition: vscode.McpStdioServerDefinition | undefined;
 let activeReportStore: ReportStore | undefined;
 
 const REPORT_READY_CONTEXT = "deslop.reportReady";
@@ -83,6 +85,7 @@ export interface ExtensionApi {
   readonly client: LanguageClient | undefined;
   readonly resolvedLsp: ResolvedBinary | undefined;
   readonly resolvedMcp: ResolvedBinary | undefined;
+  readonly mcpDefinition: vscode.McpStdioServerDefinition | undefined;
   readonly reportStore: ReportStore | undefined;
 }
 
@@ -209,6 +212,10 @@ export async function activate(
     return currentApi();
   }
 
+  // [VSIX-MCP-INTEGRATION] Register the bundled MCP with VS Code's MCP API
+  // so agent hosts launch it by absolute path, never a $PATH lookup (#267).
+  mcpDefinition = wireMcpRegistration(context, resolvedMcp, resolveWorkspaceRoot());
+
   context.subscriptions.push(wireDirtyDocuments(reportStore));
 
   const decorations = new DecorationManager(reportStore);
@@ -274,6 +281,9 @@ export function currentApi(): ExtensionApi {
     },
     get resolvedMcp() {
       return resolvedMcp;
+    },
+    get mcpDefinition() {
+      return mcpDefinition;
     },
     get reportStore() {
       return activeReportStore;

--- a/clients/vscode/src/mcpRegistration.ts
+++ b/clients/vscode/src/mcpRegistration.ts
@@ -1,0 +1,48 @@
+// [VSIX-MCP-INTEGRATION] Registers the resolved deslop-mcp with VS Code's
+// MCP API so MCP-aware agent hosts (Copilot Chat, Claude Code) launch the
+// bundled binary by absolute path — never a bare-name $PATH lookup (#267).
+// The provider id must match `contributes.mcpServerDefinitionProviders` in
+// package.json; VS Code throws at registration otherwise, failing loudly.
+
+import * as vscode from "vscode";
+import { ResolvedBinary } from "./binary";
+import { log } from "./logging";
+
+function deslopServerDefinition(
+  mcp: ResolvedBinary,
+  workspaceRoot: string,
+): vscode.McpStdioServerDefinition {
+  return new vscode.McpStdioServerDefinition(
+    "Deslop",
+    mcp.path,
+    ["--root", workspaceRoot],
+    {},
+    mcp.version,
+  );
+}
+
+/// Wires the single "deslop" stdio MCP server against the given workspace
+/// root — the same root the LSP analyses. Returns the registered definition
+/// (exposed on the extension API for tests), or undefined when there is no
+/// resolved binary or no open workspace to analyse.
+export function wireMcpRegistration(
+  context: vscode.ExtensionContext,
+  mcp: ResolvedBinary | undefined,
+  workspaceRoot: string | undefined,
+): vscode.McpStdioServerDefinition | undefined {
+  if (!mcp || workspaceRoot === undefined) {
+    log("mcp registration skipped", {
+      binaryResolved: mcp !== undefined,
+      workspaceOpen: workspaceRoot !== undefined,
+    });
+    return undefined;
+  }
+  const definition = deslopServerDefinition(mcp, workspaceRoot);
+  context.subscriptions.push(
+    vscode.lm.registerMcpServerDefinitionProvider("deslop", {
+      provideMcpServerDefinitions: () => [definition],
+    }),
+  );
+  log("mcp registered", { source: mcp.source, version: mcp.version });
+  return definition;
+}

--- a/clients/vscode/src/test/suite/activation.e2e.test.ts
+++ b/clients/vscode/src/test/suite/activation.e2e.test.ts
@@ -1,8 +1,13 @@
 // E2E: activation path — extension activates on fixture workspace, status bar appears,
-// tree populates with the sample cluster, bubble commands exist.
+// tree populates with the sample cluster, bubble commands exist, and the bundled
+// deslop-mcp is registered with VS Code's MCP API.
 
 import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import * as vscode from "vscode";
+import { ExtensionApi } from "../../extension";
+import { activateExtension } from "./helpers";
 
 // [VSIX-ACTIVATION]
 suite("activation", () => {
@@ -29,5 +34,68 @@ suite("activation", () => {
     // command it routes to is installed.
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes("deslop.openWorstCluster"));
+  });
+});
+
+// The slice of package.json this suite asserts on. `Extension.packageJSON`
+// is typed `any` upstream; the cast keeps property access type-checked.
+interface ContributesManifest {
+  readonly contributes?: {
+    readonly mcpServerDefinitionProviders?: ReadonlyArray<{
+      readonly id: string;
+      readonly label: string;
+    }>;
+    readonly mcpServers?: unknown;
+  };
+}
+
+// [VSIX-MCP-INTEGRATION] Issue #267: VS Code silently drops unknown
+// contribution keys, so the legacy `contributes.mcpServers` block never
+// registered anything — MCP hosts fell back to a hand-written bare-name
+// config and failed with "Executable not found in $PATH: deslop-mcp".
+// Activation must register the resolved absolute bundled path via
+// `mcpServerDefinitionProviders` + `vscode.lm.registerMcpServerDefinitionProvider`.
+suite("mcp registration", () => {
+  test("activation registers the bundled deslop-mcp with VS Code's MCP API by absolute path", async () => {
+    const ext = vscode.extensions.getExtension("nimblesite.deslop-live");
+    assert.ok(ext, "extension should be registered");
+
+    const manifest = ext.packageJSON as ContributesManifest;
+    const providers = manifest.contributes?.mcpServerDefinitionProviders;
+    assert.ok(
+      providers?.some((provider) => provider.id === "deslop"),
+      "package.json must contribute mcpServerDefinitionProviders with id 'deslop'",
+    );
+    assert.equal(
+      manifest.contributes?.mcpServers,
+      undefined,
+      "contributes.mcpServers is not a VS Code contribution point and must be removed",
+    );
+
+    const api = await activateExtension();
+    assert.ok(api.resolvedMcp, "bundled deslop-mcp must resolve during activation");
+    // Widened cast so this test compiled — and failed red — before the fix
+    // added the field to ExtensionApi (fix-bug skill: test precedes fix).
+    const { mcpDefinition } = api as ExtensionApi & {
+      readonly mcpDefinition?: vscode.McpStdioServerDefinition;
+    };
+    assert.ok(
+      mcpDefinition,
+      "activation must expose the MCP server definition it registered",
+    );
+    assert.equal(mcpDefinition.label, "Deslop");
+    assert.equal(mcpDefinition.command, api.resolvedMcp.path);
+    assert.ok(
+      path.isAbsolute(mcpDefinition.command),
+      "MCP server must launch by absolute path, never a $PATH lookup",
+    );
+    assert.ok(
+      fs.existsSync(mcpDefinition.command),
+      "registered command must point at the real bundled binary",
+    );
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    assert.ok(workspaceRoot, "fixture workspace must be open");
+    assert.deepEqual(mcpDefinition.args, ["--root", workspaceRoot]);
+    assert.equal(mcpDefinition.version, api.resolvedMcp.version);
   });
 });

--- a/clients/vscode/src/test/unit/mcp-registration.unit.test.ts
+++ b/clients/vscode/src/test/unit/mcp-registration.unit.test.ts
@@ -1,0 +1,76 @@
+// Unit: wireMcpRegistration — the [VSIX-MCP-INTEGRATION] activation glue
+// (#267) that the E2E suite only reaches through the bundled dist/
+// entrypoint, so it never lands in the instrumented out/ coverage. Exercised
+// directly here (same pattern as extension-glue.unit.test.ts) against the
+// real vscode.lm API in the test host.
+
+import * as assert from "node:assert/strict";
+import * as vscode from "vscode";
+import { ResolvedBinary } from "../../binary";
+import { wireMcpRegistration } from "../../mcpRegistration";
+
+function resolvedMcpBinary(): ResolvedBinary {
+  return {
+    kind: "mcp",
+    componentId: "deslop-mcp",
+    source: "bundled",
+    path: "/tmp/deslop-mcp",
+    version: "1.0.0",
+  };
+}
+
+function fakeContext(): {
+  context: vscode.ExtensionContext;
+  subscriptions: vscode.Disposable[];
+} {
+  const subscriptions: vscode.Disposable[] = [];
+  const context = { subscriptions } as unknown as vscode.ExtensionContext;
+  return { context, subscriptions };
+}
+
+suite("mcp registration glue", () => {
+  test("wireMcpRegistration skips without a resolved binary", () => {
+    const { context, subscriptions } = fakeContext();
+    const definition = wireMcpRegistration(context, undefined, "/tmp/root");
+    assert.equal(definition, undefined);
+    assert.equal(subscriptions.length, 0, "nothing must be registered");
+  });
+
+  test("wireMcpRegistration skips without a workspace root", () => {
+    const { context, subscriptions } = fakeContext();
+    const definition = wireMcpRegistration(
+      context,
+      resolvedMcpBinary(),
+      undefined,
+    );
+    assert.equal(definition, undefined);
+    assert.equal(subscriptions.length, 0, "nothing must be registered");
+  });
+
+  test("wireMcpRegistration registers a stdio definition for the absolute binary path", () => {
+    const { context, subscriptions } = fakeContext();
+    const definition = wireMcpRegistration(
+      context,
+      resolvedMcpBinary(),
+      "/tmp/fixture-root",
+    );
+    try {
+      assert.ok(definition, "definition must be returned");
+      assert.ok(definition instanceof vscode.McpStdioServerDefinition);
+      assert.equal(definition.label, "Deslop");
+      assert.equal(definition.command, "/tmp/deslop-mcp");
+      assert.deepEqual(definition.args, ["--root", "/tmp/fixture-root"]);
+      assert.deepEqual(definition.env, {});
+      assert.equal(definition.version, "1.0.0");
+      assert.equal(
+        subscriptions.length,
+        1,
+        "provider disposable must be pushed onto the context",
+      );
+    } finally {
+      // Unregister so the host is left exactly as the activated extension
+      // configured it (its own provider stays live).
+      for (const disposable of subscriptions) disposable.dispose();
+    }
+  });
+});

--- a/docs/specs/vsix.md
+++ b/docs/specs/vsix.md
@@ -426,7 +426,7 @@ The extension posts VS Code notifications sparingly:
 
 ### [VSIX-MCP-INTEGRATION] MCP integration for in-VS-Code agents
 
-VS Code's MCP-aware agent hosts (Claude Code, Copilot Chat with MCP) auto-discover the bundled `deslop-mcp` binary through the VSIX's `contributes.mcpServers` manifest entry. The VSIX registers a single server named `deslop` with the same workspace root the LSP uses. The contributed command path must resolve to one of the manifest-approved artifacts; package verification fails if the contribution and `shipwright.json` drift. Agents inside VS Code can call `find-similar` and friends against the same live daemon the UI is driving — one analysis, two consumers, no duplication of state.
+VS Code's MCP-aware agent hosts (Claude Code, Copilot Chat with MCP) auto-discover the bundled `deslop-mcp` binary through the extension's `contributes.mcpServerDefinitionProviders` entry: activation calls `vscode.lm.registerMcpServerDefinitionProvider` with a single stdio server named `deslop` targeting the same workspace root the LSP uses (`--root`). The registered command is the absolute path produced by the manifest-driven resolver — the `deslop.mcpPath` override or the bundled binary, per `shipwright.json` sources — never a bare `$PATH` name, so the contribution cannot drift from the manifest. Agents inside VS Code can call `find-similar` and friends against the same live daemon the UI is driving — one analysis, two consumers, no duplication of state.
 
 Users who run an agent *outside* VS Code (e.g. Claude Code CLI in a terminal) can still wire the MCP up manually via the agent's own config. The VSIX bundling is convenience, not a lock-in.
 


### PR DESCRIPTION
## TLDR
Register the VSIX-bundled `deslop-mcp` with VS Code's MCP API by absolute path, replacing the dead `contributes.mcpServers` key that never registered anything — closes #267.

## Details
- **`clients/vscode/package.json`** — replaced `contributes.mcpServers` (not a VS Code contribution point; silently ignored since it shipped, which is why MCP hosts fell back to hand-written bare-name configs and failed with `Executable not found in $PATH: "deslop-mcp"`) with `contributes.mcpServerDefinitionProviders: [{ "id": "deslop", "label": "Deslop" }]`. Bumped `engines.vscode` `^1.90.0` → `^1.101.0`, the floor for `vscode.lm.registerMcpServerDefinitionProvider` / `McpStdioServerDefinition` (stable since VS Code 1.101). **Breaking:** minimum supported VS Code is now 1.101 (June 2025). `package-lock.json` carries the engines mirror only — no dependency changes.
- **`clients/vscode/src/mcpRegistration.ts`** (new) — `wireMcpRegistration()` builds a single stdio definition — `command` = the manifest-driven resolver's absolute path (`deslop.mcpPath` override or the bundled binary, per the `shipwright.json` sources order `user-setting` → `bundled`; the manifest lists no `path` source for the MCP), `args` = `--root <first workspace folder>` (the same root the LSP analyses), binary version passed through — and registers it as provider id `deslop`. Skips with a structured log when no binary resolved or no workspace is open. `[VSIX-MCP-INTEGRATION]`
- **`clients/vscode/src/extension.ts`** — calls `wireMcpRegistration` right after binary resolution (reusing `resolveWorkspaceRoot()`), pushes the provider disposable onto `context.subscriptions`, and exposes the registered `mcpDefinition` on `ExtensionApi`.
- **`docs/specs/vsix.md`** — the `[VSIX-MCP-INTEGRATION]` paragraph previously described auto-discovery "through the VSIX's `contributes.mcpServers` manifest entry", a mechanism that does not exist in VS Code; it now names the real contribution point + runtime registration and notes the command comes from the shipwright resolver, so contribution/manifest drift is impossible by construction. This also makes `clients/vscode/README.md`'s existing "the MCP server auto-registers with Copilot Chat" claim true as written.
- No spec IDs changed; no report format, CLI flag, or wire model touched.

## How Do The Automated Tests Prove It Works?
- **New E2E test** (`activation.e2e.test.ts`, `mcp registration` suite; runs in a real VS Code host against the staged bundle): asserts `package.json` contributes `mcpServerDefinitionProviders` with id `deslop` and the legacy `mcpServers` key is gone, then after activation asserts the exposed definition's `command` equals `api.resolvedMcp.path`, is absolute, exists on disk, `args` are exactly `["--root", <fixture workspace>]`, and `version` matches the resolved binary. Written first (fix-bug skill) and failed red on the pre-fix tree at the contribution assertion; green only after the fix. Registration genuinely reaching VS Code is proven by activation completing — `registerMcpServerDefinitionProvider` throws when the id is not contributed.
- **New unit tests** (`mcp-registration.unit.test.ts`): both skip paths (no binary / no workspace → returns `undefined`, nothing pushed onto `subscriptions`) and the register path (real `vscode.McpStdioServerDefinition` instance; label `Deslop`; exact `command`/`args`/`env`/`version`; exactly one disposable pushed) exercised directly from the instrumented `out/` tree, since E2E drives the `dist/` bundle.
- **Coverage:** `mcpRegistration.ts` at 100% lines/branches/functions; VSIX gate at 94.4% ≥ threshold (no ratchet change in `coverage-thresholds.json`).
- **Full local CI green:** `make fmt CHECK=1`, `make lint`, `make test` (Rust coverage: core 94.6%, cli 97.2%, lsp 94.6%, mcp 97.6%), `make build`, self-hosted duplication gate ("no duplication detected"), `make deployment-verify`, `_vsix-coverage` (409 passing), `_vsix-test` (409 passing), `_vsix-playwright-html`, `_vsix-webview-coverage` (96.3%), `vsix-package`, `_jetbrains-real-binary-test`, the JetBrains IDE-level integration test, and `_jetbrains-package`.

Closes #267.
