### PR TITLE
Export a constant install directory and gate PATH/env injection with an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ lint: typediagram-gen
 	@bash scripts/taxonomy-gate.sh
 	@echo "==> VSIX stub-provider packaging gate (unit)..."
 	@node --test clients/vscode/scripts/stub-gate.test.mjs
+	@echo "==> PATH/env injection gate ([ACTION-ENVPATH])..."
+	@node --test scripts/verify-env-path-writes.test.mjs
+	@node scripts/verify-env-path-writes.mjs
 
 ## fmt: Format all code in-place. Pass CHECK=1 for read-only check (CI use).
 ##      Depends on typediagram-gen because rustfmt walks the module tree

--- a/action.yml
+++ b/action.yml
@@ -142,6 +142,20 @@ runs:
       # prefix of an absolute ${RUNNER_TEMP} path as a remote host — and GNU
       # tar cannot read the `.zip` regardless, so Windows uses the runner's
       # bsdtar from System32 ([ACTION-VERIFY]).
+      #
+      # NEVER write a caller-influenced value into ${GITHUB_PATH} or
+      # ${GITHUB_ENV}. Both files are read back by the runner as the *next*
+      # step's PATH and environment, so a value derived from an action input —
+      # `${STAGE}` carries the `version` input — hands a caller who can set that
+      # input a say in where later steps resolve their executables from. The
+      # staged directory is therefore moved to a fixed `bin` name and only that
+      # constant is exported. Enforced with an error by
+      # `scripts/verify-env-path-writes.mjs` ([ACTION-ENVPATH]).
+      #
+      # `mv` doubles as the layout assertion — a release repackaged without the
+      # versioned top-level directory fails here instead of silently exporting
+      # an empty directory. `rm -rf` keeps a second invocation in the same job
+      # from nesting the new staging directory inside the old `bin`.
       run: |
         set -euo pipefail
         cd "${RUNNER_TEMP}/deslop"
@@ -150,7 +164,9 @@ runs:
         else
           tar -xf "${ARCHIVE}"
         fi
-        echo "${RUNNER_TEMP}/deslop/${STAGE}" >> "${GITHUB_PATH}"
+        rm -rf bin
+        mv "${STAGE}" bin
+        echo "${RUNNER_TEMP}/deslop/bin" >> "${GITHUB_PATH}"
       env:
         ARCHIVE: ${{ steps.resolve.outputs.archive }}
         STAGE: ${{ steps.resolve.outputs.stage }}

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -174,6 +174,19 @@ extracts with the runner's bsdtar (`%SystemRoot%\System32\tar.exe`), the only
 tar in that shell that reads the `.zip`; every other platform reads the
 `.tar.gz` with plain `tar -xf`.
 
+**[ACTION-ENVPATH] Only runner-owned constants reach `$GITHUB_PATH` and
+`$GITHUB_ENV`.** The runner replays both files as the *next* step's PATH and
+environment, so a value built from an action input, a step output, or a
+`${{ }}` expression hands whoever sets that input a say in where later steps
+resolve their executables — CodeQL's `actions/envpath-injection`. The install
+step therefore moves the extracted `deslop-<version>-<artifact>` directory to a
+fixed `bin` name and exports `${RUNNER_TEMP}/deslop/bin`, a constant; the `mv`
+doubles as the layout assertion, failing loudly if a release is ever repackaged
+without that top-level directory. `scripts/verify-env-path-writes.mjs` enforces
+this with an error across `action.yml` and every workflow, in `make lint` so it
+runs on every CI job rather than behind a path filter, and
+`verify-env-path-writes.test.mjs` proves the gate rejects the tainted form.
+
 **[ACTION-GATE] Exit codes are surfaced, never reinterpreted.** The run step
 captures the CLI status with an `||` guard — GitHub injects `-e` into every
 composite `shell: bash` step, so an unguarded non-zero status would abort the

--- a/scripts/verify-env-path-writes.mjs
+++ b/scripts/verify-env-path-writes.mjs
@@ -1,0 +1,167 @@
+// Static lint: nothing caller-influenced may reach `$GITHUB_PATH` or
+// `$GITHUB_ENV`. [ACTION-ENVPATH]
+//
+// The runner reads both files back as the *next* step's PATH and environment.
+// A value built from an action input, a step output, or a `${{ }}` expression
+// therefore lets whoever controls that input decide where later steps resolve
+// their executables, or what their environment says — the injection class
+// CodeQL reports as `actions/envpath-injection`. The fix is always the same:
+// export a constant path built from runner-owned variables and move the
+// variable part of the layout to that constant, never the other way round.
+//
+// Runs in `make lint` so it fires on every CI run, not only when a workflow
+// path filter happens to match. Proven by `scripts/test-env-path-writes.mjs`.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/** Environment files the runner replays into the next step. */
+const SINKS = ["GITHUB_PATH", "GITHUB_ENV"];
+
+/**
+ * Expansions the runner itself owns, and which no caller can influence.
+ * Everything else — action inputs, step outputs, `${{ }}` expressions, job
+ * env — is caller-influenced until proven otherwise, so it is rejected.
+ */
+const TRUSTED = new Set([
+  "GITHUB_ACTION_PATH",
+  "GITHUB_WORKSPACE",
+  "HOME",
+  "RUNNER_ARCH",
+  "RUNNER_OS",
+  "RUNNER_TEMP",
+  "RUNNER_TOOL_CACHE",
+  "RUNNER_WORKSPACE",
+]);
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const WORKFLOW_DIR = resolve(repoRoot, ".github/workflows");
+
+/**
+ * Names the sink a line redirects into, or `""` when it writes neither.
+ *
+ * @param {string} line
+ * @returns {string}
+ */
+export function redirectSink(line) {
+  if (!line.includes(">>")) return "";
+  return SINKS.find((sink) => line.includes(sink)) ?? "";
+}
+
+/**
+ * The fragments a redirect writes: the body of a `{ … } >> "$SINK"` group, or
+ * the part of the line preceding its own `>>`.
+ *
+ * @param {string[]} lines
+ * @param {number} index Zero-based index of the redirecting line.
+ * @returns {string[]}
+ */
+export function writtenFragments(lines, index) {
+  const head = lines[index].slice(0, lines[index].indexOf(">>"));
+  return head.trim() === "}" ? groupBody(lines, index) : [head];
+}
+
+function groupBody(lines, index) {
+  const body = [];
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    if (lines[cursor].trim() === "{") return body;
+    body.push(lines[cursor]);
+  }
+  throw new Error(`line ${index + 1} closes a redirect group that was never opened`);
+}
+
+/**
+ * Every name a shell fragment expands — `$NAME`, `${NAME}` and whole `${{ }}`
+ * expressions. Hand-scanned rather than regex-matched: this repo prohibits
+ * regex over source and structured data.
+ *
+ * @param {string} fragment
+ * @returns {string[]}
+ */
+export function expansions(fragment) {
+  const names = [];
+  for (let index = fragment.indexOf("$"); index >= 0; index = fragment.indexOf("$", index)) {
+    const { name, length } = expansionAt(fragment, index);
+    if (name) names.push(name);
+    index += length;
+  }
+  return names;
+}
+
+function expansionAt(fragment, start) {
+  if (fragment.startsWith("${{", start)) {
+    const end = fragment.indexOf("}}", start);
+    if (end < 0) return { name: "", length: 3 };
+    return { name: fragment.slice(start, end + 2).trim(), length: end + 2 - start };
+  }
+  const from = fragment.startsWith("${", start) ? start + 2 : start + 1;
+  const name = identifierAt(fragment, from);
+  return { name, length: Math.max(1, from - start + name.length) };
+}
+
+function identifierAt(fragment, from) {
+  let end = from;
+  while (end < fragment.length && isIdentifierCharacter(fragment[end])) end += 1;
+  return fragment.slice(from, end);
+}
+
+function isIdentifierCharacter(character) {
+  const alphabetic = (character >= "a" && character <= "z") || (character >= "A" && character <= "Z");
+  return alphabetic || (character >= "0" && character <= "9") || character === "_";
+}
+
+/**
+ * Every caller-influenced expansion this source writes into a sink.
+ *
+ * @param {string} source Workflow or action YAML.
+ * @param {string} label Path reported in the violation.
+ * @returns {{file: string, line: number, sink: string, name: string}[]}
+ */
+export function envWriteViolations(source, label) {
+  const lines = source.split("\n");
+  return lines.flatMap((line, index) => {
+    const sink = redirectSink(line);
+    if (!sink) return [];
+    return writtenFragments(lines, index)
+      .flatMap(expansions)
+      .filter((name) => !TRUSTED.has(name))
+      .map((name) => ({ file: label, line: index + 1, sink, name }));
+  });
+}
+
+/**
+ * Every workflow and composite action this lint covers.
+ *
+ * @returns {string[]} Absolute paths.
+ */
+export function lintTargets() {
+  const workflows = readdirSync(WORKFLOW_DIR)
+    .filter((entry) => entry.endsWith(".yml") || entry.endsWith(".yaml"))
+    .sort()
+    .map((entry) => resolve(WORKFLOW_DIR, entry));
+  return [resolve(repoRoot, "action.yml"), ...workflows];
+}
+
+function main() {
+  const targets = lintTargets();
+  const violations = targets.flatMap((target) =>
+    envWriteViolations(readFileSync(target, "utf8"), relative(repoRoot, target)),
+  );
+  for (const { file, line, sink, name } of violations) {
+    console.error(`${file}:${line}: ${sink} is written from ${name}, which a caller can influence`);
+  }
+  if (violations.length > 0) {
+    console.error(
+      `\n${violations.length} PATH/env injection(s). ${SINKS.join(" and ")} are replayed as the next ` +
+        "step's PATH and environment: export a constant built from runner-owned variables and move the " +
+        "variable part of the layout to it. See docs/specs/release.md [ACTION-ENVPATH].",
+    );
+    process.exit(1);
+  }
+  console.log(`env/PATH write lint: ${targets.length} files clean`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/verify-env-path-writes.test.mjs
+++ b/scripts/verify-env-path-writes.test.mjs
@@ -6,6 +6,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 
 import {
   envWriteViolations,
@@ -74,7 +75,7 @@ test("only the fragment before the redirect is inspected, so the sink name itsel
 });
 
 test("the lint covers action.yml and every workflow", () => {
-  const targets = lintTargets().map((target) => target.split("/").at(-1));
+  const targets = lintTargets().map((target) => basename(target));
   assert.ok(targets.includes("action.yml"), "action.yml is the composite action under Marketplace listing");
   for (const workflow of ["ci.yml", "release.yml", "action-selftest.yml", "codeql.yml", "deploy-pages.yml"]) {
     assert.ok(targets.includes(workflow), `${workflow} is not covered by the env/PATH lint`);

--- a/scripts/verify-env-path-writes.test.mjs
+++ b/scripts/verify-env-path-writes.test.mjs
@@ -1,0 +1,89 @@
+// Proves the PATH/env injection lint (verify-env-path-writes.mjs) actually
+// rejects a caller-influenced write and passes a constant one — a silently
+// broken gate is worse than no gate. Spec: release.md [ACTION-ENVPATH].
+// Run with `node --test`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  envWriteViolations,
+  expansions,
+  lintTargets,
+  redirectSink,
+  writtenFragments,
+} from "./verify-env-path-writes.mjs";
+
+// The exact line CodeQL alert 25 reported against action.yml, and the constant
+// that replaced it.
+const TAINTED_PATH_WRITE = '        echo "${RUNNER_TEMP}/deslop/${STAGE}" >> "${GITHUB_PATH}"';
+const CONSTANT_PATH_WRITE = '        echo "${RUNNER_TEMP}/deslop/bin" >> "${GITHUB_PATH}"';
+
+test("a step output written to GITHUB_PATH is rejected, naming the sink and the variable", () => {
+  const violations = envWriteViolations(TAINTED_PATH_WRITE, "action.yml");
+  assert.deepEqual(violations, [{ file: "action.yml", line: 1, sink: "GITHUB_PATH", name: "STAGE" }]);
+});
+
+test("a constant built from runner-owned variables is accepted", () => {
+  assert.deepEqual(envWriteViolations(CONSTANT_PATH_WRITE, "action.yml"), []);
+});
+
+test("a bare $NAME expansion is caught, not only the braced form", () => {
+  const violations = envWriteViolations('echo "$INSTALL_DIR" >> "$GITHUB_PATH"', "w.yml");
+  assert.equal(violations[0].name, "INSTALL_DIR");
+});
+
+test("a GitHub expression written into GITHUB_ENV is reported whole", () => {
+  const violations = envWriteViolations('echo "V=${{ inputs.version }}" >> "$GITHUB_ENV"', "w.yml");
+  assert.deepEqual(violations, [
+    { file: "w.yml", line: 1, sink: "GITHUB_ENV", name: "${{ inputs.version }}" },
+  ]);
+});
+
+test("a tainted line inside a redirect group is caught though the redirect itself is clean", () => {
+  const source = ['          {', '            echo "CC=${TOOLCHAIN}"', '          } >> "$GITHUB_ENV"'].join("\n");
+  const violations = envWriteViolations(source, "release.yml");
+  assert.deepEqual(violations, [{ file: "release.yml", line: 3, sink: "GITHUB_ENV", name: "TOOLCHAIN" }]);
+});
+
+test("a redirect group of literals is accepted", () => {
+  const source = ['          {', '            echo "CC=aarch64-linux-gnu-gcc"', '          } >> "$GITHUB_ENV"'].join("\n");
+  assert.deepEqual(envWriteViolations(source, "release.yml"), []);
+});
+
+test("a redirect group that was never opened is a hard error, not a silent pass", () => {
+  assert.throws(
+    () => envWriteViolations(['            echo "CC=x"', '          } >> "$GITHUB_ENV"'].join("\n"), "w.yml"),
+    (error) => error.message.includes("never opened"),
+  );
+});
+
+test("command substitution and a literal $$ are not mistaken for expansions", () => {
+  assert.deepEqual(expansions('"$(cygpath -u "${SYSTEMROOT}")/System32/tar.exe"'), ["SYSTEMROOT"]);
+  assert.deepEqual(expansions("printf '%s' $$"), []);
+});
+
+test("GITHUB_OUTPUT is out of scope — it is not replayed as PATH or environment", () => {
+  assert.equal(redirectSink('echo "version=${tag#v}" >> "$GITHUB_OUTPUT"'), "");
+  assert.deepEqual(envWriteViolations('echo "version=${TAG}" >> "$GITHUB_OUTPUT"', "w.yml"), []);
+});
+
+test("only the fragment before the redirect is inspected, so the sink name itself is not a violation", () => {
+  assert.deepEqual(writtenFragments([CONSTANT_PATH_WRITE], 0), ['        echo "${RUNNER_TEMP}/deslop/bin" ']);
+});
+
+test("the lint covers action.yml and every workflow", () => {
+  const targets = lintTargets().map((target) => target.split("/").at(-1));
+  assert.ok(targets.includes("action.yml"), "action.yml is the composite action under Marketplace listing");
+  for (const workflow of ["ci.yml", "release.yml", "action-selftest.yml", "codeql.yml", "deploy-pages.yml"]) {
+    assert.ok(targets.includes(workflow), `${workflow} is not covered by the env/PATH lint`);
+  }
+});
+
+test("every file in this repo writes only runner-owned constants into PATH and env", () => {
+  const violations = lintTargets().flatMap((target) =>
+    envWriteViolations(readFileSync(target, "utf8"), target),
+  );
+  assert.deepEqual(violations, [], "a caller-influenced PATH/env write landed in a workflow");
+});


### PR DESCRIPTION
## What

`action.yml` wrote `${RUNNER_TEMP}/deslop/${STAGE}` into `$GITHUB_PATH`, and `STAGE` carries the caller-supplied `version` input. The runner replays that file as the *next* step's PATH, so a caller who controls `version` had a say in where later steps resolve their executables. CodeQL reported it as [alert 25](https://github.com/Nimblesite/Deslop/security/code-scanning/25) (`actions/envpath-injection`) on #291.

## The fix

The install step moves the extracted `deslop-<version>-<artifact>` directory to a fixed `bin` name and exports `${RUNNER_TEMP}/deslop/bin` — a constant built only from runner-owned variables. Nothing caller-influenced reaches the sink.

The `mv` doubles as a layout assertion: a release repackaged without that top-level directory now fails loudly instead of silently exporting an empty directory onto PATH. The preceding `rm -rf bin` keeps a second invocation in the same job (the self-test calls the action three times) from nesting the new staging directory inside the old `bin` — verified locally against a real tarball.

## The gate

A comment is not a gate, so `scripts/verify-env-path-writes.mjs` fails **`make lint` with an error** on any write into `$GITHUB_PATH` or `$GITHUB_ENV` that interpolates anything outside the runner-owned allowlist (`RUNNER_TEMP`, `GITHUB_ACTION_PATH`, …), across `action.yml` and every workflow in `.github/workflows/`.

- It lives in `make lint`, not the action self-test, so no `paths:` filter can skip it.
- It hand-scans `$NAME`, `${NAME}` and whole `${{ }}` expressions rather than matching regex over YAML, per the repo's no-regex-over-structured-data rule.
- It understands the `{ … } >> "$GITHUB_ENV"` group form and inspects the group body, and treats an unopened group as a hard error rather than a silent pass.
- `$GITHUB_OUTPUT` is deliberately out of scope — it is not replayed as PATH or environment.

`scripts/verify-env-path-writes.test.mjs` (12 tests, `node --test`) proves the gate rejects the exact line CodeQL flagged, catches taint inside a redirect group, catches the bare `$NAME` form, does not mistake `$(cygpath …)` or `$$` for an expansion, and still passes the constant form. The last test runs the lint over every real file in the repo, so this cannot regress.

Spec: `docs/specs/release.md` **[ACTION-ENVPATH]**.

## Verification

- `node --test scripts/verify-env-path-writes.test.mjs` — 12/12 pass
- `node scripts/verify-env-path-writes.mjs` — 7 files clean
- `node scripts/test-action-contract.mjs` — 24/24 pass (unchanged)
- Extract/move sequence exercised twice against a real tarball; `bin/deslop` both times, no nesting

The four-platform action self-test runs on this PR because `action.yml` changed, so the new install step is proven on Linux x64/arm64, macOS arm64 and Windows against the real published release.