### PR TITLE
Fix three MCP defects from #286: set-embedding-model, per-file payload bloat, fail-open size cap

### DIFF
--- a/crates/deslop-core/src/report.rs
+++ b/crates/deslop-core/src/report.rs
@@ -189,6 +189,7 @@ pub fn render_report<S: BuildHasher>(inputs: ReportInputs<'_, S>) -> Report {
         registry: inputs.registry,
         exclusion: inputs.exclusion,
         analysed_lines: inputs.analysed_lines,
+        scan_root: inputs.scan_root,
     });
     // Resolve the [EXIT-CODES] duplication gate here so every surface that
     // renders through this path carries the breach verdict — the live

--- a/crates/deslop-core/src/report_boilerplate.rs
+++ b/crates/deslop-core/src/report_boilerplate.rs
@@ -1,14 +1,10 @@
 //! Report projection for suppressed import/prologue boilerplate.
 
-use std::{
-    collections::BTreeMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::BTreeMap, path::Path};
 
 use crate::{
-    boilerplate::BoilerplateRange,
-    config::ExclusionConfig,
-    state::{FileId, FileRegistry},
+    boilerplate::BoilerplateRange, config::ExclusionConfig, report_render::display_path,
+    state::FileRegistry,
 };
 
 // `ReportBoilerplateHint` and `ReportBoilerplateOccurrence` are
@@ -72,14 +68,6 @@ fn occurrence(
         start_byte: range.byte_range.start,
         end_byte: range.byte_range.end,
     }
-}
-
-/// Resolves the report path for `file_id` relative to `scan_root`.
-fn display_path(file_id: FileId, registry: &FileRegistry, scan_root: &Path) -> PathBuf {
-    registry.path(file_id).map_or_else(PathBuf::new, |abs| {
-        abs.strip_prefix(scan_root)
-            .map_or_else(|_| abs.to_path_buf(), Path::to_path_buf)
-    })
 }
 
 /// Returns the gentle remediation copy for a language.

--- a/crates/deslop-core/src/report_metrics.rs
+++ b/crates/deslop-core/src/report_metrics.rs
@@ -9,11 +9,13 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     hash::BuildHasher,
+    path::Path,
 };
 
 use crate::{
     cluster::Cluster,
     config::ExclusionConfig,
+    report_render::relative_to_scan_root,
     state::{FileId, FileRegistry},
 };
 
@@ -110,6 +112,10 @@ pub struct MetricsInputs<'a, S: BuildHasher> {
     /// Per-file analysed-line counts accumulated during the corpus
     /// read-pass.
     pub analysed_lines: &'a AnalysedLines,
+    /// Scan root every `per_file` path is rendered relative to, so the
+    /// metrics rows carry the same path form as occurrence rows
+    /// ([Deslop#286]).
+    pub scan_root: &'a Path,
 }
 
 /// Computes [`RepoMetrics`] for a finished analysis pass. The returned
@@ -179,7 +185,7 @@ fn file_metric<S: BuildHasher>(
     per_file_lines: &HashMap<FileId, BTreeSet<u64>>,
     inputs: &MetricsInputs<'_, S>,
 ) -> Option<FileMetric> {
-    let path = inputs.registry.path(file_id)?.to_path_buf();
+    let path = relative_to_scan_root(inputs.registry.path(file_id)?, inputs.scan_root);
     let analysed_loc = inputs.analysed_lines.get(&file_id).copied().unwrap_or(0);
     let duplicated_loc = per_file_lines
         .get(&file_id)

--- a/crates/deslop-core/src/report_render.rs
+++ b/crates/deslop-core/src/report_render.rs
@@ -122,10 +122,7 @@ pub(crate) fn occurrence<S: BuildHasher>(
     let (start_line, end_line) = source.map_or((0, 0), |bytes| {
         byte_range_to_line_range(bytes, byte_range.start, byte_range.end)
     });
-    let path = absolute.map_or_else(PathBuf::new, |abs| {
-        abs.strip_prefix(scan_root)
-            .map_or_else(|_| abs.clone(), Path::to_path_buf)
-    });
+    let path = absolute.map_or_else(PathBuf::new, |abs| relative_to_scan_root(&abs, scan_root));
     ReportOccurrence {
         path,
         start_byte: byte_range.start,
@@ -134,6 +131,29 @@ pub(crate) fn occurrence<S: BuildHasher>(
         end_line,
         hidden,
     }
+}
+
+/// Renders `absolute` the way every report surface must: relative to
+/// `scan_root` when it lies inside, unchanged when it does not.
+///
+/// Occurrences, boilerplate rows and per-file metrics all resolve paths
+/// through here, so a single report can never mix relative and absolute
+/// forms — the drift that put the user's home directory into every
+/// `metrics.per_file` row ([Deslop#286]).
+pub(crate) fn relative_to_scan_root(absolute: &Path, scan_root: &Path) -> PathBuf {
+    absolute
+        .strip_prefix(scan_root)
+        .map_or_else(|_| absolute.to_path_buf(), Path::to_path_buf)
+}
+
+/// Resolves the report path for `file_id`, or an empty path when the
+/// registry cannot resolve it.
+pub(crate) fn display_path(file_id: FileId, registry: &FileRegistry, scan_root: &Path) -> PathBuf {
+    registry
+        .path(file_id)
+        .map_or_else(PathBuf::new, |absolute| {
+            relative_to_scan_root(absolute, scan_root)
+        })
 }
 
 /// Converts a byte range into an inclusive 1-indexed line range.

--- a/crates/deslop-lsp/src/ipc/dispatch.rs
+++ b/crates/deslop-lsp/src/ipc/dispatch.rs
@@ -26,6 +26,7 @@ pub(super) fn dispatch(
         "session/config" => dispatch_session_config(service, handle),
         "duplicates/findSimilar" => dispatch_find_similar(params, service, handle),
         "embedding/listModels" => dispatch_list_models(service, handle),
+        "embedding/setModel" => dispatch_set_model(params, service, handle),
         crate::commands::REFRESH_REPORT => dispatch_refresh_report(service, handle),
         _ => Err(json!({"code": -32601, "message": "method not found"})),
     }
@@ -116,6 +117,25 @@ fn dispatch_find_similar(
 fn dispatch_list_models(service: &Arc<LiveService>, handle: &Handle) -> Result<Value, Value> {
     let models = handle.block_on(service.embedding_list_models());
     serde_json::to_value(&models).map_err(|err| rpc_serialise_error(&err))
+}
+
+/// Delegates `embedding/setModel` to [`LiveService::embedding_set_model`].
+///
+/// The VSIX reaches this swap through the LSP custom method; MCP clients
+/// reach it here. Without this arm the MCP backend can only ever be told
+/// "method not found" ([Deslop#286]).
+fn dispatch_set_model(
+    params: &Value,
+    service: &Arc<LiveService>,
+    handle: &Handle,
+) -> Result<Value, Value> {
+    let provider_id = required_str_param(params, "provider_id")?;
+    let model_id = required_str_param(params, "model_id")?;
+    let endpoint = params.get("endpoint").and_then(Value::as_str);
+    let provenance = handle
+        .block_on(service.embedding_set_model(provider_id, model_id, endpoint))
+        .map_err(|error| json!({"code": -32603, "message": error.to_string()}))?;
+    serde_json::to_value(&provenance).map_err(|err| rpc_serialise_error(&err))
 }
 
 /// Forces the same full refresh as `workspace/executeCommand`

--- a/crates/deslop-mcp/src/backend/state.rs
+++ b/crates/deslop-mcp/src/backend/state.rs
@@ -28,7 +28,7 @@ use deslop_core::{
         FindSimilarInput as WireFindSimilarInput, FindSimilarRequest, SessionConfig,
     },
     report::ReportCluster,
-    EmbeddingSpec, Report,
+    EmbeddingProvenance, EmbeddingSpec, Report,
 };
 use serde_json::{json, Value};
 use tracing::debug;
@@ -290,13 +290,16 @@ impl McpBackend for LiveBackend {
 
     fn set_embedding_model(
         &self,
-        _provider_id: &str,
-        _model_id: &str,
-        _endpoint: Option<&str>,
+        provider_id: &str,
+        model_id: &str,
+        endpoint: Option<&str>,
     ) -> Result<EmbeddingSpec, BackendError> {
-        Err(BackendError::LspNotRunning {
-            socket_path: self.ipc_socket.clone(),
-        })
+        let params = json!({
+            "provider_id": provider_id,
+            "model_id": model_id,
+            "endpoint": endpoint,
+        });
+        spec_from_set_model_reply(ipc_call(&self.root, "embedding/setModel", &params)?)
     }
 
     fn session_config(&self) -> Result<SessionConfigSnapshot, BackendError> {
@@ -357,6 +360,29 @@ impl McpBackend for LiveBackend {
             Err(error) => debug!(reason = %error, "mcp_subscribe_connect_failed"),
         }
     }
+}
+
+/// Converts an `embedding/setModel` IPC reply into the spec the MCP
+/// response carries.
+///
+/// A null provenance means the LSP switched embeddings off rather than
+/// swapping providers. The MCP schema cannot request that, so receiving
+/// it means the two binaries disagree about the wire contract — the
+/// same class of drift `StateFileCorrupt` reports elsewhere.
+fn spec_from_set_model_reply(result: Value) -> Result<EmbeddingSpec, BackendError> {
+    let provenance = serde_json::from_value::<Option<EmbeddingProvenance>>(result)
+        .map_err(|err| BackendError::StateFileCorrupt(format!("ipc set-model parse: {err}")))?
+        .ok_or_else(|| {
+            BackendError::StateFileCorrupt(
+                "ipc set-model returned no provenance: the LSP switched embeddings off instead of swapping providers".to_owned(),
+            )
+        })?;
+    Ok(EmbeddingSpec {
+        provider_id: provenance.provider_id,
+        model_id: provenance.model_id,
+        model_version: provenance.model_version,
+        dimensions: provenance.dimensions,
+    })
 }
 
 /// Converts the compact `deslop.lsp.refreshReport` IPC response into

--- a/crates/deslop-mcp/src/page.rs
+++ b/crates/deslop-mcp/src/page.rs
@@ -12,20 +12,23 @@ use deslop_core::{
     pipeline::language_for_path,
     report::{Report, ReportCluster},
     wire_generated::{
-        ClusterSummary, OccurrenceSummary, ReportPage, ReportPageFilters, ReportPageInfo,
+        ClusterSummary, OccurrenceSummary, RepoMetrics, ReportPage, ReportPageFilters,
+        ReportPageInfo,
     },
 };
 
-/// Pagination request: zero-based `offset` + cap on returned items.
-/// Both come straight from the agent's tool call. The MCP layer
-/// rejects missing fields up front, so by the time we see them they
-/// are always present.
+/// The agent's page request: zero-based `offset`, cap on returned
+/// items, and whether the per-file metrics breakdown is wanted. The MCP
+/// layer rejects missing pagination fields up front, so by the time we
+/// see them they are always present.
 #[derive(Debug, Clone, Copy)]
 pub struct Pagination {
     /// Zero-based cluster index to start at (within the matched set).
     pub offset: usize,
     /// Maximum number of clusters to return on this page.
     pub limit: usize,
+    /// Whether to carry `metrics.per_file`. Off unless the agent asks.
+    pub include_per_file: bool,
 }
 
 /// Builds a [`ReportPage`] over `report` with the matched-and-paged
@@ -63,7 +66,7 @@ pub fn build_page(
         clusters_hidden: report.clusters_hidden,
         embedding_provenance: report.embedding_provenance.clone(),
         cache_stats: report.cache_stats,
-        metrics: report.metrics.clone(),
+        metrics: page_metrics(report, pagination.include_per_file),
         action_hints: report.action_hints.clone(),
         total_clusters,
         page: ReportPageInfo {
@@ -74,6 +77,21 @@ pub fn build_page(
         clusters: summaries,
         filters: echo_filters(filters),
     }
+}
+
+/// Builds the page's metrics block.
+///
+/// `per_file` carries one row per analysed file. On a workspace with a
+/// thousand files — or a few hundred deeply nested ones — that block
+/// outweighs the entire 200 KB tool-result budget before a single
+/// cluster is added, which made every `report-query` overflow. It is
+/// opt-in; the headline totals are always present ([Deslop#286]).
+fn page_metrics(report: &Report, include_per_file: bool) -> RepoMetrics {
+    let mut metrics = report.metrics.clone();
+    if !include_per_file {
+        metrics.per_file = Vec::new();
+    }
+    metrics
 }
 
 /// Returns whether `cluster` satisfies every active filter on `filters`.

--- a/crates/deslop-mcp/src/tools/handlers.rs
+++ b/crates/deslop-mcp/src/tools/handlers.rs
@@ -423,6 +423,10 @@ pub(super) fn extract_pagination(args: &Value) -> Result<Pagination, JsonRpcErro
     Ok(Pagination {
         offset: usize::try_from(offset).unwrap_or(usize::MAX),
         limit: usize::try_from(limit).unwrap_or(usize::MAX),
+        include_per_file: args
+            .get("include_per_file")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
     })
 }
 

--- a/crates/deslop-mcp/src/tools/limits.rs
+++ b/crates/deslop-mcp/src/tools/limits.rs
@@ -79,15 +79,21 @@ fn shrink_to_budget(mut payload: Value) -> Value {
 }
 
 /// Truncates `payload.clusters` (top level) until the result fits
-/// the budget. Returns `true` when truncation was possible, `false`
-/// when there is no `clusters` array to shrink.
+/// the budget. Returns `true` when the payload now fits, `false` when
+/// there is no `clusters` array to shrink — or when dropping every
+/// cluster still leaves it over budget, so the caller falls back to the
+/// stub instead of returning an oversized result.
 fn shrink_clusters_in_place(payload: &mut Value) -> bool {
     if !has_cluster_array(payload) {
         return false;
     }
     while serialised_len(payload) > MAX_TOOL_RESULT_BYTES {
+        // The cluster array is empty and the payload still breaches the
+        // cap: the non-cluster content alone is oversized. Reporting
+        // success here would stamp `truncated: true` on a payload that
+        // still blows the agent's wire budget ([Deslop#286]).
         if !pop_one_cluster(payload) {
-            return true;
+            return false;
         }
     }
     true

--- a/crates/deslop-mcp/src/tools/schemas.rs
+++ b/crates/deslop-mcp/src/tools/schemas.rs
@@ -42,7 +42,8 @@ pub(super) fn schema_report_get() -> Value {
         "type": "object",
         "properties": {
             "offset": { "type": "integer", "minimum": 0, "description": "Zero-based cluster index to start at." },
-            "limit": { "type": "integer", "minimum": 0, "description": "Max clusters in this page. Pick a sensible value for your context window." }
+            "limit": { "type": "integer", "minimum": 0, "description": "Max clusters in this page. Pick a sensible value for your context window." },
+            "include_per_file": { "type": "boolean", "default": false, "description": "Include the per-file duplication breakdown (one row per analysed file). Off by default: on a large workspace it alone can exceed the whole result budget." }
         },
         "required": ["offset", "limit"],
         "additionalProperties": false,
@@ -61,7 +62,8 @@ pub(super) fn schema_report_query() -> Value {
             "bucket": { "type": "string", "enum": bucket_enum(), "description": "Match clusters whose canonical bucket equals this id." },
             "path_contains": { "type": "string", "description": "Case-sensitive substring match against any occurrence path on the cluster." },
             "min_score": { "type": "number", "description": "Inclusive ranking-score floor." },
-            "min_size": { "type": "integer", "minimum": 0, "description": "Inclusive subtree-node-count floor (canonical_node_count)." }
+            "min_size": { "type": "integer", "minimum": 0, "description": "Inclusive subtree-node-count floor (canonical_node_count)." },
+            "include_per_file": { "type": "boolean", "default": false, "description": "Include the per-file duplication breakdown (one row per analysed file). Off by default: on a large workspace it alone can exceed the whole result budget." }
         },
         "required": ["offset", "limit"],
         "additionalProperties": false,

--- a/crates/deslop-mcp/tests/cli.rs
+++ b/crates/deslop-mcp/tests/cli.rs
@@ -1761,7 +1761,11 @@ fn set_embedding_model_rejects_stub_provider() -> Result<()> {
 
 #[test]
 fn set_embedding_model_preserves_shared_settings_and_endpoint() -> Result<()> {
-    // StateFileBackend does not manage embeddings — set-embedding-model requires the LSP.
+    // The harness spawns a companion LSP, so this exercises the live IPC
+    // path. Port 1 is never listening, so the swap must fail as an
+    // unreachable *provider* — naming the endpoint it was handed proves the
+    // caller's endpoint survived the trip instead of being discarded
+    // ([Deslop#286]).
     // [REMOVE-STUB] Stub provider removed from production payloads;
     // exercise the same plumbing through the ollama provider.
     let (child, response) = init_and_tool_response(
@@ -1770,7 +1774,16 @@ fn set_embedding_model_preserves_shared_settings_and_endpoint() -> Result<()> {
     )?;
     assert!(
         response.get("error").is_some(),
-        "set-embedding-model without LSP must return an error envelope: {response}",
+        "set-embedding-model against a dead endpoint must return an error envelope: {response}",
+    );
+    let rendered = response.to_string();
+    assert!(
+        !rendered.contains("LSP is not running"),
+        "issue #286: the LSP is running and serving this socket; the error must describe the real failure: {response}",
+    );
+    assert!(
+        rendered.contains("127.0.0.1:1"),
+        "the endpoint the caller supplied must reach the provider and be named in the failure: {response}",
     );
     let _ = child.finish();
     Ok(())
@@ -2030,16 +2043,28 @@ fn report_for_file_on_unknown_path_returns_empty_clusters() -> Result<()> {
 
 #[test]
 fn set_embedding_model_swap_updates_session_config_provenance() -> Result<()> {
-    // StateFileBackend does not manage embeddings — set-embedding-model requires the LSP.
+    // A swap that never reached a provider must not leave provenance behind:
+    // an agent reading session-config afterwards has to see that embeddings
+    // are still off, not a model that was never installed ([Deslop#286]).
     // [REMOVE-STUB] Use the ollama provider id since stub is no longer
     // accepted by the production MCP schema.
-    let (child, response) = init_and_tool_response(
+    let (mut child, response) = init_and_tool_response(
         "set-embedding-model",
         &json!({ "provider_id": "ollama", "model_id": "nomic-embed-text", "endpoint": "http://127.0.0.1:1", "user_initiated": true }),
     )?;
     assert!(
         response.get("error").is_some(),
-        "set-embedding-model without LSP must return an error envelope: {response}",
+        "a swap against a dead endpoint must return an error envelope: {response}",
+    );
+    assert!(
+        !response.to_string().contains("LSP is not running"),
+        "issue #286: the companion LSP is live; the error must describe the real failure: {response}",
+    );
+    let config = structured_tool_result(&call_tool(&mut child, "session-config", &json!({}))?)?;
+    assert_eq!(
+        config.get("embedding_provenance"),
+        Some(&Value::Null),
+        "a failed swap must leave session-config reporting no embedding provenance: {config}",
     );
     let _ = child.finish();
     Ok(())

--- a/crates/deslop-mcp/tests/issue_136_codex_payload_size.rs
+++ b/crates/deslop-mcp/tests/issue_136_codex_payload_size.rs
@@ -219,6 +219,77 @@ fn assert_truncation_marker(structured: &Value) -> Result<()> {
     Ok(())
 }
 
+/// Issue #286: `metrics.per_file` carries one row per analysed file. On
+/// a workspace with long paths that block alone outweighs the entire
+/// 200 KB tool-result budget, so every `report-query` overflowed before
+/// a single cluster was returned. It must be opt-in, and asking for it
+/// must never let the payload escape the cap: draining the cluster array
+/// used to be reported as a successful shrink, so an oversized result
+/// went out stamped `truncated: true`.
+#[test]
+fn issue_286_report_query_stays_within_the_wire_cap() -> Result<()> {
+    let workspace = copied_fixture()?;
+    let files = inflate_workspace_with_long_paths(workspace.path())?;
+    let _lsp_guard = spawn_lsp_and_wait_for_socket(workspace.path())?;
+    let mut mcp = initialized_mcp(workspace.path())?;
+
+    let lean = mcp.request(
+        "tools/call",
+        &json!({"name": "report-query", "arguments": {"offset": 0, "limit": 0}}),
+    )?;
+    let structured = structured_content(&lean, "report-query")?;
+    let per_file = structured
+        .pointer("/metrics/per_file")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    ensure!(
+        per_file == 0,
+        "issue #286: the per-file breakdown must be opt-in, got {per_file} rows unasked"
+    );
+    ensure!(
+        structured.pointer("/metrics/analysed_loc").is_some(),
+        "the headline metrics must survive the per-file opt-out: {structured}"
+    );
+
+    // Asking for the breakdown on this workspace cannot fit. There is no
+    // cluster left to drop — the page was requested with `limit: 0` — so
+    // the cap can only hold by falling back to the stub. It used to
+    // report that shrink as a success and ship the oversized page.
+    let fat = mcp.request(
+        "tools/call",
+        &json!({"name": "report-query", "arguments": {"offset": 0, "limit": 0, "include_per_file": true}}),
+    )?;
+    let payload = fat
+        .pointer("/result/structuredContent")
+        .ok_or_else(|| anyhow!("report-query returned no structuredContent: {fat}"))?;
+    let size = serde_json::to_vec(payload)?.len();
+    ensure!(
+        size <= 200 * 1024,
+        "issue #286: an opted-in per-file page over {files} files must still respect the {} byte cap; got {size} bytes",
+        200 * 1024
+    );
+    assert_truncation_marker(payload)?;
+    Ok(())
+}
+
+/// Writes 300 analysable C# files whose paths are long enough that the
+/// `per_file` metrics block alone exceeds the 200 KB wire cap. The
+/// bodies are trivial — this fixture exercises the metrics block, not
+/// clustering — and every component stays inside `NAME_MAX`.
+fn inflate_workspace_with_long_paths(root: &Path) -> Result<usize> {
+    let deep = root.join("d".repeat(200)).join("e".repeat(200));
+    fs::create_dir_all(&deep)?;
+    let count = 400_usize;
+    for index in 0..count {
+        let name = format!("{}{index:04}.cs", "f".repeat(190));
+        fs::write(
+            deep.join(name),
+            format!("namespace Wide{index} {{ public class Row{index} {{ }} }}\n"),
+        )?;
+    }
+    Ok(count)
+}
+
 /// Writes ~120 nearly-identical C# files into the workspace so the
 /// LSP produces enough clusters for the cap path to engage. Each
 /// file is a deep-enough subtree to clear the default `min-nodes`

--- a/crates/deslop-mcp/tests/lsp_integration.rs
+++ b/crates/deslop-mcp/tests/lsp_integration.rs
@@ -105,6 +105,51 @@ fn list_embedding_models_via_mcp_delegates_to_running_lsp() -> Result<()> {
     Ok(())
 }
 
+/// [MCP-IPC-CLIENT] Issue #286: `set-embedding-model` must travel the
+/// same IPC chain as every other compute tool. It used to ignore its
+/// arguments and answer `LspNotRunning` unconditionally — on every
+/// platform, while the LSP was up and serving `find-similar` from this
+/// very socket — so the tool could never succeed and its error blamed a
+/// server that was running.
+///
+/// An unregistered provider id keeps the assertion independent of
+/// whether an Ollama daemon happens to be installed: the only component
+/// that can name the registered providers is the live LSP's registry,
+/// so an error naming the request proves the argument crossed the IPC
+/// boundary rather than being discarded by the MCP backend.
+#[test]
+fn issue_286_set_embedding_model_reaches_the_running_lsp() -> Result<()> {
+    let (workspace, _lsp_guard, _socket) = lsp_workspace_with_socket()?;
+    let mut mcp = wait_for_state_then_init_mcp(workspace.path())?;
+
+    let response = mcp.request(
+        "tools/call",
+        &json!({
+            "name": "set-embedding-model",
+            "arguments": {
+                "user_initiated": true,
+                "provider_id": "definitely-not-a-registered-provider",
+                "model_id": "nomic-embed-text"
+            }
+        }),
+    )?;
+
+    let rendered = response.to_string();
+    ensure!(
+        !rendered.contains("LSP is not running"),
+        "issue #286: set-embedding-model reported the LSP as down while the LSP was serving this very socket: {response}"
+    );
+    ensure!(
+        !rendered.contains("method-not-found"),
+        "issue #286: the LSP IPC table must route embedding/setModel: {response}"
+    );
+    ensure!(
+        rendered.contains("definitely-not-a-registered-provider"),
+        "issue #286: the live provider registry must reject the requested provider by name, proving the argument reached the LSP: {response}"
+    );
+    Ok(())
+}
+
 /// [MCP-IPC-CLIENT] Agent `rescan` must ask the running LSP to execute
 /// `deslop.lsp.refreshReport`, then return top offenders from the
 /// refreshed state file.

--- a/crates/deslop/tests/cli/metrics.rs
+++ b/crates/deslop/tests/cli/metrics.rs
@@ -97,6 +97,30 @@ fn metrics_per_file_breakdown_matches_repo_totals() -> Result<()> {
     Ok(())
 }
 
+/// Issue #286: `per_file[].path` is documented as relative to the scan
+/// root — the same contract every occurrence path already honours — but
+/// was emitted absolute. That inflates every JSON report by the length of
+/// the scan root times the file count, and writes the user's home
+/// directory into a file agents copy between machines.
+#[test]
+fn metrics_per_file_paths_are_scan_root_relative() -> Result<()> {
+    let (_analysed, json) = run_clone_pair("8")?;
+    let mut paths: Vec<String> = metric_field(&json, "per_file")
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|entry| field(entry, "path").as_str().map(str::to_owned))
+        .collect();
+    paths.sort();
+    assert_eq!(
+        paths,
+        vec!["Alpha.cs".to_owned(), "Beta.cs".to_owned()],
+        "per_file paths must be scan-root-relative, exactly as occurrence paths are"
+    );
+    Ok(())
+}
+
 /// Asserts one `per_file` row: a `.cs` path, non-zero duplication for
 /// this cross-file clone fixture, and a percentage computed against the
 /// file's own analysed-line denominator.

--- a/docs/specs/mcp.md
+++ b/docs/specs/mcp.md
@@ -154,6 +154,14 @@ from the canonical occurrence path via the **core parser registry's** extension 
 source shared with the HTML renderer, so every registered language (Dart included, #164) reports
 its real id, never `"unknown"`.
 
+`metrics` carries the headline repo totals on every page. Its **`per_file` breakdown is opt-in**
+via `include_per_file: true` and empty otherwise: it holds one row per analysed file, so on a
+workspace of a thousand files — or a few hundred deeply nested ones — that block alone exceeds the
+whole [MCP-RESULT-SIZE-CAP] budget before a single cluster is added, which made every page overflow
+([issue #286](https://github.com/Nimblesite/Deslop/issues/286)). Every `per_file` path is rendered
+relative to the scan root, the same form occurrence paths use, so a report never mixes the two and
+never carries the user's home directory.
+
 `schema_doc` is intentionally absent from every page; agents call `schema-doc` or read
 `deslop://schema` once. `total_clusters` lets the agent decide whether to keep paging; exhaustive
 audits page until `offset + returned >= total_clusters`.
@@ -202,8 +210,12 @@ last-resort guard layered on top of the per-call occurrence budget
 dispatcher drops clusters from the tail of the inner `clusters[]` array until it
 fits, then stamps the response with `truncated: true`, a human-readable
 `truncated_reason`, `truncated_at_bytes`, and a `next_action` pointer to the
-paginated report tool; payloads with no `clusters` array degrade to a stub
-carrying the same markers. Every truncation emits a `tracing::warn!` so operators
+paginated report tool; payloads with no `clusters` array — **and payloads still
+over budget once every cluster has been dropped** — degrade to a stub carrying
+the same markers. Draining the cluster array is not by itself success: reporting
+it as one shipped an oversized payload stamped `truncated: true`, which is the
+one outcome this cap exists to prevent
+([issue #286](https://github.com/Nimblesite/Deslop/issues/286)). Every truncation emits a `tracing::warn!` so operators
 can size their corpora. A companion budget keeps the whole `tools/list` payload
 ≤16 KB with each description ≤200 chars so long-form rationale stays in the
 `deslop://schema` resource.


### PR DESCRIPTION
Fixes the defects from #286 that survived an adversarial verification pass. Each fix landed test-first: a failing E2E test written and confirmed to fail *because of the bug* before any production code changed.

## 1. `set-embedding-model` could never succeed — on any platform

The MCP backend's `set_embedding_model` discarded all three arguments and unconditionally returned `LspNotRunning` without attempting IPC, and the LSP's IPC method table had no `embedding/setModel` arm, so even a correct backend would have been answered `-32601`. Every other tool in the same impl block delegates over `ipc_call`; this one was the lone omission.

The error was worse than a plain failure — it told users to start `deslop-lsp` and suspect a `--root` mismatch **while the LSP was up and serving `find-similar` and `list-embedding-models` from the very same socket**. That is why the model had to be switched through the VS Code UI instead; the VSIX reaches the working LSP custom method and was never affected.

This is not a Windows bug and not a transport bug, contrary to the issue's framing: `transport::connect` does socket-then-TCP for *every* method. The write path simply never called it.

**Fix:** the LSP routes `embedding/setModel` to `LiveApi::embedding_set_model`; the backend issues the real call and converts the returned provenance into the spec the MCP response carries. A null provenance means the LSP switched embeddings *off* rather than swapping providers — something the MCP schema cannot request — so it is reported as wire drift rather than silently returning empty fields.

**Test:** `issue_286_set_embedding_model_reaches_the_running_lsp` drives a live LSP and asserts the provider registry rejects an unregistered provider *by name* — an outcome only reachable through IPC, and independent of whether an Ollama daemon is installed.

Two `cli.rs` tests ran against a live LSP while asserting nothing but `error.is_some()` under stale "without LSP" comments, cementing the bug rather than catching it. They now also assert the error is not the `LspNotRunning` lie, that the caller's endpoint reaches the provider, and that a failed swap leaves `session-config` reporting no provenance.

## 2. `report-query` inlined the per-file breakdown unconditionally

`metrics.per_file` carries one row per analysed file. Measured on this repo's own 453 files that block serialises to **82 KB**; on the reporter's 1,068-file workspace it is roughly **195 KB** — nearly the entire 200 KB budget spent before a single cluster. `limit: 0` did not help, because the page slice only trims `clusters`.

**Fix:** opt-in via `include_per_file` on `report-get` and `report-query`. Headline totals stay on every page.

## 3. The result size cap failed open

`shrink_clusters_in_place` popped clusters until the payload fit, but when the array ran dry while the payload was *still* over budget it returned success — so the dispatcher stamped `truncated: true` and shipped the oversized result anyway. The stub fallback was only reachable for payloads with no `clusters` key at all.

**Fix:** draining the array is now reported as a failed shrink, so an over-budget payload degrades to the stub.

**Test:** `issue_286_report_query_stays_within_the_wire_cap` drives 400 deeply nested files through the real MCP binary and asserts both halves. Against the old cap it fails with a **271,273-byte payload — 1.32× the limit — stamped as a successful truncation** (verified by reverting the fix and re-running).

## 4. Per-file metric paths were absolute

`metrics.per_file[].path` was the raw registry path while every occurrence path in the same report was already stripped to the scan root — contradicting the field's own documented wire contract, inflating each row, and writing the user's home directory into a file agents copy between machines.

Two near-identical strip implementations already existed (`report_render`, `report_boilerplate`). Rather than add a third, both now call one shared `relative_to_scan_root`.

## Verified NOT bugs (claims that did not survive)

- **Embedding results not persisted to `live-report.json`** — mechanically true but spec-mandated: `docs/specs/live.md` explicitly lists the cases the seed cache is not written on. Changing it is a spec decision, not a defect fix, so it is left alone.
- **`detect_stale_paths` stats once per occurrence without dedup** — true, but `is_stale` is a pure, side-effect-free read, so the function returns an identical deduped, sorted result either way. A possible optimisation, not a correctness bug.

Also corrected for the record: the 8.4% of dropped subtrees is **not** the model's context window. `MAX_PROVIDER_INPUT_CHARS` is hard-coded at 6,000 and rejects oversized input before the provider is consulted, so a 32k-context model would recover none of them.

## Verification

- `cargo test --workspace --features deslop-core/live -- --skip ollama_` — green
- `make lint` — green (clippy, taxonomy gate, stub gate, PATH/env injection gate)
- `make fmt CHECK=1` — clean
- Each new test confirmed failing before its fix, and the cap fix confirmed by reverting it in place

Spec updated: `docs/specs/mcp.md` [MCP-RESULT-SIZE-CAP] and the page-shape section.