### PR TITLE
Publish each platform VSIX independently with retries so one registry timeout cannot ship a partial release

### DIFF
--- a/scripts/contract-suite.mjs
+++ b/scripts/contract-suite.mjs
@@ -1,0 +1,37 @@
+// Shared runner for the deployment contract suites ([DEPLOY-CI-GATES]).
+// Every suite passes its test functions here: each test either returns
+// silently or throws, the runner prints TAP-style ok / not ok lines, and a
+// red suite exits 1 only after every test has run. A `workdirPrefix` gives
+// each test a fresh temp directory (passed as the test's argument) that is
+// removed win or lose.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Runs `tests` and reports `<n> <suiteLabel> tests passed` or exits 1.
+ */
+export function runContractSuite(tests, suiteLabel, workdirPrefix) {
+  const failed = tests.filter((test) => !runCase(test, workdirPrefix)).length;
+  if (failed > 0) {
+    console.error(`\n${failed} ${suiteLabel} test(s) failed`);
+    process.exit(1);
+  }
+  console.log(`\n${tests.length} ${suiteLabel} tests passed`);
+}
+
+function runCase(test, workdirPrefix) {
+  const work = workdirPrefix === undefined ? undefined : mkdtempSync(join(tmpdir(), workdirPrefix));
+  try {
+    test(work);
+    console.log(`ok ${test.name}`);
+    return true;
+  } catch (error) {
+    console.error(`not ok ${test.name}`);
+    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  } finally {
+    if (work !== undefined) rmSync(work, { recursive: true, force: true });
+  }
+}

--- a/scripts/test-deployment-docs-contract.mjs
+++ b/scripts/test-deployment-docs-contract.mjs
@@ -11,6 +11,8 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { runContractSuite } from "./contract-suite.mjs";
+
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const workflow = readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8");
 
@@ -25,23 +27,7 @@ const tests = [
   documentedExtensionDirectoryCarriesItsPlatformTarget,
 ];
 
-let failed = 0;
-for (const test of tests) {
-  try {
-    test();
-    console.log(`ok ${test.name}`);
-  } catch (error) {
-    failed++;
-    console.error(`not ok ${test.name}`);
-    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-if (failed > 0) {
-  console.error(`\n${failed} deployment docs contract test(s) failed`);
-  process.exit(1);
-}
-console.log(`\n${tests.length} deployment docs contract tests passed`);
+runContractSuite(tests, "deployment docs contract");
 
 // The premise of the second test. If the release workflow ever stops publishing
 // per-target VSIXes, VS Code would drop the suffix and the un-suffixed path in

--- a/scripts/test-release-publish-contract.mjs
+++ b/scripts/test-release-publish-contract.mjs
@@ -23,8 +23,10 @@
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { runContractSuite } from "./contract-suite.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const workflow = readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8");
@@ -73,25 +75,10 @@ const tests = [
   marketplaceRetriesATransientTimeoutUntilThePlatformPublishes,
   openvsxAttemptsEveryPlatformWhenOneKeepsTimingOut,
   openvsxRetriesATransientTimeoutUntilThePlatformPublishes,
+  expectedPublishCountMatchesTheBuildMatrix,
 ];
 
-let failed = 0;
-for (const test of tests) {
-  try {
-    test();
-    console.log(`ok ${test.name}`);
-  } catch (error) {
-    failed++;
-    console.error(`not ok ${test.name}`);
-    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-if (failed > 0) {
-  console.error(`\n${failed} release publish contract test(s) failed`);
-  process.exit(1);
-}
-console.log(`\n${tests.length} release publish contract tests passed`);
+runContractSuite(tests, "release publish contract");
 
 function marketplaceAttemptsEveryPlatformWhenOneKeepsTimingOut() {
   assertSurvivesPersistentTimeout(marketplaceScenario(PERSISTENT), "Marketplace");
@@ -107,6 +94,33 @@ function openvsxAttemptsEveryPlatformWhenOneKeepsTimingOut() {
 
 function openvsxRetriesATransientTimeoutUntilThePlatformPublishes() {
   assertRetriesTransientTimeout(openvsxScenario(1), "Open VSX");
+}
+
+// The completeness check is only as good as its expected count. A sixth
+// platform added to the build matrix with a stale --expected would surface
+// only at release time — so every publish step's --expected must equal the
+// number of vsix_target entries the matrix produces.
+function expectedPublishCountMatchesTheBuildMatrix() {
+  const matrixCount = new Set(
+    workflow
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("vsix_target: ")),
+  ).size;
+  assert(matrixCount >= 1, "the build matrix declares no vsix_target entries");
+  const expectations = [...workflow.matchAll(/publish-vsixes\.mjs .*--expected (\d+)/g)].map(
+    (match) => Number(match[1]),
+  );
+  assert(
+    expectations.length === 2,
+    `both publish jobs must pass --expected to scripts/publish-vsixes.mjs; found ${expectations.length}`,
+  );
+  for (const expected of expectations) {
+    assert(
+      expected === matrixCount,
+      `--expected ${expected} disagrees with the ${matrixCount} vsix_target entries the build matrix produces`,
+    );
+  }
 }
 
 // One platform never reaches the registry no matter how often it is tried.
@@ -184,34 +198,19 @@ function openvsxScenario(failTimes) {
 
 // Executes a publish step's run block the way the runner does: cwd holding
 // the downloaded artifacts/ tree, PATH resolving npx and az to the stubs, and
-// the step's env populated. scripts/ is linked into the sandbox so the block
-// may delegate to repository scripts. DESLOP_PUBLISH_BACKOFF_SECONDS=0 keeps
-// any retry backoff out of the suite's runtime — tests must not sleep.
+// the step's env populated. DESLOP_PUBLISH_BACKOFF_SECONDS=0 keeps any retry
+// backoff out of the suite's runtime — tests must not sleep.
 function runPublishStep({ runBlock, failTimes, extraEnv }) {
   const sandbox = mkdtempSync(join(tmpdir(), "deslop-publish-contract-"));
   try {
-    for (const target of VSIX_TARGETS) {
-      const artifactDir = join(sandbox, "artifacts", `vsix-${target}`);
-      mkdirSync(artifactDir, { recursive: true });
-      writeFileSync(join(artifactDir, `deslop-live-${TEST_VERSION}-${target}.vsix`), "stub vsix");
-    }
-    symlinkSync(resolve(repoRoot, "scripts"), join(sandbox, "scripts"));
-    const stubBin = join(sandbox, "stub-bin");
-    mkdirSync(stubBin);
-    for (const [name, body] of [["npx", NPX_STUB], ["az", AZ_STUB]]) {
-      writeFileSync(join(stubBin, name), body);
-      chmodSync(join(stubBin, name), 0o755);
-    }
-    const log = join(sandbox, "publish-attempts.log");
-    writeFileSync(log, "");
-
+    const { stubBin, log } = buildSandbox(sandbox);
     const result = spawnSync(bash, ["-c", runBlock], {
       cwd: sandbox,
       encoding: "utf8",
       timeout: 120_000,
       env: {
         ...process.env,
-        PATH: `${stubBin}:${process.env.PATH}`,
+        PATH: `${stubBin}${delimiter}${process.env.PATH}`,
         STUB_LOG: log,
         FAIL_TARGET: TIMING_OUT_TARGET,
         FAIL_TIMES: String(failTimes),
@@ -221,25 +220,47 @@ function runPublishStep({ runBlock, failTimes, extraEnv }) {
       },
     });
     if (result.error) throw result.error;
-
-    const invocations = readFileSync(log, "utf8")
-      .split("\n")
-      .filter((line) => line !== "");
-    const attempts = Object.fromEntries(
-      VSIX_TARGETS.map((target) => [
-        target,
-        invocations.filter((line) => line.includes(`-${target}.vsix`)).length,
-      ]),
-    );
-    return {
-      status: result.status,
-      output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
-      attempts,
-      invocations,
-    };
+    return summarize(result, readFileSync(log, "utf8"));
   } finally {
     rmSync(sandbox, { recursive: true, force: true });
   }
+}
+
+// Five platform VSIX artifacts, the npx/az stubs, and the attempt log.
+// scripts/ is linked into the sandbox (a junction on Windows, where plain
+// symlinks need privileges) so the block may delegate to repository scripts.
+function buildSandbox(sandbox) {
+  for (const target of VSIX_TARGETS) {
+    const artifactDir = join(sandbox, "artifacts", `vsix-${target}`);
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(join(artifactDir, `deslop-live-${TEST_VERSION}-${target}.vsix`), "stub vsix");
+  }
+  symlinkSync(resolve(repoRoot, "scripts"), join(sandbox, "scripts"), "junction");
+  const stubBin = join(sandbox, "stub-bin");
+  mkdirSync(stubBin);
+  for (const [name, body] of [["npx", NPX_STUB], ["az", AZ_STUB]]) {
+    writeFileSync(join(stubBin, name), body);
+    chmodSync(join(stubBin, name), 0o755);
+  }
+  const log = join(sandbox, "publish-attempts.log");
+  writeFileSync(log, "");
+  return { stubBin, log };
+}
+
+function summarize(result, attemptsLog) {
+  const invocations = attemptsLog.split("\n").filter((line) => line !== "");
+  const attempts = Object.fromEntries(
+    VSIX_TARGETS.map((target) => [
+      target,
+      invocations.filter((line) => line.includes(`-${target}.vsix`)).length,
+    ]),
+  );
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    attempts,
+    invocations,
+  };
 }
 
 // The dedented body of the publish step's `run: |` block inside the given job.

--- a/scripts/test-release-version-stamping.mjs
+++ b/scripts/test-release-version-stamping.mjs
@@ -1,11 +1,11 @@
 // Tests for first-class release/test version stamping.
 
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { runContractSuite } from "./contract-suite.mjs";
 import { readActionPins } from "./stamp-release-version.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -30,26 +30,7 @@ const tests = [
   stamperRejectsInvalidVersion,
 ];
 
-let failed = 0;
-for (const test of tests) {
-  const work = mkdtempSync(join(tmpdir(), "deslop-version-stamp-"));
-  try {
-    test(work);
-    console.log(`ok ${test.name}`);
-  } catch (error) {
-    failed++;
-    console.error(`not ok ${test.name}`);
-    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-  } finally {
-    rmSync(work, { recursive: true, force: true });
-  }
-}
-
-if (failed > 0) {
-  console.error(`\n${failed} release version stamping test(s) failed`);
-  process.exit(1);
-}
-console.log(`\n${tests.length} release version stamping tests passed`);
+runContractSuite(tests, "release version stamping", "deslop-version-stamp-");
 
 function sourceProjectsUseVersionPlaceholder() {
   const placeholder = "0.0.0-dev";

--- a/scripts/test-release-workflow-contract.mjs
+++ b/scripts/test-release-workflow-contract.mjs
@@ -9,6 +9,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { runContractSuite } from "./contract-suite.mjs";
+
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const workflowPath = resolve(repoRoot, ".github/workflows/release.yml");
 const deployWorkflowPath = resolve(repoRoot, ".github/workflows/deploy-pages.yml");
@@ -45,23 +47,7 @@ const SCOOP_TEST_VERSION = "9.8.7";
 const SCOOP_TEST_SHA256 = "d713ca72419bc535e6c64605381255e544553356290b900b6c3f1eed21bee735";
 const SCOOP_TEST_REPOSITORY = "Nimblesite/Deslop";
 
-let failed = 0;
-for (const test of tests) {
-  try {
-    test();
-    console.log(`ok ${test.name}`);
-  } catch (error) {
-    failed++;
-    console.error(`not ok ${test.name}`);
-    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-if (failed > 0) {
-  console.error(`\n${failed} release workflow contract test(s) failed`);
-  process.exit(1);
-}
-console.log(`\n${tests.length} release workflow contract tests passed`);
+runContractSuite(tests, "release workflow contract");
 
 function releaseBuildsTaggedSourceWithoutPostTagVersionCommit() {
   const versionJob = sectionBetween("  version:", "  build:");

--- a/scripts/test-verifiers.mjs
+++ b/scripts/test-verifiers.mjs
@@ -3,10 +3,11 @@
 // violates one Shipwright contract rule so verifier failures have bite.
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, copyFileSync, chmodSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync, copyFileSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { runContractSuite } from "./contract-suite.mjs";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 const verifyManifest = join(repoRoot, "scripts/verify-deployment-manifest.mjs");
@@ -38,26 +39,7 @@ const cases = [
   releaseWorkflowAcceptsRepoWorkflow,
 ];
 
-let failed = 0;
-for (const test of cases) {
-  const work = mkdtempSync(join(tmpdir(), "deslop-verifier-"));
-  try {
-    test(work);
-    console.log(`ok ${test.name}`);
-  } catch (error) {
-    failed++;
-    console.error(`not ok ${test.name}`);
-    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
-  } finally {
-    rmSync(work, { recursive: true, force: true });
-  }
-}
-
-if (failed > 0) {
-  console.error(`\n${failed} verifier proof test(s) failed`);
-  process.exit(1);
-}
-console.log(`\n${cases.length} verifier proof tests passed`);
+runContractSuite(cases, "verifier proof", "deslop-verifier-");
 
 function manifestRejectsMissingProductId(work) {
   const path = join(work, "missing-product.json");


### PR DESCRIPTION
## TLDR

One transient registry timeout can no longer ship a partial release: both VSIX publish jobs retry each platform independently, attempt all five platforms regardless of individual failures, and fail naming the platforms that never reached the registry ([DEPLOY-PUBLISH-COMPLETE]). Works on #348.

## Details

On the v0.31.0 release ([run 31478952722](https://github.com/Nimblesite/Deslop/actions/runs/31478952722), attempt 1), one Marketplace request timeout aborted the `set -e` publish loop after `darwin-arm64`: `darwin-x64` failed and `linux-arm64`/`linux-x64`/`win32-x64` were never attempted, while Open VSX served all five. Nothing in the run named the missing platforms.

**New files**

- `scripts/publish-vsixes.mjs` — one shared publisher used by both registry jobs so they cannot drift apart. Per-platform retry (3 attempts, linear backoff via `DESLOP_PUBLISH_BACKOFF_SECONDS`, default 20 s), every platform attempted even when one keeps failing, and a final `::error::` naming the VSIXes that never reached the registry. It refuses to start when fewer VSIX artifacts exist than the build matrix produced (`--expected 5`) — a missing artifact upload must not become a partial release. `--skip-duplicate` is kept on every attempt, so retries and re-runs of a partially published tag stay idempotent. The `--pre-release` handling for hyphenated tags moved out of both YAML blocks into the script.
- `scripts/test-release-publish-contract.mjs` — contract suite for the publish steps (see the tests section below), wired into `make deployment-verify`.
- `scripts/contract-suite.mjs` — the TAP-style test-runner loop that the four existing contract suites each carried a copy of (and this PR would have made a fifth — Deslop flagged the cluster, structural 1.00 / token 1.00). It now lives once; `test-release-workflow-contract.mjs`, `test-release-version-stamping.mjs`, `test-verifiers.mjs`, and `test-deployment-docs-contract.mjs` are rewired onto it with identical output.

**Modified behaviour**

- `.github/workflows/release.yml` — `publish-marketplace` and `publish-openvsx` delegate their loops to the shared script; both gained an `actions/checkout@v7` step (neither previously checked out source) and had `timeout-minutes` raised 10 → 30, because the observed Marketplace failure mode is a ~3-minute hang per request and a 10-minute budget would let the runner kill the job mid-retry, recreating the "never attempted" state.
- `Makefile` — `deployment-verify` runs the new suite.
- `docs/specs/release.md` — new **[DEPLOY-PUBLISH-COMPLETE]** entry under Distribution channels documenting the retry, completeness, and naming guarantees.

**Breaking changes:** none to any public API, CLI flag, or report format. Release-pipeline behaviour changes: a partial publish that previously reported success-so-far now fails the job loudly with platform names, and the publish jobs' timeout budget is 30 minutes.

## How Do The Automated Tests Prove It Works?

`scripts/test-release-publish-contract.mjs` is black-box against the workflow itself: it extracts the two publish jobs' actual `run:` blocks from `release.yml` and executes them in a sandbox — five fake platform VSIXes under `artifacts/`, a stub `npx` scripted to time out the way the Marketplace did, a stub `az` for the token mint.

- `marketplaceAttemptsEveryPlatformWhenOneKeepsTimingOut` / `openvsxAttemptsEveryPlatformWhenOneKeepsTimingOut` — `darwin-x64` fails every attempt. Asserts all five platforms are still attempted, the job exits non-zero, an error line names `darwin-x64` as the platform missing from the registry, every recorded invocation carries `--skip-duplicate`, and the job does not claim "Published 5".
- `marketplaceRetriesATransientTimeoutUntilThePlatformPublishes` / `openvsxRetriesATransientTimeoutUntilThePlatformPublishes` — the exact v0.31.0 scenario: one timeout, then success. Asserts `darwin-x64` is attempted at least twice, all five platforms publish, the job exits 0 and reports `Published 5 VSIX(es)`.
- `expectedPublishCountMatchesTheBuildMatrix` — each job's `--expected` equals the number of `vsix_target` entries in the build matrix, so adding a sixth platform with a stale count fails in CI, not at release time.

All four behavioural tests were written first and observed failing against the pre-fix workflow with the same attempt signature as the real incident: `{"darwin-arm64":1,"darwin-x64":1,"linux-arm64":0,"linux-x64":0,"win32-x64":0}`.

After the runner extraction, the full deployment gate still passes: 8 release workflow contract, 5 release publish contract, 2 deployment docs contract, 7 version stamping, 33 verifier proof, and 27 action contract checks. Coverage thresholds in `coverage-thresholds.json` are untouched — no Rust code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

