### PR TITLE
Compute cosine similarity in f64 so byte-identical snippets report 1.0

### DIFF
--- a/crates/deslop-core/src/embedding/pairs.rs
+++ b/crates/deslop-core/src/embedding/pairs.rs
@@ -257,3 +257,79 @@ impl Point for CosinePoint {
         1.0_f32 - dot
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Vector widths spanning the mock fixtures (4) and the widths real
+    /// embedding models return, where the accumulated error is largest.
+    const WIDTHS: [usize; 4] = [4, 384, 768, 4096];
+
+    /// Deterministic non-dyadic components, so L2 normalisation cannot be
+    /// exact in binary floating point and the rounding under test is
+    /// actually exercised.
+    fn ramp(width: usize) -> Vec<f32> {
+        (0..width)
+            .map(|index| {
+                let step = u16::try_from(index % 997).unwrap_or_default();
+                0.1_f32 + f32::from(step) * 0.017_f32
+            })
+            .collect()
+    }
+
+    /// [FUSION-EMBED-PROVIDER] A vector is perfectly similar to itself. Two
+    /// byte-identical snippets share one vector (`group_snippets_by_content`
+    /// collapses them), so this is exactly the figure the report renders for
+    /// an identical clone pair — it must be `1.0`, not `0.999998`. GH #372.
+    #[test]
+    fn identical_vectors_have_cosine_similarity_of_exactly_one() {
+        for width in WIDTHS {
+            let vector = ramp(width);
+            let cosine = cosine_similarity(&vector, &vector);
+            assert!(
+                (cosine - 1.0).abs() < f64::EPSILON,
+                "a vector of width {width} must be perfectly similar to itself, got {cosine:.17}",
+            );
+        }
+    }
+
+    /// [FUSION-EMBED-PROVIDER] Scaling a vector does not change its
+    /// direction, so cosine stays exactly `1.0` regardless of magnitude.
+    #[test]
+    fn scaled_copies_of_a_vector_have_cosine_similarity_of_exactly_one() {
+        for width in WIDTHS {
+            let vector = ramp(width);
+            let scaled: Vec<f32> = vector.iter().map(|value| value * 3.5).collect();
+            let cosine = cosine_similarity(&vector, &scaled);
+            assert!(
+                (cosine - 1.0).abs() < f64::EPSILON,
+                "a scaled copy at width {width} must stay perfectly similar, got {cosine:.17}",
+            );
+        }
+    }
+
+    /// [FUSION-EMBED-PROVIDER] The accurate path still reports the analytic
+    /// answers for orthogonal, opposed, and degenerate inputs, so tightening
+    /// precision cannot be mistaken for widening admission.
+    #[test]
+    fn cosine_similarity_reports_analytic_values_for_known_vectors() {
+        assert!(
+            cosine_similarity(&[1.0, 0.0], &[0.0, 1.0]).abs() < f64::EPSILON,
+            "orthogonal vectors must score exactly 0.0",
+        );
+        assert!(
+            cosine_similarity(&[1.0, 0.0], &[-1.0, 0.0]).abs() < f64::EPSILON,
+            "opposed vectors must clamp to exactly 0.0",
+        );
+        assert!(
+            cosine_similarity(&[0.0, 0.0], &[1.0, 1.0]).abs() < f64::EPSILON,
+            "a zero-norm vector must score exactly 0.0",
+        );
+        let half = cosine_similarity(&[1.0, 0.0], &[1.0, 1.0]);
+        assert!(
+            (half - std::f64::consts::FRAC_1_SQRT_2).abs() < 1e-9,
+            "45 degrees apart must score 1/sqrt(2), got {half:.17}",
+        );
+    }
+}

--- a/crates/deslop-core/src/embedding/pairs.rs
+++ b/crates/deslop-core/src/embedding/pairs.rs
@@ -84,27 +84,23 @@ fn ann_embedding_pairs(embeddings: &[Vec<f32>]) -> Vec<EmbeddingPair> {
 /// Scores every pair exactly for small corpora where ANN top-k recall is
 /// more fragile than the quadratic work is expensive.
 fn exact_embedding_pairs(embeddings: &[Vec<f32>]) -> Vec<EmbeddingPair> {
-    let points: Vec<CosinePoint> = embeddings
-        .iter()
-        .map(|vector| CosinePoint::new(vector))
-        .collect();
     let mut pairs = Vec::new();
-    for left in 0..points.len() {
-        collect_exact_pairs_from(left, &points, &mut pairs);
+    for left in 0..embeddings.len() {
+        collect_exact_pairs_from(left, embeddings, &mut pairs);
     }
     pairs
 }
 
 /// Appends exact embedding candidates for one left endpoint.
-fn collect_exact_pairs_from(left: usize, points: &[CosinePoint], pairs: &mut Vec<EmbeddingPair>) {
-    let Some(left_point) = points.get(left) else {
+fn collect_exact_pairs_from(left: usize, embeddings: &[Vec<f32>], pairs: &mut Vec<EmbeddingPair>) {
+    let Some(left_vector) = embeddings.get(left) else {
         return;
     };
-    for right in left.saturating_add(1)..points.len() {
-        let Some(right_point) = points.get(right) else {
+    for right in left.saturating_add(1)..embeddings.len() {
+        let Some(right_vector) = embeddings.get(right) else {
             continue;
         };
-        let cosine = cosine_between(left_point, right_point);
+        let cosine = cosine_similarity(left_vector, right_vector);
         if admits_cosine(cosine) {
             pairs.push(EmbeddingPair {
                 left,
@@ -115,29 +111,41 @@ fn collect_exact_pairs_from(left: usize, points: &[CosinePoint], pairs: &mut Vec
     }
 }
 
-/// Returns cosine similarity for two already-normalised points.
-fn cosine_between(left: &CosinePoint, right: &CosinePoint) -> f64 {
-    cosine_from_distance(f64::from(left.distance(right)))
-}
-
 /// Returns the cosine similarity of two raw vectors in `[0, 1]`.
 ///
-/// This is the crate's single definition of cosine similarity: the same
-/// L2 normalisation, dot product, and negative-cosine clamp the ANN pass
-/// applies to every [`EmbeddingPair`]. Cluster-level signal measurement
-/// calls this so a rendered `embedding_cos` is always computed by the
-/// identical arithmetic that admitted the pair evidence — a second,
-/// subtly different cosine would let the report disagree with the
-/// pipeline about the same two vectors.
+/// This is the crate's single definition of cosine similarity, used both
+/// to admit exact-path pairs and to measure the rendered `embedding_cos`,
+/// so the report can never disagree with the pipeline about the same two
+/// vectors.
 ///
-/// Both the normalisation and the dot product run in `f32`. At four
-/// digits of vector width that accumulates about `2e-6` of drift, so two
-/// byte-identical snippets sharing one vector report `0.999998` rather
-/// than `1.0`. Harmless at the current four lanes, load-bearing at any
-/// realistic width — GH #369.
+/// Accumulation is `f64` over the raw `f32` components, and no
+/// intermediate normalised vector is materialised. Normalising into `f32`
+/// first and dotting the rounded components made the error grow with
+/// vector width — two byte-identical snippets, which share one vector
+/// because `group_snippets_by_content` collapses them, reported
+/// `0.999998` instead of `1.0`, and near-threshold pairs could be admitted
+/// or dropped on rounding alone. GH #372.
 #[must_use]
 pub fn cosine_similarity(left: &[f32], right: &[f32]) -> f64 {
-    cosine_between(&CosinePoint::new(left), &CosinePoint::new(right))
+    let scale = norm(left) * norm(right);
+    if scale <= 0.0 {
+        return 0.0;
+    }
+    (dot(left, right) / scale).clamp(0.0, 1.0)
+}
+
+/// Dot product accumulated in `f64` over the raw `f32` components.
+fn dot(left: &[f32], right: &[f32]) -> f64 {
+    left.iter()
+        .zip(right.iter())
+        .map(|(lhs, rhs)| f64::from(*lhs) * f64::from(*rhs))
+        .sum()
+}
+
+/// L2 norm accumulated in `f64`. Zero-norm vectors yield `0.0`, which
+/// [`cosine_similarity`] treats as "no direction, no similarity".
+fn norm(vector: &[f32]) -> f64 {
+    dot(vector, vector).sqrt()
 }
 
 /// Runs a single HNSW query and appends any surviving pairs to `out`.
@@ -294,16 +302,23 @@ mod tests {
         }
     }
 
+    /// Tolerance for a rescale, where bit-exactness is unachievable in any
+    /// precision: `dot(v, kv)` rounds to `k * dot(v, v)` while the divisor
+    /// rounds through `sqrt(X) * sqrt(k^2 * X)`. Set four orders of
+    /// magnitude below the `6e-8` the `f32` implementation produced, so
+    /// this still fails against the GH #372 arithmetic.
+    const RESCALE_TOLERANCE: f64 = 1e-12;
+
     /// [FUSION-EMBED-PROVIDER] Scaling a vector does not change its
-    /// direction, so cosine stays exactly `1.0` regardless of magnitude.
+    /// direction, so cosine stays `1.0` regardless of magnitude.
     #[test]
-    fn scaled_copies_of_a_vector_have_cosine_similarity_of_exactly_one() {
+    fn scaled_copies_of_a_vector_have_cosine_similarity_of_one() {
         for width in WIDTHS {
             let vector = ramp(width);
             let scaled: Vec<f32> = vector.iter().map(|value| value * 3.5).collect();
             let cosine = cosine_similarity(&vector, &scaled);
             assert!(
-                (cosine - 1.0).abs() < f64::EPSILON,
+                (cosine - 1.0).abs() < RESCALE_TOLERANCE,
                 "a scaled copy at width {width} must stay perfectly similar, got {cosine:.17}",
             );
         }

--- a/crates/deslop-core/src/embedding/pairs.rs
+++ b/crates/deslop-core/src/embedding/pairs.rs
@@ -84,23 +84,34 @@ fn ann_embedding_pairs(embeddings: &[Vec<f32>]) -> Vec<EmbeddingPair> {
 /// Scores every pair exactly for small corpora where ANN top-k recall is
 /// more fragile than the quadratic work is expensive.
 fn exact_embedding_pairs(embeddings: &[Vec<f32>]) -> Vec<EmbeddingPair> {
+    let norms: Vec<f64> = embeddings.iter().map(|vector| norm(vector)).collect();
     let mut pairs = Vec::new();
     for left in 0..embeddings.len() {
-        collect_exact_pairs_from(left, embeddings, &mut pairs);
+        collect_exact_pairs_from(left, embeddings, &norms, &mut pairs);
     }
     pairs
 }
 
 /// Appends exact embedding candidates for one left endpoint.
-fn collect_exact_pairs_from(left: usize, embeddings: &[Vec<f32>], pairs: &mut Vec<EmbeddingPair>) {
-    let Some(left_vector) = embeddings.get(left) else {
+///
+/// `norms` is precomputed once per vector by the caller. Deriving them
+/// inside this loop would re-walk both endpoints for every pair, widening
+/// an already `O(N^2 * D)` pass to three passes over every component.
+fn collect_exact_pairs_from(
+    left: usize,
+    embeddings: &[Vec<f32>],
+    norms: &[f64],
+    pairs: &mut Vec<EmbeddingPair>,
+) {
+    let (Some(left_vector), Some(left_norm)) = (embeddings.get(left), norms.get(left)) else {
         return;
     };
     for right in left.saturating_add(1)..embeddings.len() {
-        let Some(right_vector) = embeddings.get(right) else {
+        let (Some(right_vector), Some(right_norm)) = (embeddings.get(right), norms.get(right))
+        else {
             continue;
         };
-        let cosine = cosine_similarity(left_vector, right_vector);
+        let cosine = cosine_from_parts(left_vector, right_vector, left_norm * right_norm);
         if admits_cosine(cosine) {
             pairs.push(EmbeddingPair {
                 left,
@@ -127,7 +138,14 @@ fn collect_exact_pairs_from(left: usize, embeddings: &[Vec<f32>], pairs: &mut Ve
 /// or dropped on rounding alone. GH #372.
 #[must_use]
 pub fn cosine_similarity(left: &[f32], right: &[f32]) -> f64 {
-    let scale = norm(left) * norm(right);
+    cosine_from_parts(left, right, norm(left) * norm(right))
+}
+
+/// Divides the `f64` dot product by an already-computed norm product, so
+/// the quadratic pair loop can hoist both norms out of its inner body
+/// without duplicating the arithmetic [`cosine_similarity`] defines.
+/// A non-positive scale means at least one vector has no direction.
+fn cosine_from_parts(left: &[f32], right: &[f32], scale: f64) -> f64 {
     if scale <= 0.0 {
         return 0.0;
     }

--- a/crates/deslop/tests/issue_372_identical_snippet_cosine.rs
+++ b/crates/deslop/tests/issue_372_identical_snippet_cosine.rs
@@ -1,0 +1,108 @@
+//! Black-box guard for GH #372: a byte-identical clone pair must render
+//! `embedding_cos = 1.0`.
+//!
+//! `group_snippets_by_content` collapses byte-identical snippets onto a
+//! single vector, so the rendered cosine is `cosine(v, v)` — analytically
+//! `1.0` for any `v`, and independent of what the embedder returns. That
+//! makes it the one embedding figure whose exact value is knowable without
+//! trusting the provider, which is why it is asserted here against the
+//! rendered report rather than against the arithmetic.
+//!
+//! This assertion is green both before and after the #372 fix, and is a
+//! guard rather than the regression test. `cosine_from_distance` clamps to
+//! `[0, 1]`, so accumulated `f32` error is only visible when it happens to
+//! round *down*; at the mock's four lanes it rounds up and the clamp
+//! absorbs it. Widening the mock does not fix that — the direction stays a
+//! rounding coincidence (measured: ~63% of seed offsets expose it at 4096
+//! lanes), and a red test built on that coincidence would be calibrated
+//! against noise, the defect class of GH #366. The arithmetic itself is
+//! pinned by the unit tests in `deslop-core/src/embedding/pairs.rs`.
+
+#[path = "cli/mock_ollama.rs"]
+mod mock_ollama;
+
+mod common;
+
+use anyhow::Result;
+use mock_ollama::MockOllama;
+
+use crate::common::{
+    cluster_bucket, clusters, embeddings::run_mock_embedding_report, expect_cluster_spanning,
+    occurrence_files, signal, write_identical_pair,
+};
+
+/// A non-trivial C# method: a guard clause, an accumulator loop and a
+/// return, so the clone is a real code unit rather than a stub.
+const TALLY: &str = "namespace Ledger\n\
+    {\n\
+    \x20   public class Beacon\n\
+    \x20   {\n\
+    \x20       public int Tally(int bound)\n\
+    \x20       {\n\
+    \x20           if (bound < 0)\n\
+    \x20           {\n\
+    \x20               return 0;\n\
+    \x20           }\n\
+    \x20           int total = 0;\n\
+    \x20           for (int step = 0; step < bound; step = step + 1)\n\
+    \x20           {\n\
+    \x20               total = total + step;\n\
+    \x20           }\n\
+    \x20           return total;\n\
+    \x20       }\n\
+    \x20   }\n\
+    }\n";
+
+/// [FUSION-EMBED-PROVIDER] Two byte-identical files share one embedding
+/// vector, so the rendered cosine is exactly `1.0` — not `0.999998`.
+/// Every other embedding cosine in the report stays inside `[0, 1]`.
+#[test]
+fn byte_identical_clone_pair_renders_embedding_cosine_of_exactly_one() -> Result<()> {
+    let server = MockOllama::spawn()?;
+    let workspace = tempfile::tempdir()?;
+    write_identical_pair(workspace.path(), "cs", TALLY)?;
+    let output = workspace.path().join("report");
+    let report = run_mock_embedding_report(workspace.path(), &output, "10", server.endpoint())?;
+
+    let cluster = expect_cluster_spanning(&report, &["a.cs", "b.cs"])?;
+    assert_eq!(
+        occurrence_files(cluster),
+        vec!["a.cs".to_owned(), "b.cs".to_owned()],
+        "the identical files must cluster together: {cluster:#}",
+    );
+    assert_eq!(
+        cluster_bucket(cluster),
+        "identical",
+        "a byte-identical file pair is an identical clone: {cluster:#}",
+    );
+
+    let cosine = signal(cluster, "embedding_cos");
+    assert!(
+        cosine > 0.0,
+        "fixture never reached the embedder, so the cosine proves nothing: {cluster:#}",
+    );
+    assert!(
+        (cosine - 1.0).abs() < f64::EPSILON,
+        "byte-identical snippets share one vector, so the rendered cosine must be \
+         exactly 1.0, got {cosine:.17}: {cluster:#}",
+    );
+    assert_eq!(
+        signal(cluster, "structural"),
+        1.0,
+        "an identical clone must also be structurally exact: {cluster:#}",
+    );
+    assert_eq!(
+        signal(cluster, "token_jaccard"),
+        1.0,
+        "an identical clone must also have exact token overlap: {cluster:#}",
+    );
+
+    for other in clusters(&report) {
+        let value = signal(other, "embedding_cos");
+        assert!(
+            (0.0..=1.0).contains(&value),
+            "embedding_cos escaped [0,1]: {other:#}",
+        );
+    }
+    Ok(())
+}

--- a/crates/deslop/tests/issue_372_identical_snippet_cosine.rs
+++ b/crates/deslop/tests/issue_372_identical_snippet_cosine.rs
@@ -86,15 +86,15 @@ fn byte_identical_clone_pair_renders_embedding_cosine_of_exactly_one() -> Result
         "byte-identical snippets share one vector, so the rendered cosine must be \
          exactly 1.0, got {cosine:.17}: {cluster:#}",
     );
-    assert_eq!(
-        signal(cluster, "structural"),
-        1.0,
-        "an identical clone must also be structurally exact: {cluster:#}",
+    let structural = signal(cluster, "structural");
+    assert!(
+        (structural - 1.0).abs() < f64::EPSILON,
+        "an identical clone must be structurally exact, got {structural:.17}: {cluster:#}",
     );
-    assert_eq!(
-        signal(cluster, "token_jaccard"),
-        1.0,
-        "an identical clone must also have exact token overlap: {cluster:#}",
+    let jaccard = signal(cluster, "token_jaccard");
+    assert!(
+        (jaccard - 1.0).abs() < f64::EPSILON,
+        "an identical clone must have exact token overlap, got {jaccard:.17}: {cluster:#}",
     );
 
     for other in clusters(&report) {

--- a/docs/plans/rename-recall-plan.md
+++ b/docs/plans/rename-recall-plan.md
@@ -1,0 +1,73 @@
+# Rename-recall repair plan — #367, #369, #370, #373
+
+One defect family: **a consistently-renamed real duplicate never reaches the report.** Two mechanisms lose it — the token signature drops the pair before it clusters (#367, and its downstream #369/#370), and the noise filters hide the cluster after it forms (#373). Every fix below is a *replacement*: the defective code is deleted, not guarded, not thresholded, not wrapped.
+
+Supersedes `docs/plans/embedding-accuracy-plan.md`, which covered only the embedding half. Nothing references it; it is deleted as part of step 0.
+
+## Measured at HEAD `8dc3d1f47`
+
+| # | Repro | Result |
+|---|---|---|
+| #367 | Two 1.1 KB TS files, consistent rename + **one** added paren pair (1 node in ~380) | `Found 0 groups`, `clusters_hidden: 0` — pair dies at fusion. Drop the parens → `Found 1 group`. |
+| #373 | Same-named `normalize_records` helper copied into two Python modules, locals renamed | `Found 0 groups`, `clusters_hidden: 1`. Log: `structural=1.0 token_jaccard=1.0 rename_consistency=0.94` — a textbook Type-2, hidden by the noise filter. |
+| #369 | 3 `#[ignore]`d tests in tree | `pair_size_coherence:124`, `issue_343_sum_clamp_saturation:89`, `lsp_embedding_determinism:36` |
+| #370 | 1 `#[ignore]`d test in tree | `embedding_failure_progress:32` — hangs >14 min on the rejected-refresh path |
+
+## Fix 1 — [FUSION-SIGNALS-TOKEN-MULTISET] (#367, root cause)
+
+`crates/deslop-core/src/lsh.rs::minhash_signature` estimates Jaccard over the **set** of distinct k-grams. A repetitive body has a small distinct-gram set, so one inserted node displaces a large share of it: two functions 99.7% identical by node count measure `token_jaccard = 0.664`, `structural = 0` (the paren rehashes every ancestor Merkle), and `bounded_fused < FUSED_THRESHOLD` kills the pair. Nothing downstream can recover it.
+
+**Delete** the set-of-distinct-grams feed into `minhash_signature` (`pipeline/signatures.rs::signature_for_tokens`). **Replace** with a multiset signature — each k-gram occurrence tagged with its per-type ordinal, so multiplicity carries weight and a single inserted node perturbs a handful of features instead of a whole feature class. `estimate_jaccard`, `BANDS`, `ROWS_PER_BAND`, `SIGNATURE_LEN` are unchanged; this is a feature-construction replacement, not a scoring one.
+
+**Not permitted:** lowering `FUSED_THRESHOLD` or `LSH_ONLY_MIN_JACCARD`. Validation runs both directions on the pinned corpus — recall on shape-changing Type-3, and zero new false positives on repetitive scaffolding.
+
+## Fix 2 — [CLONE-NOISE-COPY-PROOF] (#373)
+
+Every noise filter's escape hatch compares **raw source bytes**, so only a *verbatim* copy survives and every renamed copy is hidden. The module header at `cluster_filters/mod.rs:88` claims "a verbatim/renamed copy survives" — the code has never done the renamed half.
+
+**Delete** `enclosing_function_bodies_differ` (`cluster_filters/mod.rs:471`) and all seven `raw_snippet_texts_differ` call sites: `mod.rs:221`, `dart.rs:101`, `dart_data_table.rs:37`, `ecmascript.rs:27`, `python_constants.rs:33`, `rust.rs:422`, `rust.rs:517`. **Replace** with one predicate over the `ContentEvidence` the pipeline already measures (`content.rs` — `agreement`, `rename_consistency`, `literal_fraction`): a cluster whose identifier mapping is bijective and whose literals align is a *proven copy* and is never filtered as noise. `cluster_is_hidden` already holds `cluster.content`; thread it into `is_noise_pattern` rather than re-deriving anything. One predicate, seven call sites, no per-language variants.
+
+## Fix 3 — [FUSION-EMBED-PROVIDER] (#369a)
+
+`crates/deslop/tests/cli/mock_ollama.rs::embed_vector` returns `[sin(len), cos(first_byte), 0.5, -0.5]`: two constant lanes floor every cosine and `sin` aliases over length — a 67-byte and an 865-byte text score 0.99997. That manufactures the two embedding-only false positives #369 names.
+
+**Delete** `embed_vector`. **Replace** with a 128-lane signed shingle signature (L2-normalised indicator of distinct 5-char shingles, sign-folded to 128 lanes — measured separations 0.954 real pair / 0.782 whole-fn vs chunk / 0.107 params vs chunk / 1.0 identical). 4096 lanes is not landable: `exact_embedding_pairs` is O(N²·D) and blew past ten minutes. Keep `CosinePoint`'s precomputed per-point norm; never recompute norms inside the pair loop. Recalibrate the ~88 dependent `embedding_cos` assertions against the honest instrument — equal or stronger discrimination, none deleted or loosened.
+
+## Fix 4 — [PAIR-SIZE-COHERENCE] (#369b)
+
+`pair.rs::survival_decision` applies the LSH-only floors only when `structural <= 0 && embedding_cos <= 0`, so any ε of cosine waives both the 0.90 Jaccard floor and the 40-node floor — *weaker* corroboration promotes a pair.
+
+**Delete** the `&& embedding_cos <= 0` conjunct. **Replace** with: every `structural <= 0` pair must clear `lsh_only_node_floor`; the Jaccard floor is waived only when `embedding_cos >= fused_min_score`, i.e. when the embedding axis independently clears the survival bar. No new constants.
+
+## Fix 5 — [RANK-CATEGORY] un-gate the LSH promotion
+
+`report_render.rs::is_csharp_lsh_type3_near_miss` promotes a language-agnostic evidence profile but requires `language == "csharp"`, so the identical TypeScript pair routes `LooselySimilar` → hidden.
+
+**Delete** the language test and the `csharp` in the function name. Sweep the corpus fixtures: any newly visible cluster is adjudicated as genuine or earns its own filter *with its own fixture* — never a threshold bump. Reaches nothing until Fix 1 lands (the path also needs `token_jaccard >= 0.90`; measured 0.664).
+
+## Fix 6 — [LIVE-EMBEDDING-REFRESH-TERMINAL] (#370)
+
+On the rejected-refresh path the server emits no terminal `deslop/embeddingProgress` frame, so the client blocks forever in the unbounded read — upstream of the test's 20 s timeout. This is a server defect, not a test defect.
+
+**Delete** the path that can exit without publishing a terminal frame. **Replace** with a refresh that publishes exactly one terminal frame (success *or* failure) on every exit, preserving the last-good report. Adding a client-side timeout to the test is prohibited — it would convert a hang into a green run over a server that still hangs in the editor.
+
+## Order and gates
+
+`0 → 1 → 5 → 3 → 4 → 6`; Fix 2 is independent and can land first. After each fix: the four un-ignored tests, then `cargo test --workspace --all-targets --features deslop-core/live`, then the self-scan duplication gate. Un-ignoring is the acceptance criterion — no assertion may be weakened, no `#[ignore]` may be added, and a red test left in the tree beats a softened one.
+
+## Checklist
+
+- [ ] **0.** Promote the four scratchpad repros to committed fixtures (`ts-rename-paren` for #367, `py-renamed-helper` for #373); delete `docs/plans/embedding-accuracy-plan.md`
+- [ ] **1a.** Red E2E, no embeddings: rename + one paren pair, `--min-nodes 100` → 1 visible cluster, 2 occurrences spanning the whole function (`start_byte <= 9`, `end_byte >= 1200`), act-now bucket, `clusters_hidden == 0`
+- [ ] **1b.** Delete the distinct-gram feed; replace with the ordinal-tagged multiset signature
+- [ ] **1c.** Corpus sweep both directions — recall up, zero new false positives, no threshold touched
+- [ ] **2a.** Red E2E: same-named helper, consistent rename, two files → 1 visible cluster, `clusters_hidden == 0`, `Nearly identical`; byte-identical control still `Identical`
+- [ ] **2b.** Delete `enclosing_function_bodies_differ` + all 7 `raw_snippet_texts_differ` call sites; replace with the single `ContentEvidence` copy-proof predicate
+- [ ] **2c.** Correct the `cluster_filters/mod.rs` header claims to match the code
+- [ ] **3.** Delete `embed_vector`; replace with the 128-lane shingle signature; recalibrate the ~88 `embedding_cos` assertions
+- [ ] **4.** Delete the `embedding_cos <= 0` conjunct in `survival_decision`; node floor always, Jaccard waiver only at `cos >= fused_min_score`
+- [ ] **5.** Delete the `csharp` language gate in `is_csharp_lsh_type3_near_miss`; rename; adjudicate every newly visible corpus cluster
+- [ ] **6.** Delete the no-terminal-frame exit in the embedding refresh; publish exactly one terminal frame per refresh
+- [ ] **7.** Un-ignore all four: `pair_size_coherence:124`, `issue_343_sum_clamp_saturation:89`, `lsp_embedding_determinism:36`, `embedding_failure_progress:32`
+- [ ] **8.** Restore the blanked spec IDs at `cluster_filters/mod.rs:444` (`Detects ****:`) and `report_render.rs:355` (dangling `//,`); register `[FUSION-SIGNALS-TOKEN-MULTISET]`, `[CLONE-NOISE-COPY-PROOF]`, `[LIVE-EMBEDDING-REFRESH-TERMINAL]` in `docs/specs/`
+- [ ] **9.** `make ci` green, coverage ratchet held, self-scan duplication gate passes


### PR DESCRIPTION
## TLDR

Compute cosine similarity in `f64` over raw embedding components so byte-identical snippets report `embedding_cos = 1.0` instead of `0.999998`. Closes #372.

## Details

**The defect.** `cosine_similarity` routed through `CosinePoint`, which L2-normalised into `f32`, and then `Point::distance` dotted those already-rounded components with `f32` `mul_add`. The conversion to `f64` happened only at the very end, after all the error had accumulated. Because `group_snippets_by_content` collapses byte-identical snippets onto a single vector, an identical clone pair was measuring `cosine(v, v)` — analytically exactly `1.0` — and rendering `0.999998`. Error grows with vector width: negligible at the 4-lane test mock, ~2e-6 at the 768–4096 lanes real embedding models return.

Two things were wrong with that, both in `crates/deslop-core/src/embedding/pairs.rs`:

1. **A rendered figure was inaccurate.** `embedding_cos` reaches the report through `cluster/signals.rs`, which calls this function. Byte-identical code that does not report `1.0` fails the transparency bar directly.
2. **It could flip admission.** The same arithmetic gates the exact small-corpus pair path against `MIN_COSINE`, so rounding alone could admit or drop a near-threshold pair.

**The change.**

- `cosine_similarity` now accumulates the dot product and both norms in `f64` over the raw `f32` components, via two new private helpers `dot` and `norm`. No intermediate normalised vector is materialised, so there is no rounding step before the arithmetic.
- `exact_embedding_pairs` / `collect_exact_pairs_from` now take the raw `&[Vec<f32>]` and call `cosine_similarity` directly instead of building `CosinePoint`s. The exact path and the rendered signal are therefore computed by literally the same code.
- `exact_embedding_pairs` hoists each vector's norm into a `Vec<f64>` computed once, and the inner loop passes the norm *product* to a new `cosine_from_parts`. Deriving norms per pair would have re-walked both endpoints for every comparison, widening an already `O(N^2 * D)` pass to three passes over every component — precisely what `docs/plans/rename-recall-plan.md` (Fix 3, in this diff) forbids. `cosine_similarity` calls the same helper, so the two entry points cannot drift apart.
- `cosine_between` is deleted — it had no remaining callers.
- `CosinePoint` and its `Point::distance` impl are unchanged and still `f32`. The `instant_distance` trait requires `f32`, and the ANN pass only *proposes* candidates; it does not produce the rendered figure. Every ANN candidate is re-measured by `cosine_similarity` before it reaches a report.

Behaviour that deliberately did not change: the `[0, 1]` clamp, the `MIN_COSINE` floor of 0.80, `admits_cosine`'s finiteness check, and the zero-norm short-circuit returning `0.0`.

**Also in this branch:** `docs/plans/rename-recall-plan.md` — a new plan covering the rename-recall defect family (#367, #369, #370, #373), superseding `docs/plans/embedding-accuracy-plan.md`. It is documentation only and touches no code in this PR.

## How Do The Automated Tests Prove It Works?

**`crates/deslop-core/src/embedding/pairs.rs`** — three unit tests isolating the arithmetic, each sweeping widths `[4, 384, 768, 4096]` (the mock width plus the three widths real models return):

- `identical_vectors_have_cosine_similarity_of_exactly_one` — asserts `cosine(v, v)` is within `f64::EPSILON` of `1.0`. Against the old code this failed at width 384 with `0.99999982118606567`.
- `scaled_copies_of_a_vector_have_cosine_similarity_of_one` — asserts `cosine(v, 3.5·v)` stays `1.0` within `1e-12`. Bit-exactness is unachievable across a rescale in any precision, because `dot(v, kv)` rounds to `k·dot(v,v)` while the divisor rounds through `sqrt(X)·sqrt(k²X)`; the bound is still four orders of magnitude tighter than the `6e-8` the `f32` code produced, so it fails against the old arithmetic.
- `cosine_similarity_reports_analytic_values_for_known_vectors` — pins orthogonal (`0.0`), opposed (`0.0` after clamp), zero-norm (`0.0`), and 45° (`1/sqrt(2)`). The 45° case is the important one: the old code returned `0.70710676908493042` against `0.70710678118654752`, an error in the *interior* of the range where no clamp masks it. This is the near-threshold flip, demonstrated numerically.

**`crates/deslop/tests/issue_372_identical_snippet_cosine.rs`** — new black-box suite. Writes two byte-identical C# files, scans them with the mock Ollama provider, and asserts against the rendered JSON report: the cluster spans exactly `a.cs` and `b.cs`, its bucket is `identical`, `structural` and `token_jaccard` are exactly `1.0`, `embedding_cos` is greater than zero (proving the embedder was actually reached, so the assertion is not vacuous) and within `f64::EPSILON` of `1.0`, and every cluster in the report has `embedding_cos` inside `[0, 1]`.

This E2E suite is honest about its own limits, and its module doc says so: it is **green both before and after** the fix, and is a guard rather than the regression pin. `cosine_from_distance` clamps to `[0, 1]`, so accumulated `f32` error is only observable when it happens to round *down*; at the mock's four lanes it rounds up and the clamp absorbs it. Widening the mock does not help — measured across seed offsets at 4096 lanes, only ~63% expose the drift, so the direction is a rounding coincidence. A red test built on that coincidence would be calibrated against noise, which is the defect class of #366. The mock is therefore left untouched, and the arithmetic is pinned by the unit tests above.

No existing assertion was weakened, no test was ignored or deleted, and no lint suppression was added. `make ci` passes, including `-D clippy::pedantic`.

## For AI

Root cause is precision-loss ordering in `crates/deslop-core/src/embedding/pairs.rs`. Prior call graph: `cosine_similarity(&[f32], &[f32]) -> cosine_between(CosinePoint, CosinePoint) -> cosine_from_distance(f64::from(CosinePoint::distance))`. `CosinePoint::new` accumulated `norm_sq: f32` via `mul_add`, took an `f32` `sqrt`, and materialised an `f32` normalised copy; `Point::distance` then folded an `f32` dot over those quantised components. Three rounding stages preceded the single `f64` widening, so absolute error scaled with lane count D (~2e-6 at D=4096) rather than with `f64` unit roundoff.

New call graph: `cosine_similarity` computes `dot(l,r) / (norm(l) * norm(r))` where `dot` folds `f64::from(lhs) * f64::from(rhs)` and `norm(v) = dot(v,v).sqrt()`. Widening happens per-component before any accumulation; no normalised intermediate exists. `scale <= 0.0` short-circuits to `0.0`, preserving the prior zero-norm contract and making the `NaN` path unreachable from zero vectors. Terminal `.clamp(0.0, 1.0)` retained, so `admits_cosine`'s `is_finite()` guard against overflowing provider vectors (#5 / `embedding_non_finite`) is unaffected.

`exact_embedding_pairs` was re-typed from `&[CosinePoint]` to `&[Vec<f32>]`, eliminating N `CosinePoint` allocations on the `EXACT_PAIR_LIMIT <= 256` path and collapsing the exact-admission and signal-measurement arithmetic to one function — previously they were the same code by construction but via a lossy adapter. `cosine_between` removed as dead. ANN path (`ann_embedding_pairs` → `instant_distance::HnswMap` → `collect_neighbours` → `cosine_from_distance(f64::from(hit.distance))`) intentionally retains `f32` because `Point::distance` is trait-constrained to `-> f32`; ANN output is candidate-generation only and every surviving pair is re-measured by `cosine_similarity` in `cluster/signals.rs` before rendering.

Observability asymmetry worth recording for #366: the `[0,1]` clamp in `cosine_from_distance` makes the defect a one-sided observable. `cosine(v,v)` error is visible only when the `f32` self-dot lands below 1.0; when it lands above, `1.0 - distance > 1.0` clamps to exactly `1.0` and the defect is masked. Empirically the sign is width- and value-dependent (D=384 and D=4096 expose it under a non-dyadic ramp; D=768 and D=1536 mask it; across ±2.0 seed offsets at D=4096, 26/41 expose). Consequently no black-box fixture can robustly pin this class, and `MockBehavior` was left at four lanes rather than adding a wide variant whose redness would depend on rounding luck.

`RESCALE_TOLERANCE = 1e-12` is a mathematical bound, not a softened assertion: exact equality is unattainable across a rescale because the numerator and denominator round through different expression trees. Discriminating power against the pre-fix implementation is preserved with ~4 orders of magnitude of margin (`6e-8` observed vs `1e-12` bound).
