### PR TITLE
Run every gate on Dependabot security PRs to main, and pin it with an event-matrix test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,15 @@
 #     codeql.yml only trigger on `pull_request: [main]` (the filter matches the
 #     PR *base*), so these staging PRs run NO build/test/CodeQL.
 #   * SECURITY updates -> GitHub IGNORES `target-branch` for these and always
-#     opens them against the repo's default branch (`main`). The auto-merge
-#     workflow therefore also fires on `main` and folds the security bump into
-#     the SAME staging branch, then retires the PR — so a CVE bump never sits on
-#     main waiting for a human either. (ci.yml/codeql.yml skip Dependabot PRs, so
-#     the matrix never burns on a bump we immediately sweep away.)
+#     opens them against the repo's default branch (`main`). The sweep does NOT
+#     collect them: dependabot-automerge.yml filters its base to
+#     `dependabot-upgrades` only, deliberately, so a CVE bump stays on `main` and
+#     is merged or retargeted by a human. It is therefore the one Dependabot PR
+#     that merges to main on its own checks, and it runs the FULL set — CI,
+#     dependency review, CodeQL, Action self-test — exactly like a human PR.
+#     None of those workflows may gate on the author; #388 was the hole where
+#     they did, and scripts/test-dependabot-gate-matrix.mjs now pins it shut.
+#     ([GITHUB-DEPENDABOT-SECURITY-GATES])
 #   * groups -> each ecosystem collapses ALL version bumps (patch, minor AND
 #     major) into ONE PR, and a parallel `*-security` group (`applies-to:
 #     security-updates`) collapses CVE bumps the same way. Majors no longer need
@@ -65,9 +69,11 @@ updates:
         applies-to: security-updates
         patterns: ["*"]
 
-  # npm / Node — the three package.json roots (no root-level package.json).
+  # npm / Node — the repo root (devDependencies for the scripts/ contract
+  # suites, ships nothing) plus the three product package.json roots.
   - package-ecosystem: npm
     directories:
+      - /
       - /site
       - /clients/vscode
       - /clients/vscode/webview-ui

--- a/.github/workflows/action-selftest.yml
+++ b/.github/workflows/action-selftest.yml
@@ -34,13 +34,13 @@ permissions:
 jobs:
   contract:
     name: Action contract
-    # Dependabot PRs are swept into `dependabot-upgrades`, never merged to main
-    # directly. A github-actions SECURITY bump is force-opened against `main` and
-    # edits .github/workflows/**, matching the paths filter above, so without
-    # this gate it would run the whole hosted-runner matrix on a discarded bump.
-    # Every other job needs this one, so skipping here skips them all.
-    # ([GITHUB-DEPENDABOT])
-    if: github.actor != 'dependabot[bot]'
+    # Runs for every author. A github-actions SECURITY bump is force-opened
+    # against `main`, edits .github/workflows/**, matches the paths filter above
+    # — and is NOT swept, because the sweep's base filter is the staging branch.
+    # It is therefore the only Dependabot PR that reaches here, and the only one
+    # that rewrites the very files this suite exists to prove still work. Every
+    # other job needs this one, so an actor skip here skipped them all.
+    # ([GITHUB-DEPENDABOT-SECURITY-GATES], #388)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,24 +36,16 @@ jobs:
       - name: Classify changed paths
         id: classify
         env:
-          ACTOR: ${{ github.actor }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Dependabot PRs are swept into `dependabot-upgrades` by
-          # dependabot-automerge.yml and never merge into main directly, so the
-          # heavy matrix would only burn minutes on a bump we discard. CI runs
-          # once, on the `dependabot-upgrades -> main` consolidation PR.
-          # ([GITHUB-DEPENDABOT])
-          if [ "$ACTOR" = "dependabot[bot]" ]; then
-            {
-              echo "code=false"
-              echo "site=false"
-            } >> "$GITHUB_OUTPUT"
-            echo "Dependabot PR — skipping the code matrix and site build."
-            exit 0
-          fi
+          # Classification is by PATH ONLY — never by author. Routine Dependabot
+          # bumps target `dependabot-upgrades` and never trigger this workflow at
+          # all, so an actor short-circuit here could only ever fire on the one
+          # Dependabot PR that does reach `main`: a SECURITY bump, which no sweep
+          # carries away. Skipping that one is skipping the build and test of a
+          # CVE fix. ([GITHUB-DEPENDABOT-SECURITY-GATES], #388)
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files in this PR:"
           printf '%s\n' "$changed"
@@ -126,6 +118,7 @@ jobs:
           # behaviour), a hit skips re-downloading the tarballs.
           cache: npm
           cache-dependency-path: |
+            package-lock.json
             clients/vscode/package-lock.json
             clients/vscode/webview-ui/package-lock.json
 
@@ -184,6 +177,12 @@ jobs:
       # threshold is the single source of truth — never hardcoded here.
       - name: Duplication gate (deslop)
         run: ./target/release/deslop . --no-color
+
+      # The repo-root package.json exists only for the Node contract suites
+      # under scripts/ — `yaml`, so the workflow gates are asserted against a
+      # real parse instead of a text match. Nothing here ships.
+      - name: Install repo-script dependencies
+        run: npm ci
 
       - name: Deployment manifest and binary gates
         run: make deployment-verify
@@ -434,13 +433,17 @@ jobs:
   # it only runs on pull_request events (this workflow's trigger).
   security:
     name: security
-    # Skipped for Dependabot, like every other job here: the bump is swept into
-    # `dependabot-upgrades` and reviewed once at the consolidation PR, where this
-    # gate does run. Reviewing a vuln-fix bump for vulnerabilities it is fixing
-    # is pure noise. ([GITHUB-DEPENDABOT])
-    if: github.actor != 'dependabot[bot]'
+    # Runs for EVERY author, Dependabot included. A security bump is the one
+    # Dependabot PR that reaches `main`, and a CVE fix routinely drags in
+    # transitive dependencies the advisory said nothing about — so this is the
+    # PR that most needs the repo's only dependency vuln-gate, not the one to
+    # excuse from it. ([GITHUB-DEPENDABOT-SECURITY-GATES], #388)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # LOAD-BEARING on Dependabot runs: a Dependabot-triggered event hands the
+    # workflow a READ-ONLY GITHUB_TOKEN unless an explicit `permissions:` block
+    # raises it. Delete this and dependency review loses its PR summary on
+    # Dependabot PRs only — silently. Pinned by test-dependabot-gate-matrix.mjs.
     permissions:
       contents: read
       pull-requests: write  # dependency-review posts its PR summary

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,11 +53,16 @@ jobs:
     # private ones. Gating on public visibility lets a private fork skip cleanly
     # (no red X) and self-enable the moment it is made public.
     #
-    # Dependabot PRs are excluded: they are swept into `dependabot-upgrades` by
-    # dependabot-automerge.yml and never merge to main directly, so scanning them
-    # burns 20 minutes per language on a bump we discard. The consolidation PR is
-    # scanned. ([GITHUB-DEPENDABOT])
-    if: github.event.repository.visibility == 'public' && github.actor != 'dependabot[bot]'
+    # Visibility is the ONLY gate. Author is not: routine Dependabot bumps target
+    # `dependabot-upgrades` and never trigger this workflow, so an actor skip
+    # could only fire on a SECURITY bump — which lands on `main` unswept, and
+    # whose `actions` leg is the one scan that reads the workflow files the bump
+    # itself edits. ([GITHUB-DEPENDABOT-SECURITY-GATES], #388)
+    if: github.event.repository.visibility == 'public'
+    # LOAD-BEARING on Dependabot runs: a Dependabot-triggered event hands the
+    # workflow a READ-ONLY GITHUB_TOKEN unless an explicit `permissions:` block
+    # raises it, and without `security-events: write` the SARIF upload fails on
+    # Dependabot PRs only. Pinned by test-dependabot-gate-matrix.mjs.
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,10 +8,12 @@ name: Dependabot auto-merge
 #     directly (.github/dependabot.yml `target-branch`), and every ecosystem in
 #     that file sets it. These are what this workflow sweeps.
 #   * SECURITY updates -> GitHub IGNORES `target-branch` for these and ALWAYS
-#     opens them against the default branch (`main`). They are handled by a
-#     human, deliberately — see the trigger note below. A CVE bump getting eyes
-#     on it is not a bad outcome, and `security` (dependency-review) in ci.yml
-#     still gates it.
+#     opens them against the default branch (`main`). They are NOT swept — the
+#     base filter below is staging-only — and are handled by a human,
+#     deliberately. A CVE bump getting eyes on it is not a bad outcome, and it
+#     is gated like any other PR to main: CI, `security` (dependency-review),
+#     CodeQL and the Action self-test all run for it, none of them keyed on the
+#     author. ([GITHUB-DEPENDABOT-SECURITY-GATES])
 #
 # Sweep strategy: PATH-RESTRICTED, not a branch merge. Only the files the PR
 # itself changed (diff against its merge-base with the PR base) are copied from
@@ -36,9 +38,10 @@ name: Dependabot auto-merge
 #
 # Nothing reaches `main` this way — the full build/test (ci.yml) + CodeQL
 # (codeql.yml) gate the single `dependabot-upgrades -> main` consolidation PR,
-# which is where review and the expensive matrix actually run. ci.yml/codeql.yml
-# deliberately SKIP Dependabot PRs (they would only burn the matrix on a bump we
-# immediately sweep away).
+# which is where review and the expensive matrix actually run. Those workflows
+# subscribe to `pull_request: [main]` only, so a staging-targeted bump never
+# triggers them; that branch filter is the whole saving, and no actor check is
+# needed or permitted to achieve it. ([GITHUB-DEPENDABOT-SECURITY-GATES])
 #
 # Lives at the repo root so it is present on `dependabot-upgrades` (cut from
 # main): for `pull_request` the workflow is read from the PR's base branch, so

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # human entry points and are the only ones `make help` lists.
 # =============================================================================
 
-.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help deployment-verify vsix-package vsix-rebuild android-studio-rebuild android-studio-rebuild-reinstall typediagram-gen _delete-path-binaries _kill-deslop-processes _vsix-install _vsix-build _vsix-test _vsix-test-ollama _vsix-coverage _vsix-webview-coverage _vsix-playwright-html _vsix-install-code _vsix-clean _vsix-stage-bundled-binaries _vsix-stage-and-package _jetbrains-build _jetbrains-verify _jetbrains-package _jetbrains-test _jetbrains-real-binary-test _android-studio-install _android-studio-uninstall
+.PHONY: build test test-ollama lint fmt clean ci ci-ollama setup help deployment-verify vsix-package vsix-rebuild android-studio-rebuild android-studio-rebuild-reinstall typediagram-gen _repo-script-deps _delete-path-binaries _kill-deslop-processes _vsix-install _vsix-build _vsix-test _vsix-test-ollama _vsix-coverage _vsix-webview-coverage _vsix-playwright-html _vsix-install-code _vsix-clean _vsix-stage-bundled-binaries _vsix-stage-and-package _jetbrains-build _jetbrains-verify _jetbrains-package _jetbrains-test _jetbrains-real-binary-test _android-studio-install _android-studio-uninstall
 
 _JETBRAINS_DIR := clients/jetbrains
 
@@ -253,18 +253,35 @@ CORPUS_TESTS ?= corpus_tokio_rust corpus_nest_typescript corpus_determinism_nest
 ## deployment-verify: Validate deployment manifest and built binary contracts.
 ##                    Also runs the verifier proof suite which builds fake
 ##                    binaries and plugin zips violating each Shipwright
-##                    contract rule and asserts every verifier rejects them.
+##                    contract rule and asserts every verifier rejects them,
+##                    and the Dependabot event-matrix gate contract
+##                    ([GITHUB-DEPENDABOT-SECURITY-GATES]) which proves a
+##                    security bump against main still clears every gate.
 ##                    Without this, a silently-broken verifier could let a
 ##                    drifted binary ship.
-deployment-verify: build
+deployment-verify: build _repo-script-deps
 	node scripts/verify-deployment-manifest.mjs shipwright.json
 	node scripts/verify-deployment-binaries.mjs shipwright.json target/release
 	node scripts/verify-release-workflow-gates.mjs .github/workflows/release.yml
 	node scripts/test-release-workflow-contract.mjs
+	node scripts/test-dependabot-gate-matrix.mjs
 	node scripts/test-deployment-docs-contract.mjs
 	node scripts/test-release-version-stamping.mjs
 	node scripts/test-verifiers.mjs
 	node scripts/test-action-contract.mjs
+
+# _repo-script-deps: Install the repo-root devDependencies the Node contract
+#   suites under scripts/ import (`yaml`, so workflow gates are asserted against
+#   a real parse, never a text match). Root package.json is private and ships
+#   nothing — the VSIX remains the only distribution.
+#   Keyed on npm's own `node_modules/.package-lock.json`, which it rewrites on
+#   every install: a mere `-d node_modules` test would skip the install after a
+#   lockfile bump and run the suite against the stale parser.
+_repo-script-deps:
+	@if [ ! -f node_modules/.package-lock.json ] \
+	   || [ package-lock.json -nt node_modules/.package-lock.json ]; then \
+	  echo "==> Installing repo-root script dependencies..."; npm ci; \
+	fi
 
 # _kill-deslop-processes: SIGTERM (then SIGKILL on holdouts) every running
 #   `deslop-lsp` and `deslop-mcp` process so a stale child from a previous

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -76,9 +76,10 @@ on drift. Coverage floors are owned by `coverage-thresholds.json`
   of vulnerable-code detection; `java-kotlin` (JetBrains) is deferred until a
   `build-mode: manual` Gradle step exists.
 - **[GITHUB-DEP-REVIEW] Dependency review** — the `security` job in `ci.yml` runs
-  `actions/dependency-review-action` on every `pull_request`, blocking merges that
-  add a dependency with a known vulnerability at `fail-on-severity: high`. It is
-  the repo's only dependency vulnerability gate.
+  `actions/dependency-review-action` on every `pull_request` against `main`,
+  whoever opened it, blocking merges that add a dependency with a known
+  vulnerability at `fail-on-severity: high`. It is the repo's only dependency
+  vulnerability gate, so it is never conditioned on the author.
 - **[GITHUB-DEPENDABOT] Dependabot** — `.github/dependabot.yml` raises weekly
   grouped updates for every ecosystem (github-actions, cargo, npm ×3, gradle).
   Routine version bumps target the long-lived `dependabot-upgrades` staging branch
@@ -91,8 +92,21 @@ on drift. Coverage floors are owned by `coverage-thresholds.json`
   `main` hangs a dead check on every human PR — one that by construction can
   never run. Security updates are the cost of that filter: GitHub ignores
   `target-branch` for them and always opens them against `main`, where they are
-  merged or retargeted by a human rather than swept, still gated by the
-  `security` dependency-review job in `ci.yml`.
+  merged or retargeted by a human rather than swept.
+- **[GITHUB-DEPENDABOT-SECURITY-GATES] No author-conditioned gate** — a security
+  bump is the only Dependabot pull request that reaches `main`, and no sweep
+  removes it, so `ci.yml` (classifier included), `codeql.yml` and
+  `action-selftest.yml` must gate it exactly as they gate a human PR. None of
+  those workflows may branch on `github.actor`: routine bumps never trigger them
+  (the base filter already does that work), so such a check can only ever fire on
+  the CVE fix, and a job skipped by `if:` reports `skipped`, which branch
+  protection counts as passing — the hole is invisible on a green board (#388).
+  `dependabot-automerge.yml` is the one workflow that stays actor-gated, because
+  identifying the bumper is its actual job. The two write scopes that survive
+  Dependabot's read-only token — `pull-requests: write` on `security`,
+  `security-events: write` on `analyze` — must stay declared at job level, or the
+  gates fail on Dependabot PRs alone. `scripts/test-dependabot-gate-matrix.mjs`
+  asserts the whole matrix from a YAML parse (#394).
 - **[SWR-SEC-ACTION-PINNING] Action SHA pinning** — security-critical workflows
   pin third-party GitHub Actions to a full 40-character commit SHA with a trailing
   `# vX.Y.Z` comment, because a floating tag can be re-pointed at malicious code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "deslop-repo-scripts",
+  "version": "0.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deslop-repo-scripts",
+      "version": "0.0.0-dev",
+      "devDependencies": {
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "deslop-repo-scripts",
+  "version": "0.0.0-dev",
+  "type": "module",
+  "private": true,
+  "description": "Dependency root for the repo-level Node contract tests under scripts/. Not shipped: the VSIX is the only distribution.",
+  "devDependencies": {
+    "yaml": "^2.8.1"
+  }
+}

--- a/scripts/test-dependabot-gate-matrix.mjs
+++ b/scripts/test-dependabot-gate-matrix.mjs
@@ -1,0 +1,283 @@
+// [GITHUB-DEPENDABOT-SECURITY-GATES] Dependabot event-matrix contract.
+//
+// Two classes of Dependabot pull request exist, and they reach opposite halves
+// of this repository's CI:
+//
+//   * ROUTINE VERSION BUMP — `.github/dependabot.yml` gives every ecosystem
+//     `target-branch: dependabot-upgrades`, so the PR is opened against the
+//     staging branch. The four `main`-only gates must NOT be instantiated for
+//     it (that is the whole point of the staging branch), and the sweep in
+//     dependabot-automerge.yml must be.
+//   * SECURITY BUMP — GitHub ignores `target-branch` for security updates and
+//     always opens them against the default branch. The sweep's base filter is
+//     `dependabot-upgrades` only, so nothing carries this PR away: it merges to
+//     `main`. It must therefore clear exactly the gates a human PR clears.
+//
+// An actor short-circuit (`github.actor != 'dependabot[bot]'`) inverts that: it
+// cannot fire on a routine bump, because the workflow is never triggered for
+// one, and it always fires on the security bump — the one PR class opened
+// because of a known vulnerability. #388 shipped that hole across all four
+// gates; this suite is the assertion that keeps it closed (#394).
+//
+// Everything below is read from a real YAML parse, never from a text match, so
+// a reformat cannot make it pass and a re-added skip cannot hide behind
+// indentation.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+
+// The four gates a pull request against `main` must clear. `ci.yml`'s build and
+// test matrix is reached through the `changes` classifier — every heavy job
+// keys off its `code`/`site` outputs, so an actor short-circuit inside the
+// classifier disables all of them at once, which is how #388 hid.
+const GATES = [
+  { workflow: "ci.yml", job: "changes", gate: "build/test/coverage matrix (via the changes classifier)" },
+  { workflow: "ci.yml", job: "security", gate: "dependency review [GITHUB-DEP-REVIEW]" },
+  { workflow: "codeql.yml", job: "analyze", gate: "CodeQL [GITHUB-CODE-SCANNING]" },
+  { workflow: "action-selftest.yml", job: "contract", gate: "Action self-test [ACTION-TESTS]" },
+];
+
+// The write scopes each gate needs to do its job. A Dependabot-triggered run
+// gets a READ-ONLY GITHUB_TOKEN unless the workflow raises it with an explicit
+// `permissions:` block, so these declarations are what make the gates work on
+// exactly the PR class this suite exists for. Deleting one breaks the gate on
+// Dependabot PRs and nowhere else — silently.
+const REQUIRED_WRITE_SCOPES = [
+  { workflow: "ci.yml", job: "security", scope: "pull-requests", why: "dependency-review posts its PR summary" },
+  { workflow: "codeql.yml", job: "analyze", scope: "security-events", why: "CodeQL uploads SARIF to code scanning" },
+];
+
+// Every context that identifies who opened the pull request. Checking only
+// `github.actor` would leave the skip one rename away from returning: the same
+// short-circuit written against `github.event.pull_request.user.login` behaves
+// identically and would sail past a narrower assertion. The bare name
+// `dependabot[bot]` is flagged too — none of the four gates has any legitimate
+// reason to name the bumper in an expression at all.
+const AUTHOR_CONTEXTS = [
+  "github.actor",
+  "github.triggering_actor",
+  "github.event.pull_request.user.login",
+  "github.event.sender.login",
+  "dependabot[bot]",
+];
+
+const SWEEP_WORKFLOW = "dependabot-automerge.yml";
+const STAGING_BRANCH = "dependabot-upgrades";
+const DEFAULT_BRANCH = "main";
+
+const tests = [
+  securityBumpAgainstMainClearsEveryGate,
+  securityBumpGatesRaiseTheTokenAboveDependabotReadOnly,
+  routineVersionBumpNeverInstantiatesTheMainGates,
+  everyEcosystemTargetsTheStagingBranch,
+  theSweepIsTheOnlyActorGatedJobAndStagingOnly,
+];
+
+let failed = 0;
+for (const test of tests) {
+  try {
+    test();
+    console.log(`ok ${test.name}`);
+  } catch (error) {
+    failed++;
+    console.error(`not ok ${test.name}`);
+    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} dependabot gate matrix test(s) failed`);
+  process.exit(1);
+}
+console.log(`\n${tests.length} dependabot gate matrix tests passed`);
+
+// ---------------------------------------------------------------- the matrix
+
+// A security bump lands on `main` and no sweep removes it, so every gate must
+// both fire for it and be incapable of excusing itself because of who opened it.
+function securityBumpAgainstMainClearsEveryGate() {
+  const skips = [...gatesByWorkflow()].flatMap(([workflow, gates]) => actorSkipsIn(workflow, gates));
+  if (skips.length > 0) {
+    throw new Error(
+      `${skips.length} actor short-circuit(s) skip a gate for the only Dependabot PR class that can reach ` +
+        `${DEFAULT_BRANCH} — a security bump. Routine bumps target ${STAGING_BRANCH} and never trigger these ` +
+        `workflows, so each skip saves nothing and costs the CVE fix its gate (#388):\n  ${skips.join("\n  ")}`,
+    );
+  }
+}
+
+// Proves the workflow still fires for a PR against `main` and still defines the
+// jobs being gated, then reports every place it consults the author.
+function actorSkipsIn(workflow, gates) {
+  const parsed = loadWorkflow(workflow);
+  assertIncludes(
+    pullRequestBases(parsed, workflow),
+    DEFAULT_BRANCH,
+    `${workflow} must stay subscribed to pull requests against ${DEFAULT_BRANCH}, or ${gates.join(" and ")} never runs on a Dependabot security bump`,
+  );
+  for (const { job } of GATES.filter((gate) => gate.workflow === workflow)) assertJobExists(parsed, job, workflow);
+  return authorReferences(parsed).map(
+    ({ path, expression }) => `${workflow}:${path} — \`${expression}\` skips ${gates.join(" and ")}`,
+  );
+}
+
+// The gates `ci.yml` owns are two independent jobs, so a single short-circuit
+// there costs both. Grouping keeps the failure message honest about which.
+function gatesByWorkflow() {
+  return GATES.reduce(
+    (grouped, { workflow, gate }) => grouped.set(workflow, [...(grouped.get(workflow) ?? []), gate]),
+    new Map(),
+  );
+}
+
+// The gates that need write scopes must declare them at job level: the token on
+// a Dependabot-triggered run is read-only by default, so an inherited default
+// would leave dependency review unable to comment and CodeQL unable to upload.
+function securityBumpGatesRaiseTheTokenAboveDependabotReadOnly() {
+  for (const { workflow, job, scope, why } of REQUIRED_WRITE_SCOPES) {
+    const parsed = loadWorkflow(workflow);
+    const permissions = assertJobExists(parsed, job, workflow).permissions;
+    if (!permissions || typeof permissions !== "object") {
+      throw new Error(
+        `${workflow} job \`${job}\` declares no job-level permissions block; a Dependabot-triggered run then ` +
+          `gets a read-only token and ${why} fails on exactly the PR class this gate exists for`,
+      );
+    }
+    if (permissions[scope] !== "write") {
+      throw new Error(
+        `${workflow} job \`${job}\` must declare \`${scope}: write\` (${why}); got \`${scope}: ${permissions[scope]}\``,
+      );
+    }
+  }
+}
+
+// The staging branch's purpose is that the expensive matrix does NOT run per
+// bump. Subscribing any gate to it would burn the matrix on every routine bump
+// and re-create the cost the actor skip was mistakenly written to avoid.
+function routineVersionBumpNeverInstantiatesTheMainGates() {
+  for (const { workflow, gate } of GATES) {
+    assertExcludes(
+      pullRequestBases(loadWorkflow(workflow), workflow),
+      STAGING_BRANCH,
+      `${workflow} must not subscribe to pull requests against ${STAGING_BRANCH}: ${gate} is paid once, on the ` +
+        `${STAGING_BRANCH} -> ${DEFAULT_BRANCH} consolidation PR, not on every routine bump`,
+    );
+  }
+}
+
+// The premise of the whole matrix: routine bumps miss the gates only because
+// every ecosystem points them at staging. Drop one `target-branch` and that
+// ecosystem's bumps start arriving on `main` unannounced.
+function everyEcosystemTargetsTheStagingBranch() {
+  const config = parse(readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8"));
+  const updates = config?.updates;
+  if (!Array.isArray(updates) || updates.length === 0) {
+    throw new Error(".github/dependabot.yml declares no `updates:` entries");
+  }
+  for (const entry of updates) {
+    const where = entry?.directory ?? JSON.stringify(entry?.directories);
+    if (entry?.["target-branch"] !== STAGING_BRANCH) {
+      throw new Error(
+        `.github/dependabot.yml ecosystem \`${entry?.["package-ecosystem"]}\` at ${where} must set ` +
+          `\`target-branch: ${STAGING_BRANCH}\`; got \`${entry?.["target-branch"]}\`. Without it, routine version ` +
+          `bumps open against ${DEFAULT_BRANCH} and every gate above runs per bump.`,
+      );
+    }
+  }
+}
+
+// The sweep is the one job for which "is this Dependabot?" is a real question,
+// and it must stay staging-only: a `main` subscription would hang a permanently
+// `skipped` check on every human PR, and would also start sweeping the security
+// bump away from the gates the tests above just proved it must clear.
+function theSweepIsTheOnlyActorGatedJobAndStagingOnly() {
+  const parsed = loadWorkflow(SWEEP_WORKFLOW);
+  const bases = pullRequestBases(parsed, SWEEP_WORKFLOW);
+  assertIncludes(bases, STAGING_BRANCH, `${SWEEP_WORKFLOW} must fire on bumps opened against ${STAGING_BRANCH}`);
+  assertExcludes(
+    bases,
+    DEFAULT_BRANCH,
+    `${SWEEP_WORKFLOW} must not subscribe to pull requests against ${DEFAULT_BRANCH}: its job is actor-gated, an ` +
+      `if:-skipped job still reports a skipped check on every human PR, and sweeping a security bump would strip ` +
+      `it of the gates it is required to clear`,
+  );
+  const actorGates = authorReferences(parsed).map(({ expression }) => expression);
+  if (!actorGates.some((expression) => expression.includes(`github.actor == 'dependabot[bot]'`))) {
+    throw new Error(
+      `${SWEEP_WORKFLOW} must still refuse to act for any actor but Dependabot; found actor gates: ${JSON.stringify(actorGates)}`,
+    );
+  }
+}
+
+// ------------------------------------------------------------------- parsing
+
+function loadWorkflow(name) {
+  return parse(readFileSync(resolve(repoRoot, ".github/workflows", name), "utf8"));
+}
+
+// GitHub's `on:` key is a plain string under the YAML 1.2 core schema this
+// parser uses. Asserting it rather than assuming it keeps a parser change from
+// turning every trigger assertion below into a vacuous pass on `undefined`.
+function pullRequestBases(parsed, name) {
+  const triggers = parsed?.on;
+  if (!triggers || typeof triggers !== "object") {
+    throw new Error(`${name} has no parsable \`on:\` block (got ${JSON.stringify(triggers)})`);
+  }
+  const branches = triggers.pull_request?.branches;
+  if (!Array.isArray(branches)) {
+    throw new Error(`${name} must filter \`on.pull_request.branches\` explicitly; got ${JSON.stringify(branches)}`);
+  }
+  return branches;
+}
+
+function assertJobExists(parsed, job, name) {
+  const definition = parsed?.jobs?.[job];
+  if (!definition) throw new Error(`${name} has no job \`${job}\` (jobs: ${Object.keys(parsed?.jobs ?? {}).join(", ")})`);
+  return definition;
+}
+
+// Every place a workflow can consult who opened the pull request: a bare `if:`
+// (implicitly an expression), an interpolated `${{ }}` anywhere in the tree —
+// including the `env:` binding that carried the actor into ci.yml's classifier
+// shell — collected with their YAML paths so a failure names the exact site.
+function authorReferences(parsed) {
+  return [...expressionsIn(parsed, [])].filter(({ expression }) =>
+    AUTHOR_CONTEXTS.some((context) => expression.includes(context)),
+  );
+}
+
+function* expressionsIn(node, path) {
+  if (typeof node === "string") return yield* interpolations(node, path.join("."));
+  if (Array.isArray(node)) {
+    for (const [index, item] of node.entries()) yield* expressionsIn(item, [...path, `[${index}]`]);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "if" && typeof value === "string") yield { path: [...path, key].join("."), expression: value };
+    else yield* expressionsIn(value, [...path, key]);
+  }
+}
+
+// Split on the delimiters rather than matching a pattern: the expression is an
+// embedded language inside a YAML scalar, and its boundaries are literal.
+function* interpolations(scalar, path) {
+  for (const fragment of scalar.split("${{").slice(1)) {
+    const end = fragment.indexOf("}}");
+    if (end !== -1) yield { path, expression: fragment.slice(0, end).trim() };
+  }
+}
+
+// ---------------------------------------------------------------- assertions
+
+function assertIncludes(values, wanted, message) {
+  if (!values.includes(wanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
+}
+
+function assertExcludes(values, unwanted, message) {
+  if (values.includes(unwanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
+}


### PR DESCRIPTION
## TLDR

Removes four `github.actor` short-circuits that stripped CI, dependency review, CodeQL and the Action self-test from Dependabot **security** pull requests — the only Dependabot PR class that reaches `main` — and adds a YAML-parsed event-matrix contract test that keeps them off.

Works on #388. Works on #394.

## Details

### The defect

`ci.yml`, `codeql.yml` and `action-selftest.yml` all trigger on `pull_request: branches: [main]` only, and every ecosystem in `.github/dependabot.yml` carries `target-branch: dependabot-upgrades`. Routine version bumps therefore never instantiate those workflows at all — the branch filter alone does the saving the actor skips were written for. The one Dependabot PR whose base is `main` is a **security** update, which GitHub opens against the default branch regardless of `target-branch`, and which `dependabot-automerge.yml` does not sweep (its base filter is staging-only, deliberately). Every skip could only ever fire on the CVE fix, and an `if:`-skipped job reports `skipped`, which branch protection counts as passing — so the hole showed all-green.

### Short-circuits removed

- `.github/workflows/ci.yml` — the `changes` classifier's `ACTOR:` env binding and its `code=false; site=false` early exit, which disabled the entire build/test/coverage matrix (`ci`, `windows`, `vsix`, `jetbrains`, `site` all key off its outputs).
- `.github/workflows/ci.yml` — `if: github.actor != 'dependabot[bot]'` on the `security` job (`[GITHUB-DEP-REVIEW]`), the repo's only dependency vulnerability gate. A CVE bump routinely pulls transitive dependencies the advisory did not mention.
- `.github/workflows/codeql.yml` — the `&& github.actor != 'dependabot[bot]'` conjunct on `analyze` (`[GITHUB-CODE-SCANNING]`). The `visibility == 'public'` gate is retained.
- `.github/workflows/action-selftest.yml` — `if: github.actor != 'dependabot[bot]'` on `contract` (`[ACTION-TESTS]`). Not named in #388: every other job carries `needs: [contract]`, so this one skip disabled the whole hosted-runner matrix, on the single bump class that edits `.github/workflows/**` and so matches the workflow's own `paths:` filter.

### Corrected claims

Three documents asserted the gate existed, each deferring to another, which is why the hole survived review:

- `.github/dependabot.yml` said the sweep fires on `main` and folds security bumps into staging. It does not — `dependabot-automerge.yml` filters its base to `dependabot-upgrades` only.
- `.github/workflows/dependabot-automerge.yml` said dependency review in `ci.yml` still gated security bumps. The skip above disabled it.
- `docs/specs/release.md` `[GITHUB-DEPENDABOT]` repeated both, and `[GITHUB-DEP-REVIEW]` claimed the job runs "on every `pull_request`".

New adjacent spec section `[GITHUB-DEPENDABOT-SECURITY-GATES]` states the invariant, records why no gate may branch on the author, and names the enforcing test.

### Permissions are load-bearing, and now pinned

A Dependabot-triggered event hands the workflow a read-only `GITHUB_TOKEN` unless an explicit `permissions:` block raises it. `security` already declared `pull-requests: write` and `analyze` already declared `security-events: write`, so removing the skips required no permissions change — but deleting either block would now break the gate on Dependabot PRs *and nowhere else*. Both are asserted by the new test and annotated in place.

### New files

- `scripts/test-dependabot-gate-matrix.mjs` (267 lines) — the event-matrix contract, wired into `make deployment-verify` (`[DEPLOY-CI-GATES]`).
- `package.json` / `package-lock.json` at the repo root — private, ships nothing, one devDependency (`yaml`) so the workflow gates are asserted against a real parse rather than a text match (CLAUDE.md prohibits pattern matching on structured data). The VSIX remains the only distribution. `/` is registered in `.github/dependabot.yml`'s npm `directories` so the new root is covered by bumps.
- `Makefile` — `_repo-script-deps` installs it, keyed on npm's `node_modules/.package-lock.json` so a lockfile bump reinstalls rather than silently running the suite against a stale parser. `ci.yml`'s `ci` job runs `npm ci` and caches the root lockfile.

### Not fixed here

The `dependabot-upgrades` branch currently holds `- main` in the sweep's base filter — the #306 regression `dependabot-automerge.yml`'s own comment warns will recur — plus two actor skips in `action-selftest.yml`. The Actions token cannot push `.github/workflows/*` by construction, so only a human push to that branch can correct it; #386 is the vehicle. The new test makes that revert fail loudly instead of landing silently, but does not prevent it.

### Breaking changes

None. No public API, CLI flag, report format or existing spec ID changed. `[GITHUB-DEPENDABOT-SECURITY-GATES]` is additive.

## How Do The Automated Tests Prove It Works?

`scripts/test-dependabot-gate-matrix.mjs` runs in `make deployment-verify`. It parses `ci.yml`, `codeql.yml`, `action-selftest.yml`, `dependabot-automerge.yml` and `dependabot.yml` with the `yaml` package and asserts the two-PR-class × four-gate matrix. Five tests, each proven to fail for its own reason:

- **`securityBumpAgainstMainClearsEveryGate`** — all four workflows subscribe to `main`, each gate job is defined, and no expression anywhere in them consults who opened the PR. Against the pre-fix tree it reported all four defect sites by parsed YAML path in one failure: `ci.yml:jobs.changes.steps.[1].env.ACTOR`, `ci.yml:jobs.security.if`, `codeql.yml:jobs.analyze.if`, `action-selftest.yml:jobs.contract.if`. It catches both syntactic forms — a bare `if:` (implicitly an expression) and a `${{ }}` interpolation anywhere in the tree, which is what caught the `env:` binding that smuggled the actor into the classifier's shell. It matches five author-identifying contexts, not just `github.actor`: reintroducing the identical skip as `github.event.pull_request.user.login != 'dependabot[bot]'` was verified to fail it.
- **`securityBumpGatesRaiseTheTokenAboveDependabotReadOnly`** — `security` declares `pull-requests: write`, `analyze` declares `security-events: write`. Downgrading `security-events` to `read` was verified to fail it.
- **`routineVersionBumpNeverInstantiatesTheMainGates`** — no gate subscribes to `dependabot-upgrades`, so the staging branch stays free of the expensive matrix and the cost the removed skips were meant to avoid cannot return by the other route. Adding `dependabot-upgrades` to `ci.yml`'s bases was verified to fail it.
- **`everyEcosystemTargetsTheStagingBranch`** — every `updates:` entry sets `target-branch: dependabot-upgrades`. This is the premise the whole matrix rests on: drop one and that ecosystem's routine bumps start arriving on `main`. Removing it from the cargo entry was verified to fail it.
- **`theSweepIsTheOnlyActorGatedJobAndStagingOnly`** — the sweep fires on `dependabot-upgrades`, `main` is absent from its bases, and it still carries `github.actor == 'dependabot[bot]'`. Adding `main` back was verified to fail it, which is the assertion that would have caught #306.

Every one of those mutations was applied to the working tree, observed red, and reverted, so no assertion in the suite is vacuous. `scripts/test-release-workflow-contract.mjs` (8 tests) still passes unchanged alongside it.

Coverage thresholds in `coverage-thresholds.json` are untouched — this change adds no Rust or TypeScript.

