### PR TITLE
Pin the Dependabot security-gate matrix with a YAML-parsed event-matrix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # human entry points and are the only ones `make help` lists.
 # =============================================================================
 
-.PHONY: build dup-gate test test-ollama lint fmt clean ci ci-ollama setup help deployment-verify compile-release-tests coverage coverage-run coverage-report _ci-analyze _ci-contract-tests _ci-build _ci-gate _ci-test _ci-test-rust _ci-test-vsix vsix-package vsix-rebuild android-studio-rebuild android-studio-rebuild-reinstall typediagram-gen _delete-path-binaries _kill-deslop-processes _vsix-install _vsix-build _vsix-test _vsix-test-ollama _vsix-coverage _vsix-webview-coverage _vsix-webview-coverage-check _vsix-playwright-html _vsix-install-code _vsix-clean _vsix-stage-bundled-binaries _vsix-stage-and-package _jetbrains-build _jetbrains-verify _jetbrains-package _jetbrains-test _jetbrains-real-binary-test _android-studio-install _android-studio-uninstall
+.PHONY: build dup-gate test test-ollama lint fmt clean ci ci-ollama setup help deployment-verify _repo-script-deps compile-release-tests coverage coverage-run coverage-report _ci-analyze _ci-contract-tests _ci-build _ci-gate _ci-test _ci-test-rust _ci-test-vsix vsix-package vsix-rebuild android-studio-rebuild android-studio-rebuild-reinstall typediagram-gen _delete-path-binaries _kill-deslop-processes _vsix-install _vsix-build _vsix-test _vsix-test-ollama _vsix-coverage _vsix-webview-coverage _vsix-webview-coverage-check _vsix-playwright-html _vsix-install-code _vsix-clean _vsix-stage-bundled-binaries _vsix-stage-and-package _jetbrains-build _jetbrains-verify _jetbrains-package _jetbrains-test _jetbrains-real-binary-test _android-studio-install _android-studio-uninstall
 
 _JETBRAINS_DIR := clients/jetbrains
 
@@ -420,16 +420,30 @@ dup-gate: build
 ##                    action's own step body against the freshly built CLI in
 ##                    both gate directions — the self-test's runner leg cannot,
 ##                    since it installs a published release ([ACTION-GATE]).
-deployment-verify: build
+deployment-verify: build _repo-script-deps
 	node scripts/deployment/verify-deployment-manifest.mjs shipwright.json
 	node scripts/deployment/verify-deployment-binaries.mjs shipwright.json target/release
 	node scripts/release/verify-release-workflow-gates.mjs .github/workflows/release.yml
 	node scripts/release/test-release-workflow-contract.mjs
+	node scripts/release/test-dependabot-gate-matrix.mjs
 	node scripts/deployment/test-deployment-docs-contract.mjs
 	node scripts/release/test-release-version-stamping.mjs
 	node scripts/deployment/test-verifiers.mjs
 	node scripts/actions/test-action-contract.mjs
 	node scripts/actions/test-action-diff-gate.mjs
+
+# _repo-script-deps: Install the repo-root devDependencies the Node contract
+#   suites under scripts/ import (`yaml`, so workflow gates are asserted against
+#   a real parse, never a text match). Root package.json is private and ships
+#   nothing — the VSIX remains the only distribution.
+#   Keyed on npm's own `node_modules/.package-lock.json`, which it rewrites on
+#   every install: a mere `-d node_modules` test would skip the install after a
+#   lockfile bump and run the suite against the stale parser.
+_repo-script-deps:
+	@if [ ! -f node_modules/.package-lock.json ] \
+	   || [ package-lock.json -nt node_modules/.package-lock.json ]; then \
+	  echo "==> Installing repo-root script dependencies..."; npm ci; \
+	fi
 
 # _kill-deslop-processes: SIGTERM (then SIGKILL on holdouts) every running
 #   `deslop-lsp` and `deslop-mcp` process so a stale child from a previous

--- a/docs/specs/release.md
+++ b/docs/specs/release.md
@@ -187,10 +187,27 @@ on drift. Coverage floors are owned by `coverage-thresholds.json`
   can only be narrowed to Dependabot by a job-level `if:`, and GitHub reports an
   `if:`-skipped job as a `skipped` check run, so subscribing to PRs against
   `main` hangs a dead check on every human PR — one that by construction can
-  never run. Security updates are the cost of that filter: GitHub ignores
+  never run.
+- **[GITHUB-DEPENDABOT-SECURITY-GATES] Security bumps clear every gate** —
+  security updates are the cost of that base filter: GitHub ignores
   `target-branch` for them and always opens them against `main`, where they are
-  merged or retargeted by a human rather than swept, still gated by the
-  `security` dependency-review job in `ci.yml`.
+  merged or retargeted by a human rather than swept. They are therefore the one
+  Dependabot PR class that reaches `main`, and they must clear exactly what a
+  human PR clears: the `ci.yml` build/test matrix (reached through the `changes`
+  classifier, which every heavy job in that workflow keys off), the `security`
+  dependency-review job ([GITHUB-DEP-REVIEW]), CodeQL
+  ([GITHUB-CODE-SCANNING]), and the Action self-test ([ACTION-TESTS]).
+  No gate may excuse itself by consulting who opened the pull request. An actor
+  short-circuit inverts the intent exactly: it cannot fire on a routine bump,
+  because those target `dependabot-upgrades` and never trigger these `main`-only
+  workflows, and it always fires on the security bump — the one PR opened
+  because of a known vulnerability. A skipped job reports as a *passing*
+  required check, so the result is an all-green merge with no build, no tests,
+  no dependency review and no CodeQL. The gates that need more than the
+  read-only token a Dependabot-triggered run receives must raise it with an
+  explicit job-level `permissions:` block, or they fail on exactly this PR class
+  and nowhere else. Pinned by `scripts/release/test-dependabot-gate-matrix.mjs`,
+  which asserts the two-PR-class matrix against a real YAML parse.
 - **[SWR-SEC-ACTION-PINNING] Action SHA pinning** — security-critical workflows
   pin third-party GitHub Actions to a full 40-character commit SHA with a trailing
   `# vX.Y.Z` comment, because a floating tag can be re-pointed at malicious code

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "deslop-repo-scripts",
+  "version": "0.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deslop-repo-scripts",
+      "version": "0.0.0-dev",
+      "devDependencies": {
+        "yaml": "^2.8.1"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "deslop-repo-scripts",
+  "version": "0.0.0-dev",
+  "type": "module",
+  "private": true,
+  "description": "Dependency root for the repo-level Node contract tests under scripts/. Not shipped: the VSIX is the only distribution.",
+  "devDependencies": {
+    "yaml": "^2.8.1"
+  }
+}

--- a/scripts/release/contract-assertions.mjs
+++ b/scripts/release/contract-assertions.mjs
@@ -1,0 +1,36 @@
+// Membership assertions shared by the release contract suites.
+//
+// `test-release-workflow-contract.mjs` asserts over workflow *text* and
+// `test-dependabot-gate-matrix.mjs` asserts over parsed *lists* of branch names.
+// Both are `.includes()` against a haystack, so a copy in each file is the kind
+// of near-duplicate this repository's own tool exists to find — it lives here
+// instead, and the two suites import it.
+
+/**
+ * Assert `needle` is present in `haystack` (a string or an array).
+ *
+ * @param {string | readonly unknown[]} haystack value searched
+ * @param {unknown} needle value required to be present
+ * @param {string} message failure description
+ */
+export function assertIncludes(haystack, needle, message) {
+  if (!haystack.includes(needle)) throw new Error(withFound(message, haystack));
+}
+
+/**
+ * Assert `needle` is absent from `haystack` (a string or an array).
+ *
+ * @param {string | readonly unknown[]} haystack value searched
+ * @param {unknown} needle value required to be absent
+ * @param {string} message failure description
+ */
+export function assertExcludes(haystack, needle, message) {
+  if (haystack.includes(needle)) throw new Error(withFound(message, haystack));
+}
+
+// A parsed branch list is short enough to name in the failure, and naming it is
+// what makes the message actionable. Workflow text is not: dumping a multi-KB
+// file into the message buries the assertion that actually failed.
+function withFound(message, haystack) {
+  return Array.isArray(haystack) ? `${message} (found: ${JSON.stringify(haystack)})` : message;
+}

--- a/scripts/release/test-dependabot-gate-matrix.mjs
+++ b/scripts/release/test-dependabot-gate-matrix.mjs
@@ -1,0 +1,307 @@
+// [GITHUB-DEPENDABOT-SECURITY-GATES] Dependabot event-matrix contract.
+//
+// Two classes of Dependabot pull request exist, and they reach opposite halves
+// of this repository's CI:
+//
+//   * ROUTINE VERSION BUMP — `.github/dependabot.yml` gives every ecosystem
+//     `target-branch: dependabot-upgrades`, so the PR is opened against the
+//     staging branch. The four `main`-only gates must NOT be instantiated for
+//     it (that is the whole point of the staging branch), and the sweep in
+//     dependabot-automerge.yml must be.
+//   * SECURITY BUMP — GitHub ignores `target-branch` for security updates and
+//     always opens them against the default branch. The sweep's base filter is
+//     `dependabot-upgrades` only, so nothing carries this PR away: it merges to
+//     `main`. It must therefore clear exactly the gates a human PR clears.
+//
+// An actor short-circuit (`github.actor != 'dependabot[bot]'`) inverts that: it
+// cannot fire on a routine bump, because the workflow is never triggered for
+// one, and it always fires on the security bump — the one PR class opened
+// because of a known vulnerability. #388 shipped that hole across all four
+// gates; this suite is the assertion that keeps it closed (#394).
+//
+// Everything below is read from a real YAML parse, never from a text match, so
+// a reformat cannot make it pass and a re-added skip cannot hide behind
+// indentation.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+// The four gates a pull request against `main` must clear. `ci.yml`'s build and
+// test matrix is reached through the `changes` classifier — every heavy job
+// keys off its `code`/`site` outputs, so an actor short-circuit inside the
+// classifier disables all of them at once, which is how #388 hid.
+const GATES = [
+  { workflow: "ci.yml", job: "changes", gate: "build/test/coverage matrix (via the changes classifier)" },
+  { workflow: "ci.yml", job: "security", gate: "dependency review [GITHUB-DEP-REVIEW]" },
+  { workflow: "codeql.yml", job: "analyze", gate: "CodeQL [GITHUB-CODE-SCANNING]" },
+  { workflow: "action-selftest.yml", job: "contract", gate: "Action self-test [ACTION-TESTS]" },
+];
+
+// The write scopes each gate needs to do its job. A Dependabot-triggered run
+// gets a READ-ONLY GITHUB_TOKEN unless the workflow raises it with an explicit
+// `permissions:` block, so these declarations are what make the gates work on
+// exactly the PR class this suite exists for. Deleting one breaks the gate on
+// Dependabot PRs and nowhere else — silently.
+const REQUIRED_WRITE_SCOPES = [
+  { workflow: "ci.yml", job: "security", scope: "pull-requests", why: "dependency-review posts its PR summary" },
+  { workflow: "codeql.yml", job: "analyze", scope: "security-events", why: "CodeQL uploads SARIF to code scanning" },
+];
+
+// Every context that identifies who opened the pull request. Checking only
+// `github.actor` would leave the skip one rename away from returning: the same
+// short-circuit written against `github.event.pull_request.user.login` behaves
+// identically and would sail past a narrower assertion. The bare name
+// `dependabot[bot]` is flagged too — none of the four gates has any legitimate
+// reason to name the bumper in an expression at all.
+const AUTHOR_CONTEXTS = [
+  "github.actor",
+  "github.triggering_actor",
+  "github.event.pull_request.user.login",
+  "github.event.sender.login",
+  "dependabot[bot]",
+];
+
+const SWEEP_WORKFLOW = "dependabot-automerge.yml";
+const STAGING_BRANCH = "dependabot-upgrades";
+const DEFAULT_BRANCH = "main";
+
+const tests = [
+  securityBumpAgainstMainClearsEveryGate,
+  securityBumpGatesRaiseTheTokenAboveDependabotReadOnly,
+  routineVersionBumpNeverInstantiatesTheMainGates,
+  everyEcosystemTargetsTheStagingBranch,
+  theSweepIsTheOnlyActorGatedJobAndStagingOnly,
+];
+
+let failed = 0;
+for (const test of tests) {
+  try {
+    test();
+    console.log(`ok ${test.name}`);
+  } catch (error) {
+    failed++;
+    console.error(`not ok ${test.name}`);
+    console.error(`  ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} dependabot gate matrix test(s) failed`);
+  process.exit(1);
+}
+console.log(`\n${tests.length} dependabot gate matrix tests passed`);
+
+// ---------------------------------------------------------------- the matrix
+
+// A security bump lands on `main` and no sweep removes it, so every gate must
+// both fire for it and be incapable of excusing itself because of who opened it.
+function securityBumpAgainstMainClearsEveryGate() {
+  const skips = [...gatesByWorkflow()].flatMap(([workflow, gates]) => actorSkipsIn(workflow, gates));
+  if (skips.length > 0) {
+    throw new Error(
+      `${skips.length} actor short-circuit(s) skip a gate for the only Dependabot PR class that can reach ` +
+        `${DEFAULT_BRANCH} — a security bump. Routine bumps target ${STAGING_BRANCH} and never trigger these ` +
+        `workflows, so each skip saves nothing and costs the CVE fix its gate (#388):\n  ${skips.join("\n  ")}`,
+    );
+  }
+}
+
+// Proves the workflow still fires for a PR against `main` and still defines the
+// jobs being gated, then reports every place it consults the author.
+function actorSkipsIn(workflow, gates) {
+  const parsed = loadWorkflow(workflow);
+  assertIncludes(
+    pullRequestBases(parsed, workflow),
+    DEFAULT_BRANCH,
+    `${workflow} must stay subscribed to pull requests against ${DEFAULT_BRANCH}, or ${gates.join(" and ")} never runs on a Dependabot security bump`,
+  );
+  for (const { job } of GATES.filter((gate) => gate.workflow === workflow)) assertJobExists(parsed, job, workflow);
+  return authorReferences(parsed).map(
+    ({ path, expression }) => `${workflow}:${path} — \`${expression}\` skips ${gates.join(" and ")}`,
+  );
+}
+
+// The gates `ci.yml` owns are two independent jobs, so a single short-circuit
+// there costs both. Grouping keeps the failure message honest about which.
+function gatesByWorkflow() {
+  return GATES.reduce(
+    (grouped, { workflow, gate }) => grouped.set(workflow, [...(grouped.get(workflow) ?? []), gate]),
+    new Map(),
+  );
+}
+
+// The gates that need write scopes must declare them at job level: the token on
+// a Dependabot-triggered run is read-only by default, so an inherited default
+// would leave dependency review unable to comment and CodeQL unable to upload.
+function securityBumpGatesRaiseTheTokenAboveDependabotReadOnly() {
+  for (const { workflow, job, scope, why } of REQUIRED_WRITE_SCOPES) {
+    const parsed = loadWorkflow(workflow);
+    const permissions = assertJobExists(parsed, job, workflow).permissions;
+    if (!permissions || typeof permissions !== "object") {
+      throw new Error(
+        `${workflow} job \`${job}\` declares no job-level permissions block; a Dependabot-triggered run then ` +
+          `gets a read-only token and ${why} fails on exactly the PR class this gate exists for`,
+      );
+    }
+    if (permissions[scope] !== "write") {
+      throw new Error(
+        `${workflow} job \`${job}\` must declare \`${scope}: write\` (${why}); got \`${scope}: ${permissions[scope]}\``,
+      );
+    }
+  }
+}
+
+// The staging branch's purpose is that the expensive matrix does NOT run per
+// bump. Subscribing any gate to it would burn the matrix on every routine bump
+// and re-create the cost the actor skip was mistakenly written to avoid.
+function routineVersionBumpNeverInstantiatesTheMainGates() {
+  for (const { workflow, gate } of GATES) {
+    assertExcludes(
+      pullRequestBases(loadWorkflow(workflow), workflow),
+      STAGING_BRANCH,
+      `${workflow} must not subscribe to pull requests against ${STAGING_BRANCH}: ${gate} is paid once, on the ` +
+        `${STAGING_BRANCH} -> ${DEFAULT_BRANCH} consolidation PR, not on every routine bump`,
+    );
+  }
+}
+
+// The premise of the whole matrix: routine bumps miss the gates only because
+// every ecosystem points them at staging. Drop one `target-branch` and that
+// ecosystem's bumps start arriving on `main` unannounced.
+function everyEcosystemTargetsTheStagingBranch() {
+  const config = parse(readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8"));
+  const updates = config?.updates;
+  if (!Array.isArray(updates) || updates.length === 0) {
+    throw new Error(".github/dependabot.yml declares no `updates:` entries");
+  }
+  for (const entry of updates) {
+    const where = entry?.directory ?? JSON.stringify(entry?.directories);
+    if (entry?.["target-branch"] !== STAGING_BRANCH) {
+      throw new Error(
+        `.github/dependabot.yml ecosystem \`${entry?.["package-ecosystem"]}\` at ${where} must set ` +
+          `\`target-branch: ${STAGING_BRANCH}\`; got \`${entry?.["target-branch"]}\`. Without it, routine version ` +
+          `bumps open against ${DEFAULT_BRANCH} and every gate above runs per bump.`,
+      );
+    }
+  }
+}
+
+// The sweep is the one job for which "is this Dependabot?" is a real question,
+// and it must stay staging-only: a `main` subscription would hang a permanently
+// `skipped` check on every human PR, and would also start sweeping the security
+// bump away from the gates the tests above just proved it must clear.
+function theSweepIsTheOnlyActorGatedJobAndStagingOnly() {
+  const parsed = loadWorkflow(SWEEP_WORKFLOW);
+  assertNoPullRequestTarget(parsed);
+  const bases = pullRequestBases(parsed, SWEEP_WORKFLOW);
+  assertIncludes(bases, STAGING_BRANCH, `${SWEEP_WORKFLOW} must fire on bumps opened against ${STAGING_BRANCH}`);
+  assertExcludes(
+    bases,
+    DEFAULT_BRANCH,
+    `${SWEEP_WORKFLOW} must not subscribe to pull requests against ${DEFAULT_BRANCH}: its job is actor-gated, an ` +
+      `if:-skipped job still reports a skipped check on every human PR, and sweeping a security bump would strip ` +
+      `it of the gates it is required to clear`,
+  );
+  const actorGates = authorReferences(parsed).map(({ expression }) => expression);
+  if (!actorGates.some((expression) => expression.includes(`github.actor == 'dependabot[bot]'`))) {
+    throw new Error(
+      `${SWEEP_WORKFLOW} must still refuse to act for any actor but Dependabot; found actor gates: ${JSON.stringify(actorGates)}`,
+    );
+  }
+  // The second half of the actor-AND-source gate. `github.actor` alone is not
+  // enough: it is the account that triggered the run, so a human `@dependabot
+  // recreate` comment or a re-run can carry the bot's name onto a branch the
+  // bot did not raise. The `dependabot/*` source-branch requirement is what
+  // pins the sweep to branches Dependabot actually owns.
+  if (!actorGates.some((expression) => expression.includes(`startsWith(github.head_ref, 'dependabot/')`))) {
+    throw new Error(
+      `${SWEEP_WORKFLOW} must still require a \`dependabot/*\` source branch — the second half of the ` +
+        `actor-AND-source gate; found actor gates: ${JSON.stringify(actorGates)}`,
+    );
+  }
+}
+
+// `pull_request_target` runs with the base repository's write token and secrets
+// while checking out PR-controlled content, which would turn the merge bot into
+// an exfiltration sink. The sweep must stay on the plain `pull_request` event.
+function assertNoPullRequestTarget(parsed) {
+  if (parsed?.on && typeof parsed.on === "object" && "pull_request_target" in parsed.on) {
+    throw new Error(
+      `${SWEEP_WORKFLOW} must not subscribe to \`pull_request_target\`: it hands the write token and repository ` +
+        `secrets to PR-controlled content, turning the merge bot into an exfiltration sink`,
+    );
+  }
+}
+
+// ------------------------------------------------------------------- parsing
+
+function loadWorkflow(name) {
+  return parse(readFileSync(resolve(repoRoot, ".github/workflows", name), "utf8"));
+}
+
+// GitHub's `on:` key is a plain string under the YAML 1.2 core schema this
+// parser uses. Asserting it rather than assuming it keeps a parser change from
+// turning every trigger assertion below into a vacuous pass on `undefined`.
+function pullRequestBases(parsed, name) {
+  const triggers = parsed?.on;
+  if (!triggers || typeof triggers !== "object") {
+    throw new Error(`${name} has no parsable \`on:\` block (got ${JSON.stringify(triggers)})`);
+  }
+  const branches = triggers.pull_request?.branches;
+  if (!Array.isArray(branches)) {
+    throw new Error(`${name} must filter \`on.pull_request.branches\` explicitly; got ${JSON.stringify(branches)}`);
+  }
+  return branches;
+}
+
+function assertJobExists(parsed, job, name) {
+  const definition = parsed?.jobs?.[job];
+  if (!definition) throw new Error(`${name} has no job \`${job}\` (jobs: ${Object.keys(parsed?.jobs ?? {}).join(", ")})`);
+  return definition;
+}
+
+// Every place a workflow can consult who opened the pull request: a bare `if:`
+// (implicitly an expression), an interpolated `${{ }}` anywhere in the tree —
+// including the `env:` binding that carried the actor into ci.yml's classifier
+// shell — collected with their YAML paths so a failure names the exact site.
+function authorReferences(parsed) {
+  return [...expressionsIn(parsed, [])].filter(({ expression }) =>
+    AUTHOR_CONTEXTS.some((context) => expression.includes(context)),
+  );
+}
+
+function* expressionsIn(node, path) {
+  if (typeof node === "string") return yield* interpolations(node, path.join("."));
+  if (Array.isArray(node)) {
+    for (const [index, item] of node.entries()) yield* expressionsIn(item, [...path, `[${index}]`]);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "if" && typeof value === "string") yield { path: [...path, key].join("."), expression: value };
+    else yield* expressionsIn(value, [...path, key]);
+  }
+}
+
+// Split on the delimiters rather than matching a pattern: the expression is an
+// embedded language inside a YAML scalar, and its boundaries are literal.
+function* interpolations(scalar, path) {
+  for (const fragment of scalar.split("${{").slice(1)) {
+    const end = fragment.indexOf("}}");
+    if (end !== -1) yield { path, expression: fragment.slice(0, end).trim() };
+  }
+}
+
+// ---------------------------------------------------------------- assertions
+
+function assertIncludes(values, wanted, message) {
+  if (!values.includes(wanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
+}
+
+function assertExcludes(values, unwanted, message) {
+  if (values.includes(unwanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
+}

--- a/scripts/release/test-dependabot-gate-matrix.mjs
+++ b/scripts/release/test-dependabot-gate-matrix.mjs
@@ -28,6 +28,8 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
+import { assertExcludes, assertIncludes } from "./contract-assertions.mjs";
+
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 // The four gates a pull request against `main` must clear. `ci.yml`'s build and
@@ -197,6 +199,14 @@ function everyEcosystemTargetsTheStagingBranch() {
 function theSweepIsTheOnlyActorGatedJobAndStagingOnly() {
   const parsed = loadWorkflow(SWEEP_WORKFLOW);
   assertNoPullRequestTarget(parsed);
+  assertSweepTriggersStagingOnly(parsed);
+  assertSweepRequiresDependabotActorAndSourceBranch(parsed);
+}
+
+// The base filter is what keeps the sweep invisible to humans, and it is also
+// what keeps it away from the security bump the tests above just proved must
+// clear every gate.
+function assertSweepTriggersStagingOnly(parsed) {
   const bases = pullRequestBases(parsed, SWEEP_WORKFLOW);
   assertIncludes(bases, STAGING_BRANCH, `${SWEEP_WORKFLOW} must fire on bumps opened against ${STAGING_BRANCH}`);
   assertExcludes(
@@ -206,22 +216,26 @@ function theSweepIsTheOnlyActorGatedJobAndStagingOnly() {
       `if:-skipped job still reports a skipped check on every human PR, and sweeping a security bump would strip ` +
       `it of the gates it is required to clear`,
   );
+}
+
+// Both halves of the actor-AND-source gate. `github.actor` alone is not enough:
+// it is the account that triggered the run, so a human `@dependabot recreate`
+// comment or a re-run can carry the bot's name onto a branch the bot did not
+// raise. The `dependabot/*` source-branch requirement is what pins the sweep to
+// branches Dependabot actually owns.
+function assertSweepRequiresDependabotActorAndSourceBranch(parsed) {
   const actorGates = authorReferences(parsed).map(({ expression }) => expression);
-  if (!actorGates.some((expression) => expression.includes(`github.actor == 'dependabot[bot]'`))) {
-    throw new Error(
-      `${SWEEP_WORKFLOW} must still refuse to act for any actor but Dependabot; found actor gates: ${JSON.stringify(actorGates)}`,
-    );
-  }
-  // The second half of the actor-AND-source gate. `github.actor` alone is not
-  // enough: it is the account that triggered the run, so a human `@dependabot
-  // recreate` comment or a re-run can carry the bot's name onto a branch the
-  // bot did not raise. The `dependabot/*` source-branch requirement is what
-  // pins the sweep to branches Dependabot actually owns.
-  if (!actorGates.some((expression) => expression.includes(`startsWith(github.head_ref, 'dependabot/')`))) {
-    throw new Error(
-      `${SWEEP_WORKFLOW} must still require a \`dependabot/*\` source branch — the second half of the ` +
-        `actor-AND-source gate; found actor gates: ${JSON.stringify(actorGates)}`,
-    );
+  const required = [
+    { fragment: `github.actor == 'dependabot[bot]'`, why: "refuse to act for any actor but Dependabot" },
+    { fragment: `startsWith(github.head_ref, 'dependabot/')`, why: "require a `dependabot/*` source branch" },
+  ];
+  for (const { fragment, why } of required) {
+    if (!actorGates.some((expression) => expression.includes(fragment))) {
+      throw new Error(
+        `${SWEEP_WORKFLOW} must still ${why} — \`${fragment}\` is absent; found actor gates: ` +
+          JSON.stringify(actorGates),
+      );
+    }
   }
 }
 
@@ -296,12 +310,3 @@ function* interpolations(scalar, path) {
   }
 }
 
-// ---------------------------------------------------------------- assertions
-
-function assertIncludes(values, wanted, message) {
-  if (!values.includes(wanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
-}
-
-function assertExcludes(values, unwanted, message) {
-  if (values.includes(unwanted)) throw new Error(`${message} (found: ${JSON.stringify(values)})`);
-}

--- a/scripts/release/test-release-workflow-contract.mjs
+++ b/scripts/release/test-release-workflow-contract.mjs
@@ -12,10 +12,8 @@ import { fileURLToPath } from "node:url";
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const workflowPath = resolve(repoRoot, ".github/workflows/release.yml");
 const deployWorkflowPath = resolve(repoRoot, ".github/workflows/deploy-pages.yml");
-const dependabotWorkflowPath = resolve(repoRoot, ".github/workflows/dependabot-automerge.yml");
 const workflow = readFileSync(workflowPath, "utf8");
 const deployWorkflow = readFileSync(deployWorkflowPath, "utf8");
-const dependabotWorkflow = readFileSync(dependabotWorkflowPath, "utf8");
 
 const tests = [
   releaseBuildsTaggedSourceWithoutPostTagVersionCommit,
@@ -24,13 +22,16 @@ const tests = [
   scoopAutoupdateTemplatesEveryVersionedSegment,
   releaseBuildsPlatformSpecificVsixArtifacts,
   pagesDeployCleansRerunArtifactsAndRetries,
-  dependabotSweepLeavesNoDeadCheckOnHumanPullRequests,
   contractFilesCheckOutLfOnEveryPlatform,
 ];
 
-// Every file this suite and test-action-contract.mjs match line-exactly. Git for
-// Windows ships core.autocrlf=true in its system config, so without an explicit
-// attribute these check out CRLF and every `\n`-anchored match silently misses.
+// Every workflow file the contract suites read. Git for Windows ships
+// core.autocrlf=true in its system config, so without an explicit attribute
+// these check out CRLF and every `\n`-anchored match silently misses.
+// dependabot-automerge.yml is read through a YAML parse rather than matched
+// line-exactly ([GITHUB-DEPENDABOT-SECURITY-GATES]), so CRLF cannot break it
+// today; the pin stays because the guarantee is cheap and the next assertion
+// added against that file should not have to rediscover this.
 const LINE_MATCHED_FILES = [
   ".github/workflows/release.yml",
   ".github/workflows/deploy-pages.yml",
@@ -296,41 +297,6 @@ function pagesDeployCleansRerunArtifactsAndRetries() {
     deployWorkflow,
     "steps.deploy_retry.outcome == 'failure'",
     "Pages deploy workflow must fail only when the retry also fails",
-  );
-}
-
-// The sweep is event-driven, and its base filter is what keeps it invisible to
-// humans. A job-level `if:` does not make a job disappear — GitHub still
-// materialises it as a check run with conclusion `skipped` — so subscribing to
-// pull requests against `main` hangs a dead check on every human PR, one that
-// by construction can never run. Filtering the base to the staging branch means
-// the workflow is never instantiated for a human PR at all. ([GITHUB-DEPENDABOT])
-function dependabotSweepLeavesNoDeadCheckOnHumanPullRequests() {
-  const triggers = sectionBetween("\non:\n", "\npermissions:", dependabotWorkflow);
-  assertExcludes(
-    triggers,
-    "main",
-    "the sweep must not subscribe to pull requests against main: its job is actor-gated, and an if:-skipped job still reports a skipped check on every human PR",
-  );
-  assertIncludes(
-    triggers,
-    "- dependabot-upgrades",
-    "the sweep must still fire on bumps opened against the staging branch, which is where every ecosystem in .github/dependabot.yml targets them",
-  );
-  assertExcludes(
-    triggers,
-    "pull_request_target",
-    "pull_request_target would hand the write token and secrets to PR-controlled content, turning the merge bot into an exfiltration sink",
-  );
-  assertIncludes(
-    dependabotWorkflow,
-    "github.actor == 'dependabot[bot]'",
-    "the sweep must still refuse to act for any actor but Dependabot",
-  );
-  assertIncludes(
-    dependabotWorkflow,
-    "startsWith(github.head_ref, 'dependabot/')",
-    "the sweep must still require a dependabot/* source branch — the second half of the actor-AND-source gate",
   );
 }
 

--- a/scripts/release/test-release-workflow-contract.mjs
+++ b/scripts/release/test-release-workflow-contract.mjs
@@ -9,6 +9,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { assertExcludes, assertIncludes } from "./contract-assertions.mjs";
+
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const workflowPath = resolve(repoRoot, ".github/workflows/release.yml");
 const deployWorkflowPath = resolve(repoRoot, ".github/workflows/deploy-pages.yml");
@@ -328,20 +330,12 @@ function assertAbsent(pattern, message) {
   if (pattern.test(workflow)) throw new Error(message);
 }
 
-function assertExcludes(value, unexpected, message) {
-  if (value.includes(unexpected)) throw new Error(message);
-}
-
 function assertSectionAbsent(section, pattern, message) {
   if (pattern.test(section)) throw new Error(message);
 }
 
 function assertPresent(pattern, message) {
   if (!pattern.test(workflow)) throw new Error(message);
-}
-
-function assertIncludes(value, expected, message) {
-  if (!value.includes(expected)) throw new Error(message);
 }
 
 function assertEqual(actual, expected, message) {


### PR DESCRIPTION
## TLDR

Adds a YAML-parsed event-matrix contract test that pins the property `main` currently satisfies only by accident: a Dependabot **security** PR against the default branch must clear the build/test matrix, dependency review, CodeQL and the Action self-test, while routine version bumps stay on `dependabot-upgrades`.

## Details

Routine Dependabot bumps carry `target-branch: dependabot-upgrades`, so they never trigger the four `main`-only gates. Security updates are the exception — GitHub ignores `target-branch` for them and always opens them against the default branch, and the sweep's base filter is `dependabot-upgrades` only, so nothing carries them away. They merge to `main`.

That makes an actor short-circuit exactly inverted. It cannot fire on the routine bumps it was written for, and it always fires on the PR opened because of a known vulnerability. A skipped job reports as a *passing* required check, so the result is an all-green merge with no build, no tests, no dependency review and no CodeQL. #388 shipped that hole across all four gates; #392 removed the skips; nothing asserted they stay removed.

**New files**

- `scripts/release/test-dependabot-gate-matrix.mjs` (300 lines) — the event-matrix contract, `[GITHUB-DEPENDABOT-SECURITY-GATES]`. Reads `ci.yml`, `codeql.yml`, `action-selftest.yml`, `dependabot-automerge.yml` and `dependabot.yml` through a real YAML parse, never a text match, so a reformat cannot make it pass and a re-added skip cannot hide behind indentation. Its author-context list spans `github.actor`, `github.triggering_actor`, `github.event.pull_request.user.login`, `github.event.sender.login` and the bare `dependabot[bot]` name, walked at any depth including `env:` bindings — the shape the original defect used to hide inside `ci.yml`'s classifier shell.
- `scripts/release/contract-assertions.mjs` (36 lines) — `assertIncludes` / `assertExcludes`, previously defined locally in `test-release-workflow-contract.mjs` and about to be defined a second time in the new suite. Both now import it. The shared version names the haystack in the failure only when it is an array; workflow text is left undumped, so the existing suite's messages are unchanged rather than buried under a multi-KB file.

**Modified**

- `scripts/release/test-release-workflow-contract.mjs` (407 → 367) — `dependabotSweepLeavesNoDeadCheckOnHumanPullRequests` **moves** into the new suite. It asserted by text matching over YAML, which this repository prohibits for structured data; all five of its assertions are re-expressed against the parse and each is pinned by a mutant below. Its now-dead `dependabotWorkflow` / `dependabotWorkflowPath` bindings and its two local assert helpers are removed. `dependabot-automerge.yml` stays in `LINE_MATCHED_FILES`: nothing line-matches it now, but the LF pin is a real guarantee and cheap to keep — the comment there says so.
- `docs/specs/release.md` — `[GITHUB-DEPENDABOT]` claimed security bumps were gated by dependency review *alone*, which under-describes what the workflows do post-#392. The property is promoted to its own `[GITHUB-DEPENDABOT-SECURITY-GATES]` section naming all four gates, the read-only-token constraint, and the inversion argument.
- `Makefile` — `deployment-verify` gains `_repo-script-deps` as a prerequisite and one line invoking the new suite. `_repo-script-deps` installs the repo-root devDependencies, keyed on npm's own `node_modules/.package-lock.json` so a lockfile bump re-installs rather than running against a stale parser.

**New dependency**

`package.json` / `package-lock.json` — a private repo-root manifest whose only devDependency is `yaml`. `scripts/actions/action-yaml.mjs` hand-scans YAML today specifically because no parser sat on that dependency path, but that scanner is text pattern matching over structured data. Adding the parser closes this properly and makes deleting the scanner possible later. CI already sets up Node 22.x at `.github/workflows/ci.yml:295` in the same `repository-tests` job that runs `make deployment-verify` at `:323`, so no workflow change is needed.

**No breaking changes.** No public API, CLI flag, or report format changes. `[GITHUB-DEPENDABOT]` keeps its id; `[GITHUB-DEPENDABOT-SECURITY-GATES]` is added alongside it.

## How Do The Automated Tests Prove It Works?

The suite is black-box: it drives the real workflow files and asserts against a parse of them, reaching into no internals.

Each of its five tests was verified by reintroducing the exact defect it exists to catch and watching it fail for the real reason — 11 mutants, 11 killed:

| Mutant | Killed by |
|---|---|
| `if:` skip on `ci.yml` `changes` (the classifier 9 of 11 jobs key off) | `securityBumpAgainstMainClearsEveryGate` |
| `if:` skip on `ci.yml` `security` | `securityBumpAgainstMainClearsEveryGate` |
| `if:` skip on `codeql.yml` `analyze` | `securityBumpAgainstMainClearsEveryGate` |
| `if:` skip on `action-selftest.yml` `contract` | `securityBumpAgainstMainClearsEveryGate` |
| `env: ACTOR: ${{ github.event.pull_request.user.login }}` rename-evasion | `securityBumpAgainstMainClearsEveryGate` |
| CodeQL `security-events` downgraded to `read` | `securityBumpGatesRaiseTheTokenAboveDependabotReadOnly` |
| dependency review `pull-requests` downgraded to `read` | `securityBumpGatesRaiseTheTokenAboveDependabotReadOnly` |
| an ecosystem drops `target-branch` | `everyEcosystemTargetsTheStagingBranch` |
| sweep subscribes to `main` *(moved assertion)* | `theSweepIsTheOnlyActorGatedJobAndStagingOnly` |
| sweep drops the `head_ref` gate *(moved assertion)* | `theSweepIsTheOnlyActorGatedJobAndStagingOnly` |
| sweep switches to `pull_request_target` *(moved assertion)* | `theSweepIsTheOnlyActorGatedJobAndStagingOnly` |

Two things that table is doing beyond "tests pass":

1. **All five gate mutants survive `main` as it stands today.** The existing `test-release-workflow-contract.mjs` stays green through every one of them. That is the regression hole #394 was filed for, reproduced rather than argued.
2. **The three *(moved assertion)* rows** are the evidence that relocating `dependabotSweepLeavesNoDeadCheckOnHumanPullRequests` preserved its assertiveness. Each corresponds to one assertion of the deleted test, now enforced from its new home against a parse instead of a substring search.

The suite also fails loudly rather than vacuously when misplaced: run from the wrong directory depth every test raises `ENOENT` instead of passing on `undefined`, and `pullRequestBases` rejects a non-array `on.pull_request.branches` rather than treating a parser change as "no branches configured".

Coverage thresholds in `coverage-thresholds.json` are unchanged — this adds Node contract tests, not Rust code.

## For AI

Defect class: **false-negative gate evaluation via workflow-level short-circuit**, not a detector-pipeline defect. No `crates/` code is touched; the accuracy surface here is CI's own gating, where a skipped required check is indistinguishable from a passing one at the branch-protection layer.

Assertion substrate is `yaml.parse` → plain JS object graph. `expressionsIn()` is a generator doing a depth-first walk of the parsed tree, yielding `{path, expression}` for every bare `if:` scalar and every `${{ … }}` interpolation found in any string node; `interpolations()` splits on the literal `${{` / `}}` delimiters rather than matching a pattern, per the repo-wide prohibition on regex over source and structured data. `authorReferences()` filters that stream against `AUTHOR_CONTEXTS`. Consequence: detection is context-name-based and depth-independent, so it catches a skip relocated from `jobs.<id>.if` into `jobs.<id>.env.<KEY>` (the #388 shape) or into a step-level conditional, and it is invariant under YAML reflow, anchor use, and comment churn.

`GATES` and `REQUIRED_WRITE_SCOPES` are declarative tables; adding a fifth gate is a row, not a function. `gatesByWorkflow()` groups by workflow so a single `ci.yml` short-circuit reports both gates it costs rather than one.

Token-scope assertions encode a GitHub-specific invariant worth restating: a workflow run triggered by `dependabot[bot]` receives a read-only `GITHUB_TOKEN` regardless of repository default, so `pull-requests: write` and `security-events: write` at job level are load-bearing for exactly this PR class and inert for every other. Deleting either breaks the gate only on Dependabot PRs — the failure mode is invisible to human-PR testing.

`withFound()` in `contract-assertions.mjs` branches on `Array.isArray` specifically to avoid an error-message regression: the two consumers pass different haystack types (parsed branch list vs. raw workflow text), and unconditional `JSON.stringify` would inline a multi-KB file into the failure of every text assertion in the older suite.

Known pre-existing conditions this PR deliberately does not expand into: `assertIncludes` / `assertEqual` are independently redefined across `scripts/deployment/*.mjs`, `scripts/release/test-release-version-stamping.mjs` and `scripts/benchmarks/*.mjs` (the version in `test-release-version-stamping.mjs` has 2-arity, so it is not a drop-in); and `.devcontainer/devcontainer.json` declares no Node feature despite `typediagram-gen` and eight existing `node scripts/…` invocations already requiring one — `npm ci` adds no tool requirement beyond the Node that was already assumed.

Works on #394

Related: #388 is already fixed by #392 (skips present at `f92300e5`, absent at `2dae2a5b`) and can be closed. #419 is superseded — its workflow edits re-delete those same skips, which is why it conflicts across six files; only its test was worth keeping and it is here, rebased onto the restructured `scripts/` layout.

