### PR TITLE
Spell every published path with a forward slash, and give the shell gates a shell they can spawn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,14 @@ jobs:
     needs: [changes, lint]
     if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
-    timeout-minutes: 30
+    # TIMEOUT EXCEPTION: this job builds the `deslop` E2E suite under llvm-cov
+    # instrumentation on top of the LSP binary and the MCP transport target.
+    # A cold Windows build of that set runs past the old 30-minute cap on its
+    # own, before a single assertion has been evaluated. The alternative —
+    # dropping the path-spelling guards below — would leave the one rule only
+    # this platform can break unenforced, which is what the cap would be
+    # buying.
+    timeout-minutes: 50
     env:
       CARGO_TARGET_DIR: target/windows-llvm-cov
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -593,7 +593,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # [OUTPUT-SCHEMA-PATH-SEPARATOR] Every filter below names a suite whose
+      # assertions compare a rendered path against the `/` spelling the output
+      # contract mandates. They pass on Linux whatever the renderer does,
+      # because there the host joiner *is* the published one — so this job is
+      # the only place a host-spelled path can be caught, and without it the
+      # rule is unenforced on the one platform that can break it.
       - name: Run Windows tests with coverage collection
+        env:
+          WINDOWS_SUITE_FILTERS: location_rendering:: defaults:: diff_ingest_refusals:: diff_scoped_ingest:: diff_scoped_reporting:: report_golden:: metrics_folder_rollup::
         run: |
           $coverageEnv = cargo llvm-cov show-env --cmd
           foreach ($line in $coverageEnv) {
@@ -604,6 +612,10 @@ jobs:
           cargo build --release -p deslop-lsp --bin deslop-lsp
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --release -p deslop-mcp --test tcp_transport --features deslop-core/live
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test --release -p deslop-core --lib paths::
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test --release -p deslop --test suite -- $env:WINDOWS_SUITE_FILTERS.Split(" ")
 
       # The Windows lcov is calculated HERE, not in the coverage job:
       # the instrumented PE/PDB binaries can only be read by a Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,7 @@ jobs:
       # rule is unenforced on the one platform that can break it.
       - name: Run Windows tests with coverage collection
         env:
-          WINDOWS_SUITE_FILTERS: location_rendering:: defaults:: diff_ingest_refusals:: diff_scoped_ingest:: diff_scoped_reporting:: report_golden:: metrics_folder_rollup::
+          WINDOWS_SUITE_FILTERS: "location_rendering:: defaults:: diff_ingest_refusals:: diff_scoped_ingest:: diff_scoped_reporting:: report_golden:: metrics_folder_rollup::"
         run: |
           $coverageEnv = cargo llvm-cov show-env --cmd
           foreach ($line in $coverageEnv) {

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ _ci-contract-tests: _vsix-node-modules
 	@node --test scripts/repository/scrub-path-binaries.test.mjs
 	@echo "==> Process-scrub + host-shell gate ([DEPLOY-EXTENSION-BUNDLED-TESTS])..."
 	@node --test scripts/repository/kill-deslop-processes.test.mjs
+	@node --test scripts/repository/posix-shell.test.mjs
 	@echo "==> Duplication-gate provenance gate ([CI-DESLOP])..."
 	@node --test scripts/repository/dup-gate-source.test.mjs
 	@echo "==> Test-selection gate ([TEST-SELECTION])..."

--- a/crates/deslop-core/src/diff_scope/verify.rs
+++ b/crates/deslop-core/src/diff_scope/verify.rs
@@ -191,11 +191,17 @@ fn verify_line(
 /// Canonicalises when the file exists so symlinked roots (macOS
 /// `/var` → `/private/var`) compare on one filesystem identity; a
 /// path the diff adds outside the corpus need not exist, so the
-/// lexical join stands in when canonicalisation fails.
+/// lexical join stands in when canonicalisation fails. The result is
+/// spelled for publication ([OUTPUT-SCHEMA-PATH-SEPARATOR]): it keys
+/// the scope the report is tagged against and names the file in a
+/// stale-diff refusal, and both are read off this host by another.
 fn resolve_to_scan_root(new_path: &str, cwd: &Path, scan_root: &Path) -> Option<PathBuf> {
     let joined = cwd.join(new_path);
     let absolute = std::fs::canonicalize(&joined).unwrap_or(joined);
-    absolute.strip_prefix(scan_root).ok().map(Path::to_path_buf)
+    absolute
+        .strip_prefix(scan_root)
+        .ok()
+        .map(crate::paths::reported)
 }
 
 /// Splits source bytes into lines on `\n`, excluding the terminator.

--- a/crates/deslop-core/src/live/transport.rs
+++ b/crates/deslop-core/src/live/transport.rs
@@ -46,6 +46,19 @@ pub fn port_file_path(root: &Path) -> PathBuf {
     crate::paths::cache_dir(root).join(IPC_PORT_FILE_NAME)
 }
 
+/// Absolute path of the discovery artefact this platform's IPC server
+/// publishes — the socket itself on Unix, the endpoint record on
+/// Windows. A caller waiting for the server to come up watches this
+/// rather than picking one of the two, so it cannot end up waiting for
+/// an artefact this platform never writes.
+#[must_use]
+pub fn endpoint_path(root: &Path) -> PathBuf {
+    match IpcMode::platform_default() {
+        IpcMode::Unix => socket_path(root),
+        IpcMode::Tcp => port_file_path(root),
+    }
+}
+
 /// Which transport the IPC server binds ([LIVE-IPC-TCP]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IpcMode {

--- a/crates/deslop-core/src/paths.rs
+++ b/crates/deslop-core/src/paths.rs
@@ -15,6 +15,9 @@
 //!       live-report.json deslop.sock deslop.port
 //! ```
 //!
+//! The module also owns the other half of "where a path goes": how a
+//! path is *spelled* once Deslop publishes it ([`reported`]).
+//!
 //! The CLI, LSP, and MCP surfaces all resolve through this module, so
 //! the three never disagree about where a workspace's artefacts live.
 //! The CLI's `--output` flag overrides the report base (and with it the
@@ -22,7 +25,7 @@
 //! addressed by the LSP and MCP independently and must be discoverable
 //! from the scan root alone.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// Name of the per-workspace output directory, relative to the scan
 /// root. Dot-prefixed so the discovery pass's hidden-directory prune
@@ -62,6 +65,52 @@ pub fn report_base(root: &Path) -> PathBuf {
     output_dir(root).join(REPORT_STEM)
 }
 
+/// [OUTPUT-SCHEMA-PATH-SEPARATOR] The one character Deslop puts
+/// between the segments of a path it *publishes*, on every platform.
+///
+/// Reports are read somewhere other than the machine that wrote them —
+/// a Windows developer's report opened in a Linux CI gate, two
+/// platforms' reports compared in one dashboard — so a path is part of
+/// the output contract and cannot be spelled the host's way. Paths
+/// Deslop *opens* keep the host's own separators; only rendered ones
+/// pass through [`reported`].
+pub const REPORT_SEPARATOR: char = '/';
+
+/// Respells `path` for publication: its segments joined with
+/// [`REPORT_SEPARATOR`], whatever the host joined them with.
+///
+/// Only the separators change. A Windows drive or UNC prefix keeps its
+/// own spelling, because it names a volume rather than a segment and
+/// respelling it would produce something that is neither a valid
+/// Windows path nor a portable one. Nothing else is rewritten: no
+/// canonicalisation, no `.`/`..` collapsing, no case folding.
+///
+/// The result compares equal to its input as a [`Path`] on every
+/// platform — Windows accepts both separators when it walks
+/// components, and on Unix the function is the identity — so a
+/// respelled path stays a usable map key beside paths that were not.
+#[must_use]
+pub fn reported(path: &Path) -> PathBuf {
+    let mut spelled = String::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => spelled.push_str(&prefix.as_os_str().to_string_lossy()),
+            Component::RootDir => spelled.push(REPORT_SEPARATOR),
+            segment => push_segment(&mut spelled, &segment.as_os_str().to_string_lossy()),
+        }
+    }
+    PathBuf::from(spelled)
+}
+
+/// Appends one path segment to `spelled`, separating it from whatever
+/// is already there unless that ends in a separator of its own.
+fn push_segment(spelled: &mut String, segment: &str) {
+    if !spelled.is_empty() && !spelled.ends_with(REPORT_SEPARATOR) {
+        spelled.push(REPORT_SEPARATOR);
+    }
+    spelled.push_str(segment);
+}
+
 /// Log directory for reports written to `report_dir` —
 /// `<report_dir>/logs`. Defined relative to the report directory rather
 /// than the scan root so that redirecting reports with `--output` takes
@@ -69,4 +118,110 @@ pub fn report_base(root: &Path) -> PathBuf {
 #[must_use]
 pub fn logs_dir(report_dir: &Path) -> PathBuf {
     report_dir.join(LOGS_DIR_NAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{reported, REPORT_SEPARATOR};
+    use std::path::{Path, PathBuf};
+
+    /// A workspace-relative path two directories deep — the shape every
+    /// occurrence, per-file metric and folder rollup carries, spelled
+    /// the one way a report is allowed to spell it.
+    const NESTED: &str = "src/billing/InvoiceAlpha.cs";
+
+    /// The byte a Windows host joins path segments with. Named by code
+    /// point so the constant survives every quoting layer between a
+    /// source file and a shell.
+    const HOST_JOINER: u8 = 0x5C;
+
+    /// The three segments of [`NESTED`], joined the way *this* host
+    /// joins them. On Windows that is the backslash spelling a report
+    /// must never carry; on Unix it is already [`NESTED`]. Building it
+    /// with [`Path::join`] rather than a literal is what lets one
+    /// assertion state the contract on both platforms.
+    fn joined_by_the_host() -> PathBuf {
+        Path::new("src").join("billing").join("InvoiceAlpha.cs")
+    }
+
+    #[test]
+    fn a_host_joined_path_is_respelled_for_publication() {
+        let native = joined_by_the_host();
+        let spelled = reported(&native);
+        assert_eq!(
+            spelled,
+            PathBuf::from(NESTED),
+            "a path the host joined must publish as {NESTED}, whatever this host joined it with",
+        );
+        assert_eq!(
+            spelled.to_string_lossy().matches(REPORT_SEPARATOR).count(),
+            2,
+            "two directory levels means two separators",
+        );
+        assert!(
+            !spelled
+                .to_string_lossy()
+                .bytes()
+                .any(|byte| byte == HOST_JOINER),
+            "no rendered path may carry the Windows joiner",
+        );
+        assert_eq!(
+            spelled.as_path(),
+            native.as_path(),
+            "a spelled path still names the same file, so it keeps working as a map key",
+        );
+    }
+
+    #[test]
+    fn spelling_is_idempotent_and_leaves_simple_paths_alone() {
+        let once = reported(Path::new(NESTED));
+        assert_eq!(once, PathBuf::from(NESTED));
+        assert_eq!(reported(&once), once, "reported must be idempotent");
+        assert_eq!(reported(Path::new("alpha.rs")), PathBuf::from("alpha.rs"));
+        assert_eq!(reported(Path::new("")), PathBuf::new());
+    }
+
+    #[test]
+    fn a_rooted_path_keeps_its_leading_separator_and_gains_no_empty_segment() {
+        let rooted = Path::new("/srv").join("repo");
+        assert_eq!(reported(&rooted), PathBuf::from("/srv/repo"));
+        assert_eq!(
+            reported(&joined_by_the_host().join("")),
+            PathBuf::from(NESTED),
+            "a trailing separator contributes no empty segment",
+        );
+    }
+
+    // A Windows volume names a device rather than a segment: respelling it
+    // would produce something that is neither a valid Windows path nor a
+    // portable one, so only what follows it is respelled. The expectation is
+    // the same on a host with no such concept, where the drive letter is an
+    // ordinary first segment.
+    #[test]
+    fn a_volume_keeps_its_own_spelling_while_what_follows_it_is_respelled() {
+        let absolute = Path::new("C:/repo").join("src").join("alpha.rs");
+        assert_eq!(reported(&absolute), PathBuf::from("C:/repo/src/alpha.rs"));
+    }
+
+    // Spelling changes separators and nothing else. Stated as a property, it
+    // holds on every host: on Unix the host joiner is an ordinary byte in a
+    // file name and rewriting it would rename the file, while on Windows the
+    // same bytes are two segments — and either way the count survives.
+    #[test]
+    fn spelling_invents_no_segment_and_loses_none() {
+        let name = format!("weird{}name.rs", char::from(HOST_JOINER));
+        for original in [Path::new("src").join(&name), joined_by_the_host()] {
+            let spelled = reported(&original);
+            assert_eq!(
+                spelled.components().count(),
+                original.components().count(),
+                "spelling {original:?} changed how many segments it has",
+            );
+            assert_eq!(
+                spelled.as_path(),
+                original.as_path(),
+                "spelling {original:?} changed which file it names",
+            );
+        }
+    }
 }

--- a/crates/deslop-core/src/report_render.rs
+++ b/crates/deslop-core/src/report_render.rs
@@ -180,11 +180,12 @@ fn occurrence<S: BuildHasher>(
     }
 }
 
-/// Renders `absolute` relative to `scan_root` when it lies inside.
+/// Renders `absolute` relative to `scan_root` when it lies inside, and
+/// spells the result for publication ([OUTPUT-SCHEMA-PATH-SEPARATOR]).
+/// Every path the report carries — occurrence, per-file metric,
+/// boilerplate hint — is built here, so the spelling is decided once.
 pub(crate) fn relative_to_scan_root(absolute: &Path, scan_root: &Path) -> PathBuf {
-    absolute
-        .strip_prefix(scan_root)
-        .map_or_else(|_| absolute.to_path_buf(), Path::to_path_buf)
+    crate::paths::reported(absolute.strip_prefix(scan_root).unwrap_or(absolute))
 }
 
 /// Resolves the report path for `file_id`.

--- a/crates/deslop-lsp/src/navigation.rs
+++ b/crates/deslop-lsp/src/navigation.rs
@@ -19,17 +19,31 @@ pub fn paths_from_file_events(events: &[FileEvent]) -> Vec<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use tower_lsp::lsp_types::{FileChangeType, FileEvent, Url};
 
     use super::paths_from_file_events;
 
+    /// A path in an imagined repository, absolute on this host.
+    ///
+    /// `Url::from_file_path` refuses a relative path, and `/repo/A.cs` is
+    /// relative on Windows: a path with no volume names a location on
+    /// whatever drive the caller happens to be on. The crate directory is
+    /// absolute everywhere and fixed for a checkout, so the test stays
+    /// deterministic without asking the environment anything.
+    fn in_repo(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("repo")
+            .join(name)
+    }
+
     #[test]
     fn paths_from_file_events_keeps_file_uris_and_drops_non_file_uris(
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let file_a = Url::from_file_path("/repo/A.cs").map_err(|()| "A.cs is a file url")?;
-        let file_b = Url::from_file_path("/repo/B.cs").map_err(|()| "B.cs is a file url")?;
+        let (path_a, path_b) = (in_repo("A.cs"), in_repo("B.cs"));
+        let file_a = Url::from_file_path(&path_a).map_err(|()| "A.cs is a file url")?;
+        let file_b = Url::from_file_path(&path_b).map_err(|()| "B.cs is a file url")?;
         let non_file = Url::parse("untitled:Untitled-1")?;
         let events = vec![
             FileEvent::new(file_a, FileChangeType::CHANGED),
@@ -38,7 +52,7 @@ mod tests {
         ];
         assert_eq!(
             paths_from_file_events(&events),
-            vec![PathBuf::from("/repo/A.cs"), PathBuf::from("/repo/B.cs")],
+            vec![path_a, path_b],
             "only file: URIs survive, preserving event order",
         );
         Ok(())

--- a/crates/deslop-mcp/tests/cli.rs
+++ b/crates/deslop-mcp/tests/cli.rs
@@ -20,6 +20,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use assert_cmd::cargo::cargo_bin;
+use deslop_core::live::transport::endpoint_path;
 use serde_json::{json, Value};
 use tempfile::TempDir;
 
@@ -357,20 +358,29 @@ fn read_lsp_frame(reader: &mut BufReader<ChildStdout>) -> Result<Value> {
     deslop_test_support::read_lsp_frame(reader)
 }
 
-/// Polls until `<root>/.deslop/cache/deslop.sock` exists. Failure
-/// after 30 s is fatal — the LSP is meant to bind within seconds.
+/// Polls until the companion LSP has published the IPC endpoint this
+/// platform binds ([LIVE-IPC-SOCKET], [LIVE-IPC-TCP]). Failure after
+/// 30 s is fatal — the LSP is meant to bind within seconds.
+///
+/// Which artefact appears is the platform's choice, not the test's:
+/// Windows has no Unix-domain sockets and binds TCP loopback with a
+/// discovery record instead, so a poll hard-coded to `deslop.sock`
+/// there waits out the whole timeout against a server that bound
+/// correctly seconds earlier. The mode comes from the engine rather
+/// than from a `cfg` here, so the test cannot disagree with the code
+/// about which transport is in use.
 fn wait_for_socket(root: &Path) -> Result<()> {
-    let socket = root.join(".deslop/cache").join("deslop.sock");
+    let endpoint = endpoint_path(root);
     let started = std::time::Instant::now();
     while started.elapsed() < Duration::from_secs(PROCESS_TIMEOUT_SECS) {
-        if socket.exists() {
+        if endpoint.exists() {
             return Ok(());
         }
         std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MILLIS));
     }
     Err(anyhow!(
-        "companion LSP did not bind {} within 30s",
-        socket.display()
+        "companion LSP did not publish {} within 30s",
+        endpoint.display()
     ))
 }
 

--- a/crates/deslop-mcp/tests/common/mod.rs
+++ b/crates/deslop-mcp/tests/common/mod.rs
@@ -149,15 +149,20 @@ pub fn wait_for_path(path: &Path, timeout: Duration) -> Result<()> {
     }
 }
 
-/// Spawns an initialized LSP against `root` and blocks until its IPC socket
-/// exists, returning a kill-on-drop guard for the LSP process. The caller
-/// MUST bind the returned `ChildKillOnDrop` to a live (named) local —
-/// dropping it early kills the LSP mid-test.
+/// Spawns an initialized LSP against `root` and blocks until it has
+/// published its IPC endpoint, returning a kill-on-drop guard for the LSP
+/// process. The caller MUST bind the returned `ChildKillOnDrop` to a live
+/// (named) local — dropping it early kills the LSP mid-test.
+///
+/// The artefact waited on comes from the engine ([LIVE-IPC-SOCKET],
+/// [LIVE-IPC-TCP]): Windows has no Unix-domain sockets and publishes a TCP
+/// endpoint record instead, so a wait spelled `deslop.sock` there times out
+/// against a server that came up seconds earlier.
 pub fn spawn_lsp_and_wait_for_socket(root: &Path) -> Result<ChildKillOnDrop> {
     let lsp = spawn_lsp_and_initialize(root)?;
     let guard = ChildKillOnDrop(lsp);
-    let socket = root.join(".deslop/cache/deslop.sock");
-    wait_for_path(&socket, SOCKET_TIMEOUT).context("wait for ipc socket")?;
+    let endpoint = deslop_core::live::transport::endpoint_path(root);
+    wait_for_path(&endpoint, SOCKET_TIMEOUT).context("wait for ipc endpoint")?;
     Ok(guard)
 }
 
@@ -169,8 +174,8 @@ pub fn spawn_lsp_and_wait_for_socket(root: &Path) -> Result<ChildKillOnDrop> {
 pub fn lsp_workspace_with_socket() -> Result<(TempDir, ChildKillOnDrop, PathBuf)> {
     let workspace = copied_fixture()?;
     let guard = spawn_lsp_and_wait_for_socket(workspace.path())?;
-    let socket = workspace.path().join(".deslop/cache/deslop.sock");
-    Ok((workspace, guard, socket))
+    let endpoint = deslop_core::live::transport::endpoint_path(workspace.path());
+    Ok((workspace, guard, endpoint))
 }
 
 /// Spawned MCP child + an id-tracked JSON-RPC request loop.

--- a/crates/deslop/tests/location_rendering.rs
+++ b/crates/deslop/tests/location_rendering.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use anyhow::Result;
+use serde_json::Value;
 
-use crate::common::*;
+use crate::common::{scan_dir::temp_scan_dir, *};
 
 #[test]
 fn rendered_occurrence_locations_are_line_column_not_byte_ranges() -> Result<()> {
@@ -59,4 +60,202 @@ fn with_ext(base: &Path, ext: &str) -> PathBuf {
     let mut path = base.to_path_buf();
     let _changed = path.set_extension(ext);
     path
+}
+
+// ---------------------------------------------------------------------------
+// [OUTPUT-SCHEMA-PATH-SEPARATOR] Rendered path spelling.
+// ---------------------------------------------------------------------------
+
+/// The one separator a rendered report puts between path segments, on
+/// every platform. A consumer that reads a report produced on Windows
+/// and one produced on Linux must get the same string for the same
+/// file, or every path comparison it makes across the two is wrong.
+const REPORT_SEPARATOR: char = '/';
+
+/// The separator the host's own [`std::path`] joins with. It is `\` on
+/// Windows, and finding it in a rendered report is the defect this
+/// section exists to catch.
+const HOST_SEPARATOR: char = std::path::MAIN_SEPARATOR;
+
+/// Directory the clone pair is staged into: two levels deep, so a fix
+/// that only respells the first separator still fails here.
+const NESTED_DIR: &str = "src/billing";
+
+/// The same directory spelled the way a Windows host would join it.
+/// No rendered surface may contain this.
+const NESTED_DIR_HOST_SPELLING: &str = "src\\billing";
+
+/// The character no rendered path may contain.
+const BACKSLASH: char = '\\';
+
+/// How one backslash appears once JSON has escaped it, so the raw
+/// document can be swept without parsing it back.
+const ESCAPED_BACKSLASH: &str = "\\\\";
+
+/// The two staged clones, spelled the way every surface must render
+/// them.
+const ALPHA_PATH: &str = "src/billing/Alpha.cs";
+const BETA_PATH: &str = "src/billing/Beta.cs";
+
+/// Both folder rows the nested corpus must roll up into.
+const FOLDER_ROWS: [&str; 2] = ["src", "src/billing"];
+
+/// Subtree floor that publishes the staged C# pair as one cluster.
+const NESTED_MIN_NODES: &str = "8";
+
+/// The object key every rendered workspace-relative path sits under.
+const PATH_KEY: &str = "path";
+
+/// Stages `csharp-small` two directories deep and renders all three
+/// formats over it.
+fn nested_corpus_reports() -> Result<(tempfile::TempDir, PathBuf)> {
+    let (tmp, root) = temp_scan_dir("repo")?;
+    seed(&fixture("csharp-small"), &root.join(NESTED_DIR))?;
+    let output = tmp.path().join("report");
+    let mut cmd = deslop_cmd(&root, &output)?;
+    let _assertion = cmd
+        .args(["--min-nodes", NESTED_MIN_NODES, "--embeddings", "off"])
+        .assert()
+        .success();
+    Ok((tmp, output))
+}
+
+/// Every `path` string in `value`, paired with the JSON pointer it was
+/// found at so a failure names the offending field.
+fn rendered_paths(value: &Value) -> Vec<(String, String)> {
+    let mut found = Vec::new();
+    collect_paths(value, "", &mut found);
+    found
+}
+
+fn collect_paths(value: &Value, at: &str, found: &mut Vec<(String, String)>) {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                let here = format!("{at}/{key}");
+                if key == PATH_KEY {
+                    if let Some(text) = child.as_str() {
+                        found.push((here.clone(), text.to_owned()));
+                    }
+                }
+                collect_paths(child, &here, found);
+            }
+        }
+        Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                collect_paths(child, &format!("{at}/{index}"), found);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The `path` values of one named metrics array, in wire order.
+fn metric_paths(report: &Value, array: &str) -> Vec<String> {
+    field(field(report, "metrics"), array)
+        .as_array()
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| row.get(PATH_KEY).and_then(Value::as_str))
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// [OUTPUT-SCHEMA-PATH-SEPARATOR] Every workspace-relative path the JSON
+// report publishes — occurrence, per-file metric, folder rollup — is
+// spelled with `/`, whatever the host joins its own paths with. The
+// sweep is exhaustive rather than field-by-field: a new path-bearing
+// field added later is covered the day it ships, with no edit here.
+#[test]
+fn every_rendered_json_path_is_spelled_with_forward_slashes() -> Result<()> {
+    let (_tmp, output) = nested_corpus_reports()?;
+    let report = load_json(&with_ext(&output, "json"))?;
+
+    let rendered = rendered_paths(&report);
+    assert!(
+        rendered.len() >= 5,
+        "a two-file nested corpus must publish at least two occurrence, \
+         two per-file and two folder paths, found {rendered:?}: {report:#}",
+    );
+    for (pointer, path) in &rendered {
+        assert!(
+            !path.contains(HOST_SEPARATOR) || HOST_SEPARATOR == REPORT_SEPARATOR,
+            "{pointer} renders the host separator {HOST_SEPARATOR:?} in {path:?}: \
+             a report is read on platforms other than the one that wrote it",
+        );
+        assert!(
+            !path.contains(BACKSLASH),
+            "{pointer} renders a backslash in {path:?}: every rendered path \
+             segment is joined with {REPORT_SEPARATOR:?}",
+        );
+        assert_eq!(
+            path,
+            &path
+                .split(REPORT_SEPARATOR)
+                .collect::<Vec<_>>()
+                .join(&REPORT_SEPARATOR.to_string()),
+            "{pointer} must survive a split/join on {REPORT_SEPARATOR:?} unchanged",
+        );
+    }
+
+    let occurrence_paths: Vec<String> = clusters(&report)
+        .iter()
+        .flat_map(|cluster| occurrences(cluster).iter())
+        .filter_map(|occurrence| occurrence.get(PATH_KEY).and_then(Value::as_str))
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        occurrence_paths,
+        vec![ALPHA_PATH.to_owned(), BETA_PATH.to_owned()],
+        "the staged clone pair must be named by its nested path: {report:#}",
+    );
+
+    let mut per_file = metric_paths(&report, "per_file");
+    per_file.sort();
+    assert_eq!(
+        per_file,
+        vec![ALPHA_PATH.to_owned(), BETA_PATH.to_owned()],
+        "per-file metric rows carry the same spelling as occurrences: {report:#}",
+    );
+
+    let mut folders = metric_paths(&report, "folders");
+    folders.sort();
+    assert_eq!(
+        folders,
+        FOLDER_ROWS.map(str::to_owned).to_vec(),
+        "folder rollups group the segments a client splits a file row into: {report:#}",
+    );
+    Ok(())
+}
+
+// [OUTPUT-SCHEMA-PATH-SEPARATOR] The derived text and HTML renderings
+// carry the JSON spelling through unchanged — a human reading either
+// one, and a tool matching a location out of either one, sees the same
+// path the canonical report published.
+#[test]
+fn derived_text_and_html_carry_the_json_path_spelling() -> Result<()> {
+    let (_tmp, output) = nested_corpus_reports()?;
+    let json = fs::read_to_string(with_ext(&output, "json"))?;
+    let text = fs::read_to_string(with_ext(&output, "txt"))?;
+    let html = fs::read_to_string(with_ext(&output, "html"))?;
+
+    for (label, rendered) in [("JSON", &json), ("text", &text), ("HTML", &html)] {
+        for expected in [ALPHA_PATH, BETA_PATH] {
+            assert!(
+                rendered.contains(expected),
+                "{label} report must name {expected}: {rendered}",
+            );
+        }
+        assert!(
+            !rendered.contains(NESTED_DIR_HOST_SPELLING),
+            "{label} report must not spell a nested path with a backslash: {rendered}",
+        );
+    }
+    assert!(
+        !json.contains(ESCAPED_BACKSLASH),
+        "no JSON string value may carry an escaped backslash: {json}",
+    );
+    Ok(())
 }

--- a/docs/specs/pipeline.md
+++ b/docs/specs/pipeline.md
@@ -354,6 +354,18 @@ Top level:
 
 Default output paths, the format suppressors, and `--from-report` re-rendering are invocation behaviour, owned by [cli.md §OUTPUT-FORMAT-DERIVED](cli.md).
 
+#### [OUTPUT-SCHEMA-PATH-SEPARATOR] How a path is spelled
+
+Every workspace-relative path a report publishes — occurrence, per-file metric row, folder rollup, boilerplate hint, and the file named in a stale-diff refusal — is spelled with `/` between its segments, on every platform.
+
+A report is read somewhere other than the machine that wrote it: a Windows developer's report opened by a Linux merge gate, two platforms' reports compared in one dashboard, a path pasted from a report into a tool. A path is therefore part of the output contract and cannot be spelled the host's way. Rendering `src\billing\Invoice.cs` on one host and `src/billing/Invoice.cs` on another gives a consumer two different strings for one file, and every comparison it makes across the two is wrong.
+
+Only separators change. A Windows drive or UNC prefix keeps its own spelling, because it names a volume rather than a segment. Nothing is canonicalised, no `.`/`..` is collapsed, and no case is folded, so a spelled path still names exactly the file it named — which is what lets it stay a map key beside paths that were never spelled.
+
+This governs paths Deslop *publishes*. Paths Deslop *opens* keep the host's own separators, and so do diagnostics about the local filesystem, which name a location on this machine rather than a place in the analysed workspace.
+
+`deslop-core::paths::reported` is the single implementation; `report_render::relative_to_scan_root` and the diff verifier's `resolve_to_scan_root` are the only two callers, so every published path is built through one of them. Pinned end-to-end by `crates/deslop/tests/location_rendering.rs`, which sweeps every `path` in a rendered JSON report over a two-level corpus and re-asserts the spelling in the derived text and HTML.
+
 #### [OUTPUT-SCHEMA-DIFF-TAGS] Diff-scope tags
 
 > **Status: shipped.** Field presence and absence are both pinned by `crates/deslop/tests/diff_scoped_reporting.rs`.

--- a/scripts/deployment/installer-snippet.test.mjs
+++ b/scripts/deployment/installer-snippet.test.mjs
@@ -6,17 +6,25 @@
 // (no network: `DESLOP_RELEASE_BASE` points at a file:// mirror and
 // `DESLOP_TAG` pins the version — both honored by the published snippet), and
 // asserts on the recorded `tar`/`sudo` invocations. Run with `node --test`.
+//
+// The snippet chooses its archive from `uname`, so `uname` is stubbed too and
+// the platform under test is chosen by the test rather than by whichever
+// machine happens to be running it. That makes every assertion here identical
+// on every host, puts all four published platforms under test on all of them,
+// and lets the snippet's own unsupported-platform refusal be asserted instead
+// of only being met by the host the suite could not run on.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { arch, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { repoRoot } from "../lib/repo-root.mjs";
+import { posixShell, shellPath } from "../lib/posix-shell.mjs";
 
 const TAG = "v9.9.9";
 const VERSION = "9.9.9";
@@ -26,17 +34,25 @@ const PAGES = [
   { name: "zh", path: "site/src/zh/docs/index.md", heading: "### macOS / Linux（curl）" },
 ];
 
-function hostPlatform() {
-  const mapping = {
-    "linux-x64": "linux-x64",
-    "linux-arm64": "linux-arm64",
-    "darwin-arm64": "macos-arm64",
-    "darwin-x64": "macos-x64",
-  };
-  const platform = mapping[`${process.platform}-${arch()}`];
-  assert.ok(platform, `unsupported test host: ${process.platform}-${arch()}`);
-  return platform;
-}
+/** The shell that runs the published snippet, whatever this host is. */
+const BASH = posixShell();
+
+/** Every `uname` answer the published snippet claims to support, and the
+ * release archive each one must select. The snippet is the only source of
+ * this mapping; the table restates it so a silent edit fails here. */
+const PLATFORMS = [
+  { system: "Linux", machine: "x86_64", platform: "linux-x64" },
+  { system: "Linux", machine: "aarch64", platform: "linux-arm64" },
+  { system: "Darwin", machine: "arm64", platform: "macos-arm64" },
+  { system: "Darwin", machine: "x86_64", platform: "macos-x64" },
+];
+
+/** The platform the checksum scenarios run on. Any of the four would do —
+ * the mapping itself is asserted over all of them separately. */
+const DEFAULT_TARGET = PLATFORMS[0];
+
+/** A `uname` answer no release is published for. */
+const UNSUPPORTED_TARGET = { system: "Plan9", machine: "sparc", platform: undefined };
 
 // Fence extraction by exact line matching — no pattern matching on the code.
 function extractSnippet(page) {
@@ -64,8 +80,15 @@ function writeFixtureRelease(fixtures, platform, goodChecksum) {
     writeFileSync(join(stage, payload, binary), `#!/bin/sh\necho ${binary} ${VERSION}\n`, { mode: 0o755 });
   }
   const archive = join(releaseDir, `${payload}.tar.gz`);
-  const tar = spawnSync("tar", ["-czf", archive, "-C", stage, payload]);
-  assert.equal(tar.status, 0, "fixture tar failed");
+  // Built through the same shell that will extract it, with the paths spelled
+  // the way that shell spells them: GNU tar reads a leading `C:` as a remote
+  // host and refuses the archive outright.
+  const tar = spawnSync(
+    BASH,
+    ["-c", 'tar -czf "$1" -C "$2" "$3"', "tar", shellPath(archive), shellPath(stage), payload],
+    { encoding: "utf8" },
+  );
+  assert.equal(tar.status, 0, `fixture tar failed: ${tar.stderr}`);
   const digest = sha256Of(archive);
   const published = goodChecksum ? digest : `${digest[0] === "0" ? "1" : "0"}${digest.slice(1)}`;
   writeFileSync(`${archive}.sha256`, `${published}  ${payload}.tar.gz\n`);
@@ -78,37 +101,56 @@ function writeStub(stubBin, name, body) {
 // tar delegates to the real binary so extraction genuinely happens on the
 // good-checksum path; sudo and deslop only record, so nothing touches
 // /usr/local/bin and no real binary is needed.
-function writeStubs(stubBin, log) {
+function writeStubs(stubBin, log, target) {
   mkdirSync(stubBin, { recursive: true });
-  const realTar = spawnSync("bash", ["-c", "command -v tar"], { encoding: "utf8" }).stdout.trim();
+  const realTar = spawnSync(BASH, ["-c", "command -v tar"], { encoding: "utf8" }).stdout.trim();
   assert.ok(realTar, "real tar not found on PATH");
-  writeStub(stubBin, "tar", `echo "tar $*" >> "${log}"\nexec "${realTar}" "$@"`);
-  writeStub(stubBin, "sudo", `echo "sudo $*" >> "${log}"`);
-  writeStub(stubBin, "deslop", `echo "deslop $*" >> "${log}"\necho "deslop ${VERSION}"`);
+  const recorded = shellPath(log);
+  writeStub(stubBin, "tar", `echo "tar $*" >> "${recorded}"\nexec "${realTar}" "$@"`);
+  writeStub(stubBin, "sudo", `echo "sudo $*" >> "${recorded}"`);
+  writeStub(stubBin, "deslop", `echo "deslop $*" >> "${recorded}"\necho "deslop ${VERSION}"`);
+  // The snippet reads the platform from `uname`, so the test names it. Every
+  // other flag is refused rather than answered: a snippet that asked
+  // something this stub silently made up would be tested against a fiction.
+  writeStub(
+    stubBin,
+    "uname",
+    [
+      'case "$1" in',
+      `  -s) echo ${target.system} ;;`,
+      `  -m) echo ${target.machine} ;;`,
+      '  *) echo "stub uname: unexpected flag $1" >&2; exit 1 ;;',
+      "esac",
+    ].join("\n"),
+  );
 }
 
 function runSnippet(snippet, sandbox) {
-  return spawnSync("bash", ["-c", snippet], {
+  return spawnSync(BASH, ["-c", snippet], {
     cwd: join(sandbox, "cwd"),
     encoding: "utf8",
     env: {
       ...process.env,
-      PATH: `${join(sandbox, "stub-bin")}:${process.env.PATH}`,
+      // A PATH entry is spelled the way the shell spells it: a host path can
+      // carry the very character PATH separates on, and the shell would then
+      // read one directory as two and find neither.
+      PATH: `${shellPath(join(sandbox, "stub-bin"))}:${process.env.PATH}`,
       DESLOP_TAG: TAG,
       DESLOP_RELEASE_BASE: pathToFileURL(join(sandbox, "fixtures")).href,
-      TMPDIR: join(sandbox, "tmp"),
+      TMPDIR: shellPath(join(sandbox, "tmp")),
     },
   });
 }
 
-function setupAndRun(page, goodChecksum) {
+function setupAndRun(page, goodChecksum, target = DEFAULT_TARGET) {
   const sandbox = mkdtempSync(join(tmpdir(), "deslop-installer-"));
-  const platform = hostPlatform();
+  const platform = target.platform;
   const log = join(sandbox, "recorder.log");
   mkdirSync(join(sandbox, "tmp"));
   mkdirSync(join(sandbox, "cwd"));
-  writeFixtureRelease(join(sandbox, "fixtures"), platform, goodChecksum);
-  writeStubs(join(sandbox, "stub-bin"), log);
+  if (platform) writeFixtureRelease(join(sandbox, "fixtures"), platform, goodChecksum);
+  else mkdirSync(join(sandbox, "fixtures"), { recursive: true });
+  writeStubs(join(sandbox, "stub-bin"), log, target);
   const result = runSnippet(extractSnippet(page), sandbox);
   return { result, sandbox, platform, log };
 }
@@ -117,8 +159,8 @@ function recordedLines(log) {
   return existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean) : [];
 }
 
-function assertFailsClosed(page) {
-  const { result, sandbox, platform, log } = setupAndRun(page, false);
+function assertFailsClosed(page, target = DEFAULT_TARGET) {
+  const { result, sandbox, platform, log } = setupAndRun(page, false, target);
   const archive = `deslop-${VERSION}-${platform}.tar.gz`;
   const output = `${result.stdout}\n${result.stderr}`;
   assert.notEqual(result.status, 0, `${page.name}: snippet exited 0 despite a bad checksum`);
@@ -130,8 +172,8 @@ function assertFailsClosed(page) {
   rmSync(sandbox, { recursive: true, force: true });
 }
 
-function assertInstalls(page) {
-  const { result, sandbox, platform, log } = setupAndRun(page, true);
+function assertInstalls(page, target = DEFAULT_TARGET) {
+  const { result, sandbox, platform, log } = setupAndRun(page, true, target);
   const archive = `deslop-${VERSION}-${platform}.tar.gz`;
   const lines = recordedLines(log);
   const tarLine = lines.find((line) => line.startsWith("tar "));
@@ -178,3 +220,32 @@ for (const page of PAGES) {
   test(`${page.name}: a bad checksum aborts before extraction and installation`, () => assertFailsClosed(page));
   test(`${page.name}: a good checksum extracts, installs all three binaries, and cleans up`, () => assertInstalls(page));
 }
+
+// [DEPLOY-DOCS-INSTALLER-FAILCLOSED] The snippet picks its archive from
+// `uname`, and picking the wrong one is a 404 for the user rather than an
+// install. Every published platform is exercised, not just this host's.
+for (const target of PLATFORMS) {
+  test(`${target.system}-${target.machine} installs the ${target.platform} archive`, () => {
+    assertInstalls(PAGES[0], target);
+  });
+}
+
+// [DEPLOY-DOCS-INSTALLER-FAILCLOSED] The refusal arm of that same `case`. A
+// platform with no published release must stop before the first download —
+// not fetch a URL that does not exist and report whatever curl said.
+test("an unsupported platform aborts before anything is downloaded or installed", () => {
+  const named = `${UNSUPPORTED_TARGET.system}-${UNSUPPORTED_TARGET.machine}`;
+  for (const page of PAGES) {
+    const { result, sandbox, log } = setupAndRun(page, true, UNSUPPORTED_TARGET);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.notEqual(result.status, 0, `${page.name}: snippet exited 0 on ${named}`);
+    assert.ok(
+      output.includes(`unsupported platform: ${named}`),
+      `${page.name}: the refusal must name the platform it could not serve:\n${output}`,
+    );
+    assert.deepEqual(recordedLines(log), [], `${page.name}: tar/sudo/deslop ran on ${named}`);
+    assert.deepEqual(readdirSync(join(sandbox, "tmp")), [], `${page.name}: work directory leaked on ${named}`);
+    assert.deepEqual(readdirSync(join(sandbox, "cwd")), [], `${page.name}: files were written to the caller's directory`);
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/makefile.mjs
+++ b/scripts/lib/makefile.mjs
@@ -73,16 +73,32 @@ export function words(text) {
  * @returns {string[]} every word assigned, `[]` when the variable is undeclared
  */
 export function variableWords(name) {
+  return words(variableValue(name)).filter((word) => word !== CONTINUATION);
+}
+
+/**
+ * The whole right-hand side of a make variable, as one string.
+ *
+ * `variableWords` is the right reader for a list; this is the right reader for
+ * a single value that may contain spaces. `GIT_BASH` is one:
+ * `C:/Program Files/Git/usr/bin/bash.exe` is a path, and the two words a
+ * word-splitting reader returns are neither of them a shell.
+ *
+ * @param {string} name
+ * @returns {string} the trimmed value, `""` when the variable is undeclared
+ */
+export function variableValue(name) {
   const start = makefileLines.findIndex(
     (line) => line.startsWith(`${name} `) || line.startsWith(`${name}=`),
   );
-  if (start < 0) return [];
+  if (start < 0) return "";
   const declaration = [];
   for (let index = start; index < makefileLines.length; index += 1) {
     const line = makefileLines[index];
     declaration.push(line);
     if (!line.trimEnd().endsWith(CONTINUATION)) break;
   }
-  const [, value] = declaration.join(" ").split("=");
-  return words(value ?? "").filter((word) => word !== CONTINUATION);
+  const joined = declaration.join(" ");
+  const assignedAt = joined.indexOf("=");
+  return assignedAt < 0 ? "" : joined.slice(assignedAt + 1).trim();
 }

--- a/scripts/lib/posix-shell.mjs
+++ b/scripts/lib/posix-shell.mjs
@@ -1,0 +1,96 @@
+// The POSIX shell a Node contract test can spawn on this host, and the path
+// spellings that shell understands. [DEPLOY-EXTENSION-BUNDLED-TESTS]
+//
+// Several gates here drive shell scripts Deslop publishes for macOS and Linux
+// — the PATH scrub, the process scrub, the documented curl installer. The
+// scripts are POSIX, so the tests must run them under a POSIX shell, and on
+// Windows that shell is Git Bash. Two things then stop being interchangeable:
+//
+//   * `/bin/bash` is not a path Windows can spawn. It is an MSYS name that
+//     exists only once bash is already running, so a test that hard-codes it
+//     never starts a process at all and then reports on the empty output of a
+//     program that never ran — a green gate over an unexercised script.
+//   * A Windows path cannot go into a POSIX `PATH`. `C:\repo\bin` carries the
+//     very character `PATH` separates on, so the shell reads one entry as two
+//     and finds neither.
+//
+// The Windows shell location is read from the Makefile's own `GIT_BASH` rather
+// than copied, so a developer whose Git for Windows lives elsewhere overrides
+// one variable and both make and these tests follow it.
+
+import { spawnSync } from "node:child_process";
+import { platform } from "node:os";
+
+import { variableValue } from "./makefile.mjs";
+
+/** Make variable naming the Windows shell, and the environment override. */
+export const GIT_BASH_VARIABLE = "GIT_BASH";
+
+/** Where a POSIX host keeps the shell these scripts are written for. */
+export const POSIX_SHELL = "/bin/bash";
+
+/** Git Bash's own path translator, and its two directions. */
+const TRANSLATOR = "cygpath";
+const TO_SHELL = "-u";
+const TO_HOST = "-w";
+
+/**
+ * Absolute path to a shell that can run this repository's POSIX scripts.
+ *
+ * @param {string} [host] `os.platform()` value; defaults to this host
+ * @returns {string} a path `spawnSync` can execute on `host`
+ */
+export function posixShell(host = platform()) {
+  if (host !== "win32") return POSIX_SHELL;
+  return process.env[GIT_BASH_VARIABLE] ?? variableValue(GIT_BASH_VARIABLE);
+}
+
+/**
+ * How [`posixShell`] spells `path` — `/c/repo/bin` for `C:\repo\bin`.
+ *
+ * Use it for anything handed to the shell as a `PATH` entry or compared
+ * against a path the script printed. Off Windows it is the identity.
+ *
+ * @param {string} path a path spelled the way this host spells it
+ * @param {string} [host] `os.platform()` value; defaults to this host
+ * @returns {string}
+ */
+export function shellPath(path, host = platform()) {
+  return translate(TO_SHELL, path, host);
+}
+
+/**
+ * How this host spells a path the shell named — the inverse of
+ * [`shellPath`]. Use it for anything a POSIX name must be opened by, such as
+ * checking what actually sits in the shell's `/usr/bin`.
+ *
+ * @param {string} path a path spelled the way [`posixShell`] spells it
+ * @param {string} [host] `os.platform()` value; defaults to this host
+ * @returns {string}
+ */
+export function hostPath(path, host = platform()) {
+  return translate(TO_HOST, path, host);
+}
+
+/**
+ * Runs the shell's own translator. The path travels as a positional argument
+ * rather than inside the command text, so a directory name is never read as
+ * shell syntax.
+ *
+ * @param {string} direction
+ * @param {string} path
+ * @param {string} host
+ * @returns {string}
+ */
+function translate(direction, path, host) {
+  if (host !== "win32") return path;
+  const result = spawnSync(
+    posixShell(host),
+    ["-c", `${TRANSLATOR} "$1" "$2"`, TRANSLATOR, direction, path],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    throw new Error(`${TRANSLATOR} ${direction} ${path} failed: ${result.stderr ?? result.error}`);
+  }
+  return result.stdout.trim();
+}

--- a/scripts/repository/posix-shell.test.mjs
+++ b/scripts/repository/posix-shell.test.mjs
@@ -1,0 +1,84 @@
+// Host-shell resolution contract. [DEPLOY-EXTENSION-BUNDLED-TESTS]
+//
+// The gates that drive Deslop's published shell scripts need three things
+// from this host: a shell that can actually be spawned, the spelling that
+// shell uses for a path, and the spelling this host uses for a path the shell
+// named. Get any of them wrong on Windows and the failure is silent in the
+// worst way — `spawnSync` returns a null status and empty output, and an
+// assertion written against "what the script printed" is then comparing two
+// empty strings and passing. Run with `node --test`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { platform } from "node:os";
+import { isAbsolute, resolve } from "node:path";
+
+import { repoRoot } from "../lib/repo-root.mjs";
+import { variableValue } from "../lib/makefile.mjs";
+import {
+  GIT_BASH_VARIABLE,
+  POSIX_SHELL,
+  hostPath,
+  posixShell,
+  shellPath,
+} from "../lib/posix-shell.mjs";
+
+/** The two hosts the helper distinguishes. */
+const WINDOWS = "win32";
+const LINUX = "linux";
+
+/** A directory every checkout has, used as the round-trip subject. */
+const SUBJECT = resolve(repoRoot, "scripts", "repository");
+
+test("the shell make runs POSIX recipes under is the shell these tests spawn", () => {
+  const declared = variableValue(GIT_BASH_VARIABLE);
+  assert.notEqual(declared, "", `the Makefile must declare ${GIT_BASH_VARIABLE}`);
+  assert.ok(isAbsolute(declared), `${GIT_BASH_VARIABLE} must be absolute: ${declared}`);
+  assert.equal(
+    posixShell(WINDOWS),
+    process.env[GIT_BASH_VARIABLE] ?? declared,
+    "a Windows host must resolve the shell the Makefile declares, not a second copy of the path",
+  );
+  assert.equal(posixShell(LINUX), POSIX_SHELL, "a POSIX host keeps its own shell");
+});
+
+test("the resolved shell exists and runs a POSIX script", () => {
+  const shell = posixShell();
+  assert.ok(isAbsolute(shell), `the shell must be named absolutely: ${shell}`);
+  assert.equal(existsSync(shell), true, `${shell} does not exist — set ${GIT_BASH_VARIABLE}`);
+  // `case` is the construct that made these recipes POSIX-only in the first
+  // place, so it is the one worth proving the resolved shell can parse.
+  const result = spawnSync(shell, ["-c", 'case "$1" in ok) echo parsed ;; *) exit 3 ;; esac', "sh", "ok"], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, `the resolved shell could not run a POSIX script: ${result.stderr}`);
+  assert.equal(result.stdout.trim(), "parsed");
+});
+
+test("a path survives the round trip between host and shell spelling", () => {
+  const asShell = shellPath(SUBJECT);
+  assert.equal(hostPath(asShell), SUBJECT, "translating a path and back must return the original");
+  assert.equal(
+    spawnSync(posixShell(), ["-c", '[ -d "$1" ]', "sh", asShell], { encoding: "utf8" }).status,
+    0,
+    `the shell cannot open ${asShell} — the spelling handed to it is not one it understands`,
+  );
+});
+
+test("a shell PATH entry never carries the character PATH separates on", () => {
+  const entry = shellPath(SUBJECT);
+  assert.ok(entry.length > 0, "a translated PATH entry must not be empty");
+  assert.equal(
+    entry.includes(":"),
+    false,
+    `${entry} would be read as two PATH entries, and the shell would find neither`,
+  );
+  // The same subject, untranslated, is exactly what the mistake looks like on
+  // Windows — proving the translation is doing work rather than passing a
+  // string through that happened to be fine already.
+  if (platform() === WINDOWS) {
+    assert.equal(SUBJECT.includes(":"), true, "a Windows path carries the separator, which is why translation exists");
+  }
+});

--- a/scripts/repository/posix-shell.test.mjs
+++ b/scripts/repository/posix-shell.test.mjs
@@ -13,7 +13,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { platform } from "node:os";
-import { isAbsolute, resolve } from "node:path";
+import path, { resolve } from "node:path";
 
 import { repoRoot } from "../lib/repo-root.mjs";
 import { variableValue } from "../lib/makefile.mjs";
@@ -35,18 +35,29 @@ const SUBJECT = resolve(repoRoot, "scripts", "repository");
 test("the shell make runs POSIX recipes under is the shell these tests spawn", () => {
   const declared = variableValue(GIT_BASH_VARIABLE);
   assert.notEqual(declared, "", `the Makefile must declare ${GIT_BASH_VARIABLE}`);
-  assert.ok(isAbsolute(declared), `${GIT_BASH_VARIABLE} must be absolute: ${declared}`);
+  // Judged as a *Windows* path whatever host is asking: `C:/...` is not
+  // absolute to a POSIX `isAbsolute`, and this value is only ever used on
+  // Windows. The reverse mistake — checking a Windows path the POSIX way —
+  // is exactly what makes a cross-platform helper look correct on one host.
+  assert.ok(
+    path.win32.isAbsolute(declared),
+    `${GIT_BASH_VARIABLE} must be an absolute Windows path: ${declared}`,
+  );
   assert.equal(
     posixShell(WINDOWS),
     process.env[GIT_BASH_VARIABLE] ?? declared,
     "a Windows host must resolve the shell the Makefile declares, not a second copy of the path",
   );
   assert.equal(posixShell(LINUX), POSIX_SHELL, "a POSIX host keeps its own shell");
+  assert.ok(
+    path.posix.isAbsolute(POSIX_SHELL),
+    `the POSIX shell must be an absolute POSIX path: ${POSIX_SHELL}`,
+  );
 });
 
 test("the resolved shell exists and runs a POSIX script", () => {
   const shell = posixShell();
-  assert.ok(isAbsolute(shell), `the shell must be named absolutely: ${shell}`);
+  assert.ok(path.isAbsolute(shell), `the shell must be named absolutely: ${shell}`);
   assert.equal(existsSync(shell), true, `${shell} does not exist — set ${GIT_BASH_VARIABLE}`);
   // `case` is the construct that made these recipes POSIX-only in the first
   // place, so it is the one worth proving the resolved shell can parse.
@@ -55,6 +66,15 @@ test("the resolved shell exists and runs a POSIX script", () => {
   });
   assert.equal(result.status, 0, `the resolved shell could not run a POSIX script: ${result.stderr}`);
   assert.equal(result.stdout.trim(), "parsed");
+});
+
+test("translation is the identity for a host that already spells paths that way", () => {
+  // Stated with an explicit host so the claim is checked on every machine,
+  // not only on the one that happens to be POSIX. A translation that quietly
+  // rewrote a Linux path would be invisible to a Linux-only assertion.
+  assert.equal(shellPath(SUBJECT, LINUX), SUBJECT, "a POSIX host needs no translation");
+  assert.equal(hostPath(SUBJECT, LINUX), SUBJECT, "and none in the other direction either");
+  assert.equal(shellPath("", LINUX), "", "an empty path translates to itself");
 });
 
 test("a path survives the round trip between host and shell spelling", () => {

--- a/scripts/repository/scrub-path-binaries.test.mjs
+++ b/scripts/repository/scrub-path-binaries.test.mjs
@@ -22,14 +22,19 @@ import { join, resolve } from "node:path";
 
 import { repoRoot } from "../lib/repo-root.mjs";
 import { recipeBlocks } from "../lib/makefile.mjs";
+import { hostPath, posixShell, shellPath } from "../lib/posix-shell.mjs";
 
 /** The scrub under test, and the target that must delegate to it. */
 const SCRIPT = resolve(repoRoot, "scripts/repository/scrub-path-binaries.sh");
 const SCRUB_TARGET = "_delete-path-binaries";
 const SCRIPT_INVOCATION = "bash scripts/repository/scrub-path-binaries.sh";
 
-/** Absolute bash, so the test pins the 3.2 build macOS ships. */
-const BASH = "/bin/bash";
+/** Absolute bash: the 3.2 build macOS ships, or Git Bash on Windows. A bare
+ * name would find WSL's bash on Windows, which sees a different filesystem. */
+const BASH = posixShell();
+
+/** The scrub as the shell must name it — bash opens the script by this path. */
+const SCRIPT_FOR_SHELL = shellPath(SCRIPT);
 
 /** Query mode: print what shadows, delete nothing, fail if anything does. */
 const LIST_FLAG = "--list";
@@ -64,7 +69,11 @@ function entryExistsThroughLink(path) {
 function assertSystemPathIsClean() {
   for (const directory of SYSTEM_PATH.split(":")) {
     for (const name of BINARY_NAMES) {
-      const path = join(directory, name);
+      // The system directories are named the way the *shell* names them, so
+      // this must open them the way the host does. Left untranslated on
+      // Windows it looks under the drive root, finds nothing, and passes
+      // without having examined the shell's real /usr/bin at all.
+      const path = join(hostPath(directory), name);
       assert.equal(entryExists(path), false, `${path} exists — refusing to run the scrub over a real install`);
     }
   }
@@ -83,17 +92,27 @@ function fixture() {
 /** Runs the scrub with nothing but the fixture directory and the system tools. */
 function runScrub({ binDir, homeDir }, args = [], { withSystemTools = true } = {}) {
   assertSystemPathIsClean();
-  const path = withSystemTools ? `${binDir}:${SYSTEM_PATH}` : binDir;
-  return spawnSync(BASH, [SCRIPT, ...args], { encoding: "utf8", env: { PATH: path, HOME: homeDir } });
+  const fixtureEntry = shellPath(binDir);
+  const path = withSystemTools ? `${fixtureEntry}:${SYSTEM_PATH}` : fixtureEntry;
+  return spawnSync(BASH, [SCRIPT_FOR_SHELL, ...args], {
+    encoding: "utf8",
+    env: { PATH: path, HOME: shellPath(homeDir) },
+  });
 }
 
 /** What `command -v` — the detection #474 relied on — reports for a name. */
 function commandVee({ binDir, homeDir }, name) {
   const result = spawnSync(BASH, ["-c", `command -v ${name} || true`], {
     encoding: "utf8",
-    env: { PATH: `${binDir}:${SYSTEM_PATH}`, HOME: homeDir },
+    env: { PATH: `${shellPath(binDir)}:${SYSTEM_PATH}`, HOME: shellPath(homeDir) },
   });
   return result.stdout.trim();
+}
+
+/** How the scrub prints `path` — it names what it found in the shell's own
+ * spelling, which is the only spelling the operator can paste back. */
+function asPrinted(path) {
+  return shellPath(path);
 }
 
 /** Stages a symlink to a bundle path that was deleted — the #474 leftover. */
@@ -123,7 +142,7 @@ test("[#474] --list reports the dangling symlink and exits non-zero", () => {
   const dirs = fixture();
   const link = stageDanglingLink(dirs, "deslop-mcp");
   const listed = runScrub(dirs, [LIST_FLAG]);
-  assert.equal(listed.stdout.trim(), link, "the shadowing path must be named exactly");
+  assert.equal(listed.stdout.trim(), asPrinted(link), "the shadowing path must be named exactly");
   assert.equal(listed.status, 1, "a shadowed PATH must fail closed, not report clean");
 });
 
@@ -132,7 +151,7 @@ test("[#474] the scrub deletes the dangling symlink and only then reports succes
   const link = stageDanglingLink(dirs, "deslop-mcp");
   const scrubbed = runScrub(dirs);
   assert.equal(scrubbed.status, 0, `scrub failed: ${scrubbed.stdout}${scrubbed.stderr}`);
-  assert.ok(scrubbed.stdout.includes(`deleting ${link}`), "the scrub must say what it removed");
+  assert.ok(scrubbed.stdout.includes(`deleting ${asPrinted(link)}`), "the scrub must say what it removed");
   assert.ok(scrubbed.stdout.includes("PATH is clear of deslop deslop-lsp deslop-mcp"), "and confirm the result");
   assert.equal(entryExists(link), false, "the leftover must be gone, not merely unreported");
   assert.equal(runScrub(dirs, [LIST_FLAG]).status, 0, "a re-check must now find nothing");
@@ -147,7 +166,7 @@ test("[#474] the scrub fails closed when a shadowing name survives deletion", ()
   const scrubbed = runScrub(dirs, [], { withSystemTools: false });
   assert.equal(scrubbed.status, 1, "a scrub that cannot remove a shadowing name must fail");
   assert.ok(scrubbed.stdout.includes("FAIL: these PATH entries still shadow"), "and explain what is wrong");
-  assert.ok(scrubbed.stdout.includes(link), "naming every survivor");
+  assert.ok(scrubbed.stdout.includes(asPrinted(link)), "naming every survivor");
   assert.equal(entryExists(link), true, "the survivor is genuinely still on PATH");
 });
 
@@ -156,9 +175,9 @@ test("the scrub removes an executable and a non-executable leftover alike", () =
   const executable = stageFile(dirs, "deslop", EXECUTABLE_MODE);
   const inert = stageFile(dirs, "deslop-lsp", READ_ONLY_MODE);
   const listed = runScrub(dirs, [LIST_FLAG]);
-  assert.deepEqual(listed.stdout.trim().split("\n").sort(), [executable, inert].sort());
+  assert.deepEqual(listed.stdout.trim().split("\n").sort(), [executable, inert].map(asPrinted).sort());
   assert.equal(listed.status, 1);
-  assert.equal(commandVee(dirs, "deslop"), executable, "an executable copy is exactly what command -v did catch");
+  assert.equal(commandVee(dirs, "deslop"), asPrinted(executable), "an executable copy is exactly what command -v did catch");
   const scrubbed = runScrub(dirs);
   assert.equal(scrubbed.status, 0, `scrub failed: ${scrubbed.stdout}${scrubbed.stderr}`);
   assert.equal(entryExists(executable), false);


### PR DESCRIPTION
## TLDR

Reports now spell every published path with `/` on every platform, the MCP suite waits for the IPC endpoint Windows actually binds, and the Node gates that drive Deslop's POSIX shell scripts resolve a shell they can spawn — taking the Rust workspace on Windows from 100 failures to zero (gh #500).

## Details

**A report said two different things about the same file.** Inside one JSON document, `metrics.folders[].path` read `src/billing` while `metrics.per_file[].path` and every occurrence path read `src\billing\InvoiceAlpha.cs`. The folder rollup was normalised at construction; nothing else was. A report is read somewhere other than the machine that wrote it — a Windows developer's report opened by a Linux merge gate, two platforms compared on one dashboard — so a consumer matching paths across the two gets different strings for one file and every comparison it makes is wrong. Nothing in `docs/specs/` said which spelling was right, so this was unspecified behaviour, inconsistently implemented.

`[OUTPUT-SCHEMA-PATH-SEPARATOR]` now states the rule: every workspace-relative path a report publishes — occurrence, per-file metric row, folder rollup, boilerplate hint, and the file named in a stale-diff refusal — is spelled with `/`. Only separators change: a Windows volume keeps its own spelling because it names a device rather than a segment, nothing is canonicalised, and no case is folded, so a spelled path still names exactly the file it named. Paths Deslop *opens*, and diagnostics about the local filesystem, keep the host's separators.

`deslop-core::paths::reported` is the single implementation. It has two callers — `report_render::relative_to_scan_root`, through which every report path is built, and the diff verifier's `resolve_to_scan_root`, which keys the scope a `--diff` run is tagged against and names the file in a refusal. Because a respelled path still compares equal as a `Path` on both platforms, it stays a usable map key beside paths that were never respelled.

**Gates that drive published shell scripts could not start one.** `scrub-path-binaries.test.mjs` spawned `/bin/bash`, which is not a path Windows can execute: it is an MSYS name that exists only once bash is already running. Every spawn returned a null status and empty output, and assertions written against "what the script printed" were comparing two empty strings — a gate reporting on a script that never ran. The second half of the same problem: a Windows path carries the character `PATH` separates on, so `C:\repo\bin` handed to a POSIX shell is read as two entries and neither is found.

The new `scripts/lib/posix-shell.mjs` answers all three questions once — which shell to spawn, how that shell spells a path, and how this host spells a path the shell named. The Windows location is read from the Makefile's own `GIT_BASH`, not copied, so a developer whose Git for Windows lives elsewhere overrides one variable and both make and these tests follow it. `scripts/lib/makefile.mjs` gains `variableValue` for that: `variableWords` splits on whitespace, and the two words it returns for `C:/Program Files/Git/...` are neither of them a shell.

**The installer gate now tests the installer instead of the host.** `installer-snippet.test.mjs` read the platform from `process.platform`, refused to run on anything but the four it publishes for, and therefore tested exactly one platform per machine. `uname` is now stubbed, so the platform under test is chosen by the test: all four published platforms are exercised on every host, and the snippet's own unsupported-platform refusal — a branch nothing asserted anywhere — is exercised too. The fixture archive is now built through the same shell that will extract it, because GNU tar reads a leading `C:` as a remote host and refuses the archive outright.

**The MCP end-to-end suite spent thirty seconds per test waiting for a file Windows never writes.** All ninety-four tests waited for `.deslop/cache/deslop.sock` before talking to the companion LSP. Windows has no Unix-domain sockets — it binds TCP loopback and publishes an endpoint record instead, which is *why* the Windows CI job runs `tcp_transport` at all. `transport::endpoint_path` now names whichever artefact this platform's server publishes, and the three waits ask the engine rather than spelling one of the two, so a test cannot disagree with the code about which transport is in use. These ninety-four were invisible to the original audit, which ran `-p deslop --test suite` rather than `--all-targets`.

**One LSP unit test asserted a Windows-relative path was absolute.** `Url::from_file_path("/repo/A.cs")` fails on Windows: a path with no volume names a location on whatever drive the caller is on. It now builds its subject from the crate directory, which is absolute everywhere and fixed for a checkout.

**CI can now catch a regression.** The Windows job ran one target (`deslop-mcp --test tcp_transport`), so nothing here was under test on the only platform that can break it. It now also runs `deslop-core`'s `paths::` unit tests and the seven suites whose assertions compare a rendered path against the `/` spelling — including the two report goldens. The job's timeout rises from 30 to 50 minutes with a stated reason: a cold Windows build of that set under llvm-cov instrumentation runs past the old cap before a single assertion is evaluated, and the cap's alternative is leaving the one rule only this platform can break unenforced.

### Not fixed, and why

Five `deployment-verify` scripts still fail on Windows, for two reasons that are not defects in Deslop. `test-verifiers.mjs` shells to `zip` and `unzip`, which Windows does not ship; its binary-contract proofs also write an extensionless `#!/bin/sh` fake binary, while the verifier correctly looks for `deslop.exe` on win32 — a JS test cannot synthesise a real Windows executable. Fixing either means changing production release-verification code, which is not Windows-specific and is outside this change. The release pipeline runs on `ubuntu-latest`, where all of it passes.

### Breaking changes

None to any CLI flag, spec ID, or report field. The *values* of `path` fields rendered on Windows change from `src\a.rs` to `src/a.rs` — which is the defect being fixed, and is what every consumer already assumed.

## How Do The Automated Tests Prove It Works?

`location_rendering.rs` stages a clone pair two directories deep — deep enough that a fix respelling only the first separator still fails — and sweeps the rendered report:

- `every_rendered_json_path_is_spelled_with_forward_slashes` walks the whole JSON document and collects every `path` value with the pointer it sat at, so a failure names the field. Each must carry no backslash, no host separator, and survive a split/join on `/` unchanged. The sweep is exhaustive rather than field-by-field, so a path-bearing field added later is covered the day it ships. It then pins the values: occurrences are exactly `src/billing/Alpha.cs` and `src/billing/Beta.cs`, `per_file` carries the same two, and `folders` rolls up to `src` and `src/billing`.
- `derived_text_and_html_carry_the_json_path_spelling` re-asserts all of it in the text and HTML renderings, and that no JSON string value carries an escaped backslash.

Both failed against the old renderer with `"path": "src\\billing\\Alpha.cs"`, and they are guards on Linux rather than dead weight: they fail there too if a renderer ever introduces a backslash.

Six suites that were failing on Windows now pass unchanged — `defaults`, the three `diff_ingest_refusals` cases, `diff_scoped_ingest::diff_from_stdin_tags_identically`, and `diff_scoped_reporting::diff_tags_the_four_populations_and_metrics_add_up`. Not one assertion was relaxed to get there; they were asserting the right answer all along.

`paths::reported`'s five unit tests state the contract without a single `#[cfg]` — which the `skip_policy_contract` gate forbids on a test. `a_host_joined_path_is_respelled_for_publication` builds its subject with `Path::join`, so the *host* supplies the separator and one assertion states the rule on both platforms: it is the backslash spelling on Windows and already correct on Unix. `spelling_invents_no_segment_and_loses_none` states the safety property as a property — the component count and the file named both survive — which is why a backslash inside a Unix file name is left alone and the same bytes are two segments on Windows, with no branch in the test.

`scrub-path-binaries.test.mjs` goes from one passing test of nine to nine, driving the real script against a fixture PATH. `installer-snippet.test.mjs` goes from six tests (two passing) to eleven, all passing: four new ones assert each published platform selects its own archive, and one asserts an unsupported platform aborts before anything is downloaded, with nothing recorded and no work directory left behind. `posix-shell.test.mjs` is new: it asserts the resolved shell is the one the Makefile declares (so the path is not duplicated), that it exists and can parse a `case` statement, that a path round-trips between the two spellings, and that a translated PATH entry never carries `:`.

`posix-shell.test.mjs` also pins the mistake it exists to prevent, because the first version of it made that mistake: it judged `C:/Program Files/Git/...` with the host's own `isAbsolute`, which is `false` on Linux, and the repository gate caught it. The Windows value is now judged as a Windows path and the POSIX one as a POSIX path, and the identity direction is asserted with an explicit host so the claim is checked on every machine rather than only on the one that happens to be POSIX.

Full local Windows run — `cargo test --release --workspace --all-targets` with the Makefile's feature set — exits 0: 1,192 tests across `deslop` (460), `deslop-core` (193), `deslop-mcp` (192 + 94), `deslop-test-support` (121), `deslop-lsp` (69 + 55 + 5 + 3), zero failures. Plus 126 Node contract tests across every gate. `make lint` (clippy `-D warnings` + all Node gates), `make fmt CHECK=1`, and the duplication gate all exit 0.

## For AI

`paths::reported(&Path) -> PathBuf` folds `Component::Prefix` verbatim, maps `Component::RootDir` to `/`, and joins the rest with `/`. `Component`-based rather than string replacement: on Unix `\` is a legal filename byte and a `replace('\\', "/")` would rename the file, while `MAIN_SEPARATOR`-conditional code would leave the interesting branch unexercised on the only platform CI measures coverage on. Idempotent; `reported(p).as_path() == p` holds on both platforms because Windows `Path` comparison walks components and accepts either separator, which is what keeps `BTreeMap<PathBuf, _>` lookups working across the mixed corpus in `diff_scope::verify` (corpus keys come from `relative_to_scan_root`, probe keys from `resolve_to_scan_root`, both now respelled).

Call sites are deliberately two. `relative_to_scan_root` also drops a `map_or_else(|_| .., Path::to_path_buf)` for `strip_prefix(..).unwrap_or(absolute)` — same semantics, one allocation instead of two. `folder_prefixes` in `report_metrics.rs` is untouched: it already emitted `/` and builds prefixes rather than respelling a path.

`posix-shell.mjs`'s `shellPath`/`hostPath` shell out to `cygpath -u`/`-w` with the path as a positional argument (`bash -c 'cygpath "$1" "$2"' name flag path`), never interpolated into command text. Both are the identity off win32, so Linux CI pays nothing. `variableValue` slices at the first `=` rather than `split("=")[1]`, which silently truncated any value containing `=`; `variableWords` is now expressed through it.

The Windows CI filters live in a `WINDOWS_SUITE_FILTERS` env var split in PowerShell rather than inline, so the list is one readable line. `report_golden::` and `metrics_folder_rollup::` are included even though both currently scan flat roots — they are the determinism pins most likely to acquire nested paths later.

gh #500. No `unwrap`/`expect`/`panic!` added, no suppressions, no file over 500 lines, no function over 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
